### PR TITLE
remove AbstractStructureOutput -- rely on DCE pass instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ This interface is the same for all structure prediction models, so in theory we 
 We also define a collection of (model agnostic!) structure prediction related losses [here](src/mosaic/losses/structure_prediction.py). It's super easy to define your own using the provided interface.
 
 
-> Internally we distinguish between three classes of losses: those that rely only on the trunk, structure module, or confidence module. For computational efficiency we only run the structure module or confidence module if required.
+> In practice there are three types of structure prediction losses: those that rely on the trunk, structure module, or confidence module. Under JIT, JAX will prune code related to the structure module and confidence module if they're not needed; so if your loss only relies on the trunk it will be quite fast.
 
 
 Continuing the example above, we can construct a loss and do design as follows:

--- a/examples/boltzgen_pipeline.py
+++ b/examples/boltzgen_pipeline.py
@@ -14,7 +14,7 @@ def _():
         CoordsToToken,
     )
     from mosaic.models.boltz2 import Boltz2, pad_atom_features
-    from mosaic.losses.boltz2 import Boltz2Output, Boltz2FromTrunkOutput
+    from mosaic.losses.boltz2 import boltz2_trunk, boltz2_forward_from_trunk
     from mosaic.losses.structure_prediction import (
         BinderTargetIPSAE,
         TargetBinderIPSAE,
@@ -48,8 +48,8 @@ def _():
     return (
         BinderTargetIPSAE,
         Boltz2,
-        Boltz2FromTrunkOutput,
-        Boltz2Output,
+        boltz2_trunk,
+        boltz2_forward_from_trunk,
         BoltzGenOutput,
         CoordsToToken,
         IPTMLoss,
@@ -486,7 +486,7 @@ def _(calculate_rmsd, eqx, jax):
 
 
 @app.cell
-def _(BINDER_LEN, Boltz2FromTrunkOutput, Boltz2Output, eqx, fold_in, jax, jnp):
+def _(BINDER_LEN, boltz2_trunk, boltz2_forward_from_trunk, eqx, fold_in, jax, jnp):
     class FoldOutput(eqx.Module):
         loss: float
         structure_coordinates: jax.Array
@@ -499,33 +499,29 @@ def _(BINDER_LEN, Boltz2FromTrunkOutput, Boltz2Output, eqx, fold_in, jax, jnp):
         Refold multiple times (one trunk run, multiple diffusion samples)
         and pick the best (lowest) according to a mosaic loss functional
         """
-        output = Boltz2Output(
-            joltz2=model.model,
-            features=features,
+        initial_embedding, trunk_state = boltz2_trunk(
+            model.model, features,
+            recycling_steps=3,
             deterministic=True,
             key=fold_in(key, "trunk"),
-            recycling_steps=3,
         )
 
         def apply_loss_to_single_sample(key):
-            from_trunk_output = Boltz2FromTrunkOutput(
-                joltz2=model.model,
-                features=features,
+            output = boltz2_forward_from_trunk(
+                model.model, features, initial_embedding, trunk_state,
+                num_sampling_steps=25,
                 deterministic=True,
                 key=key,
-                initial_embedding=output.initial_embedding,
-                trunk_state=output.trunk_state,
-                recycling_steps=3,
             )
             v, aux = loss(
                 sequence=jnp.zeros((BINDER_LEN, 20)),
-                output=from_trunk_output,
+                output=output,
                 key=fold_in(key, "loss"),
             )
             return FoldOutput(
                 v,
-                from_trunk_output.structure_coordinates,
-                from_trunk_output.backbone_coordinates,
+                output.structure_coordinates,
+                output.backbone_coordinates,
             )
 
         output = jax.vmap(apply_loss_to_single_sample)(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ boltz = { git = "https://github.com/escalante-bio/boltz.git" }
 boltzgen = { git = "https://github.com/escalante-bio/boltzgen.git" }
 
 [tool.uv]
+required-environments = ["sys_platform == 'linux' and platform_machine == 'x86_64'"]
 conflicts = [
     [
       { group = "jax-cpu" },

--- a/src/mosaic/losses/boltz.py
+++ b/src/mosaic/losses/boltz.py
@@ -406,7 +406,6 @@ def boltz1_trunk(
     key: jax.Array,
 ) -> joltz.TrunkOutputs:
     """Run embedding + trunk recycling. Returns TrunkOutputs."""
-    print("JIT compiling boltz1 trunk...")
     return model.trunk(
         features,
         recycling_steps=recycling_steps,
@@ -427,7 +426,6 @@ def boltz1_forward_from_trunk(
     """Run distogram, structure, and confidence from pre-computed trunk output."""
     distogram_logits = trunk_outputs.pdistogram[0]  # strip batch dim
 
-    print("JIT compiling boltz1 structure module...")
     structure_outputs = model.sample_structure(
         features,
         trunk_outputs,
@@ -435,7 +433,6 @@ def boltz1_forward_from_trunk(
         key=key,
     )
 
-    print("JIT compiling boltz1 confidence module...")
     confidence = model.predict_confidence(
         features,
         trunk_outputs,

--- a/src/mosaic/losses/boltz.py
+++ b/src/mosaic/losses/boltz.py
@@ -1,8 +1,7 @@
-from dataclasses import asdict, dataclass
-from functools import cached_property
+from dataclasses import asdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import yaml 
+import yaml
 
 import equinox as eqx
 import jax
@@ -27,7 +26,7 @@ from jaxtyping import Array, Float, PyTree
 
 from ..common import LinearCombination, LossTerm
 
-from .structure_prediction import AbstractStructureOutput
+from .structure_prediction import PAE_BINS, StructureModelOutput
 
 
 def load_boltz(
@@ -395,97 +394,80 @@ def set_binder_sequence(
     }
 
 
-@dataclass
-class Boltz1Output(AbstractStructureOutput):
-    joltz: joltz.Joltz1
-    features: PyTree
-    deterministic: bool
-    key: jax.Array
-    recycling_steps: int = 0
-    num_sampling_steps: int = 25
+BOLTZ1_DISTOGRAM_BINS = np.linspace(start=2.0, stop=22.0, num=64)
 
-    @property
-    def full_sequence(self):
-        return self.features["res_type"][0][:, 2:22]
 
-    @property
-    def asym_id(self):
-        return self.features["asym_id"][0]
+def boltz1_trunk(
+    model: joltz.Joltz1,
+    features: PyTree,
+    *,
+    recycling_steps: int,
+    deterministic: bool,
+    key: jax.Array,
+) -> joltz.TrunkOutputs:
+    """Run embedding + trunk recycling. Returns TrunkOutputs."""
+    print("JIT compiling boltz1 trunk...")
+    return model.trunk(
+        features,
+        recycling_steps=recycling_steps,
+        key=key,
+        deterministic=deterministic,
+    )
 
-    @property
-    def residue_idx(self):
-        return self.features["residue_index"][0]
 
-    @property
-    def distogram_bins(self) -> Float[Array, "64"]:
-        return np.linspace(start=2.0, stop=22.0, num=64)
+def boltz1_forward_from_trunk(
+    model: joltz.Joltz1,
+    features: PyTree,
+    trunk_outputs: joltz.TrunkOutputs,
+    *,
+    num_sampling_steps: int,
+    deterministic: bool,
+    key: jax.Array,
+) -> StructureModelOutput:
+    """Run distogram, structure, and confidence from pre-computed trunk output."""
+    distogram_logits = trunk_outputs.pdistogram[0]  # strip batch dim
 
-    @cached_property
-    def trunk_outputs(self) -> joltz.TrunkOutputs:
-        return self.joltz.trunk(
-            self.features,
-            recycling_steps=self.recycling_steps,
-            key=self.key,
-            deterministic=self.deterministic,
-        )
+    print("JIT compiling boltz1 structure module...")
+    structure_outputs = model.sample_structure(
+        features,
+        trunk_outputs,
+        num_sampling_steps=num_sampling_steps,
+        key=key,
+    )
 
-    @cached_property
-    def distogram_logits(self) -> Float[Array, "N N 64"]:
-        return self.trunk_outputs.pdistogram[0]  # strip batch dim
+    print("JIT compiling boltz1 confidence module...")
+    confidence = model.predict_confidence(
+        features,
+        trunk_outputs,
+        structure_outputs,
+        key=key,
+        deterministic=deterministic,
+    )
 
-    @cached_property
-    def structure_outputs(self) -> joltz.StructureModuleOutputs:
-        print("JIT compiling boltz1 structure module...")
-        return self.joltz.sample_structure(
-            self.features,
-            self.trunk_outputs,
-            num_sampling_steps=self.num_sampling_steps,
-            key=self.key,
-        )
+    # Backbone coordinates (N, CA, C, O)
+    features_unbatched = jax.tree.map(lambda x: x[0], features)
+    assert ref_atoms["UNK"][:4] == ["N", "CA", "C", "O"]
+    first_atom_idx = jax.vmap(lambda atoms: jnp.nonzero(atoms, size=1)[0][0])(
+        features_unbatched["atom_to_token"].T
+    )
+    all_atom_coords = structure_outputs.sample_atom_coords[0]
+    backbone_coordinates = jnp.stack(
+        [all_atom_coords[first_atom_idx + i] for i in range(4)], -2
+    )
 
-    @cached_property
-    def confidence_outputs(self) -> PyTree:
-        print("JIT compiling boltz1 confidence module...")
-        return self.joltz.predict_confidence(
-            self.features,
-            self.trunk_outputs,
-            self.structure_outputs,
-            key=self.key,
-            deterministic=self.deterministic,
-        )
-
-    @property
-    def plddt(self) -> Float[Array, "N"]:
-        return self.confidence_outputs["plddt"][0]
-
-    @property
-    def pae(self) -> Float[Array, "N N"]:
-        return self.confidence_outputs["pae"][0]
-
-    @property
-    def pae_logits(self) -> Float[Array, "N N 64"]:
-        return self.confidence_outputs["pae_logits"][0]
-
-    @property
-    def pae_bins(self) -> Float[Array, "64"]:
-        end = 32.0
-        num_bins = 64
-        bin_width = end / num_bins
-        return np.arange(start=0.5 * bin_width, stop=end, step=bin_width)
-
-    @property
-    def backbone_coordinates(self) -> Float[Array, "N 4"]:
-        features = jax.tree.map(lambda x: x[0], self.features)
-        # In order these are N, C-alpha, C, O
-        assert ref_atoms["UNK"][:4] == ["N", "CA", "C", "O"]
-        # first step, which is a bit cryptic, is to get the first atom for each token
-        first_atom_idx = jax.vmap(lambda atoms: jnp.nonzero(atoms, size=1)[0][0])(
-            features["atom_to_token"].T
-        )
-        # NOTE: this will completely (and silently) fail if any tokens are non-protein!
-        all_atom_coords = self.structure_output.sample_atom_coords[0]
-        coords = jnp.stack([all_atom_coords[first_atom_idx + i] for i in range(4)], -2)
-        return coords
+    return StructureModelOutput(
+        distogram_logits=distogram_logits,
+        distogram_bins=BOLTZ1_DISTOGRAM_BINS,
+        plddt=confidence["plddt"][0],
+        pae=confidence["pae"][0],
+        pae_logits=confidence["pae_logits"][0],
+        pae_bins=PAE_BINS,
+        structure_coordinates=structure_outputs.sample_atom_coords,
+        backbone_coordinates=backbone_coordinates,
+        full_sequence=features["res_type"][0][:, 2:22],
+        asym_id=features["asym_id"][0],
+        residue_idx=features["residue_index"][0],
+    )
 
 
 class Boltz1Loss(LossTerm):
@@ -499,22 +481,20 @@ class Boltz1Loss(LossTerm):
 
     def __call__(self, sequence: Float[Array, "N 20"], key=None):
         """Compute the loss for a given sequence."""
-        # Set the binder sequence in the features
         features = set_binder_sequence(sequence, self.features)
 
-        # initialize lazy output object
-        output = Boltz1Output(
-            joltz=self.joltz1,
-            features=features,
+        trunk_outputs = boltz1_trunk(
+            self.joltz1, features,
+            recycling_steps=self.recycling_steps,
             deterministic=self.deterministic,
             key=key,
-            recycling_steps=self.recycling_steps,
-            num_sampling_steps=self.sampling_steps,
         )
-
-        v, aux = self.loss(
-            sequence=sequence,
-            output=output,
+        output = boltz1_forward_from_trunk(
+            self.joltz1, features, trunk_outputs,
+            num_sampling_steps=self.sampling_steps,
+            deterministic=self.deterministic,
             key=key,
         )
+
+        v, aux = self.loss(sequence=sequence, output=output, key=key)
         return v, {self.name: aux}

--- a/src/mosaic/losses/boltz2.py
+++ b/src/mosaic/losses/boltz2.py
@@ -1,5 +1,4 @@
-from dataclasses import asdict, dataclass
-from functools import cached_property
+from dataclasses import asdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -19,8 +18,7 @@ from joltz import TrunkState
 
 
 from ..common import LinearCombination, LossTerm
-from ..util import pairwise_distance
-from .structure_prediction import AbstractStructureOutput, predicted_tm_score
+from .structure_prediction import PAE_BINS, StructureModelOutput
 
 
 def load_boltz2(checkpoint_path=Path("~/.boltz/boltz2_conf.ckpt").expanduser()):
@@ -227,152 +225,128 @@ def set_binder_sequence(
     }
 
 
-# TODO: remove some batch dimensions
-@dataclass
-class Boltz2Output(AbstractStructureOutput):
-    joltz2: joltz.Joltz2
-    features: PyTree
-    deterministic: bool
-    key: jax.Array
-    recycling_steps: int = 0
-    num_sampling_steps: int = 25
-    initial_recycling_state: TrunkState | None = None
+BOLTZ2_DISTOGRAM_BINS = np.linspace(start=2.0, stop=22.0, num=64)
 
-    @property
-    def full_sequence(self):
-        return self.features["res_type"][0][:, 2:22]
 
-    @property
-    def asym_id(self):
-        return self.features["asym_id"][0]
+def boltz2_trunk(
+    model: joltz.Joltz2,
+    features: PyTree,
+    *,
+    recycling_steps: int,
+    deterministic: bool,
+    initial_recycling_state: TrunkState | None = None,
+    key: jax.Array,
+):
+    """Run embedding + trunk recycling. Returns (initial_embedding, trunk_state)."""
+    print("JIT compiling trunk module...")
+    initial_embedding = model.embed_inputs(features)
 
-    @property
-    def residue_idx(self):
-        return self.features["residue_index"][0]
-
-    @cached_property
-    def initial_embedding(self):
-        return self.joltz2.embed_inputs(self.features)
-
-    @cached_property
-    def trunk_state(self):
-        print("JIT compiling trunk module...")
-
-        def body_fn(carry, _):
-            trunk_state, key = carry
-            trunk_state = jax.tree.map(jax.lax.stop_gradient, trunk_state)
-            trunk_state, key = self.joltz2.trunk_iteration(
-                trunk_state,
-                self.initial_embedding,
-                self.features,
-                key=key,
-                deterministic=self.deterministic,
-            )
-            return (trunk_state, key), None
-
-        if self.initial_recycling_state is None:
-            state = TrunkState(
-                s=jnp.zeros_like(self.initial_embedding.s_init),
-                z=jnp.zeros_like(self.initial_embedding.z_init),
-            )
-        else:
-            state = self.initial_recycling_state
-
-        (final_state, _), _ = jax.lax.scan(
-            body_fn,
-            (state, self.key),
-            None,
-            length=self.recycling_steps,
+    if initial_recycling_state is None:
+        state = TrunkState(
+            s=jnp.zeros_like(initial_embedding.s_init),
+            z=jnp.zeros_like(initial_embedding.z_init),
         )
-        return final_state
+    else:
+        state = initial_recycling_state
 
-    @property
-    def distogram_bins(self) -> Float[Array, "64"]:
-        return np.linspace(start=2.0, stop=22.0, num=64)
-
-    @cached_property
-    def distogram_logits(self) -> Float[Array, "N N 64"]:
-        return self.joltz2.distogram_module(self.trunk_state.z)[0, :, :, 0, :]
-
-    @cached_property
-    def structure_coordinates(self):
-        print("JIT compiling structure module...")
-        q, c, to_keys, atom_enc_bias, atom_dec_bias, token_trans_bias = (
-            self.joltz2.diffusion_conditioning(
-                self.trunk_state.s,
-                self.trunk_state.z,
-                self.initial_embedding.relative_position_encoding,
-                self.features,
-            )
+    def body_fn(carry, _):
+        trunk_state, key = carry
+        trunk_state = jax.tree.map(jax.lax.stop_gradient, trunk_state)
+        trunk_state, key = model.trunk_iteration(
+            trunk_state,
+            initial_embedding,
+            features,
+            key=key,
+            deterministic=deterministic,
         )
-        with jax.default_matmul_precision("float32"):
-            return self.joltz2.structure_module.sample(
-                s_trunk=self.trunk_state.s,
-                s_inputs=self.initial_embedding.s_inputs,
-                feats=self.features,
-                num_sampling_steps=self.num_sampling_steps,
-                atom_mask=self.features["atom_pad_mask"],
-                multiplicity=1,
-                diffusion_conditioning={
-                    "q": q,
-                    "c": c,
-                    "to_keys": to_keys,
-                    "atom_enc_bias": atom_enc_bias,
-                    "atom_dec_bias": atom_dec_bias,
-                    "token_trans_bias": token_trans_bias,
-                },
-                key=jax.random.fold_in(self.key, 2),
-            )
+        return (trunk_state, key), None
 
-    @cached_property
-    def confidence_metrics(self) -> joltz.ConfidenceMetrics:
-        print("JIT compiling confidence module...")
-        return self.joltz2.confidence_module(
-            s_inputs=self.initial_embedding.s_inputs,
-            s=self.trunk_state.s,
-            z=self.trunk_state.z,
-            x_pred=self.structure_coordinates,
-            feats=self.features,
-            pred_distogram_logits=self.distogram_logits[None],
-            key=jax.random.fold_in(self.key, 5),
-            deterministic=self.deterministic,
+    (final_state, _), _ = jax.lax.scan(
+        body_fn,
+        (state, key),
+        None,
+        length=recycling_steps,
+    )
+    return initial_embedding, final_state
+
+
+def boltz2_forward_from_trunk(
+    model: joltz.Joltz2,
+    features: PyTree,
+    initial_embedding,
+    trunk_state: TrunkState,
+    *,
+    num_sampling_steps: int,
+    deterministic: bool,
+    key: jax.Array,
+) -> StructureModelOutput:
+    """Run distogram, structure, and confidence from pre-computed trunk state."""
+    distogram_logits = model.distogram_module(trunk_state.z)[0, :, :, 0, :]
+
+    print("JIT compiling structure module...")
+    q, c, to_keys, atom_enc_bias, atom_dec_bias, token_trans_bias = (
+        model.diffusion_conditioning(
+            trunk_state.s,
+            trunk_state.z,
+            initial_embedding.relative_position_encoding,
+            features,
+        )
+    )
+    with jax.default_matmul_precision("float32"):
+        structure_coordinates = model.structure_module.sample(
+            s_trunk=trunk_state.s,
+            s_inputs=initial_embedding.s_inputs,
+            feats=features,
+            num_sampling_steps=num_sampling_steps,
+            atom_mask=features["atom_pad_mask"],
+            multiplicity=1,
+            diffusion_conditioning={
+                "q": q,
+                "c": c,
+                "to_keys": to_keys,
+                "atom_enc_bias": atom_enc_bias,
+                "atom_dec_bias": atom_dec_bias,
+                "token_trans_bias": token_trans_bias,
+            },
+            key=jax.random.fold_in(key, 2),
         )
 
-    @property
-    def plddt(self) -> Float[Array, "N"]:
-        """PLDDT *normalized* to between 0 and 1."""
-        return self.confidence_metrics.plddt[0]
+    print("JIT compiling confidence module...")
+    confidence = model.confidence_module(
+        s_inputs=initial_embedding.s_inputs,
+        s=trunk_state.s,
+        z=trunk_state.z,
+        x_pred=structure_coordinates,
+        feats=features,
+        pred_distogram_logits=distogram_logits[None],
+        key=jax.random.fold_in(key, 5),
+        deterministic=deterministic,
+    )
 
-    @property
-    def pae(self) -> Float[Array, "N N"]:
-        return self.confidence_metrics.pae[0]
+    # Backbone coordinates (N, CA, C, O)
+    features_unbatched = jax.tree.map(lambda x: x[0], features)
+    assert ref_atoms["UNK"][:4] == ["N", "CA", "C", "O"]
+    first_atom_idx = jax.vmap(lambda atoms: jnp.nonzero(atoms, size=1)[0][0])(
+        features_unbatched["atom_to_token"].T
+    )
+    all_atom_coords = structure_coordinates[0]
+    backbone_coordinates = jnp.stack(
+        [all_atom_coords[first_atom_idx + i] for i in range(4)], -2
+    )
 
-    @property
-    def pae_logits(self) -> Float[Array, "N N Bins"]:
-        return self.confidence_metrics.pae_logits[0]
-
-    @property
-    def pae_bins(self) -> Float[Array, "Bins"]:
-        end = 32.0
-        num_bins = 64
-        bin_width = end / num_bins
-        return np.arange(start=0.5 * bin_width, stop=end, step=bin_width)
-
-    @property
-    def backbone_coordinates(self) -> Float[Array, "N 4"]:
-        # this can also be done with the atom_backbone_feat feature -- 
-        # something like index = jnp.nonzero(abf[..., 1:5].any(axis=-1), size=4*N).reshape(N,4)
-        features = jax.tree.map(lambda x: x[0], self.features)
-        # In order these are N, C-alpha, C, O
-        assert ref_atoms["UNK"][:4] == ["N", "CA", "C", "O"]
-        # first step, which is a bit cryptic, is to get the first atom for each token
-        first_atom_idx = jax.vmap(lambda atoms: jnp.nonzero(atoms, size=1)[0][0])(
-            features["atom_to_token"].T
-        )
-        # NOTE: this will completely (and silently) fail if any tokens are non-protein!
-        all_atom_coords = self.structure_coordinates[0]
-        coords = jnp.stack([all_atom_coords[first_atom_idx + i] for i in range(4)], -2)
-        return coords
+    return StructureModelOutput(
+        distogram_logits=distogram_logits,
+        distogram_bins=BOLTZ2_DISTOGRAM_BINS,
+        plddt=confidence.plddt[0],
+        pae=confidence.pae[0],
+        pae_logits=confidence.pae_logits[0],
+        pae_bins=PAE_BINS,
+        structure_coordinates=structure_coordinates,
+        backbone_coordinates=backbone_coordinates,
+        full_sequence=features["res_type"][0][:, 2:22],
+        asym_id=features["asym_id"][0],
+        residue_idx=features["residue_index"][0],
+    )
 
 
 class Boltz2Loss(LossTerm):
@@ -387,137 +361,24 @@ class Boltz2Loss(LossTerm):
 
     def __call__(self, sequence: Float[Array, "N 20"], key=None):
         """Compute the loss for a given sequence."""
-        # Set the binder sequence in the features
         features = set_binder_sequence(sequence, self.features)
 
-        # initialize lazy output object
-        output = Boltz2Output(
-            joltz2=self.joltz2,
-            features=features,
-            deterministic=self.deterministic,
-            key=key,
+        initial_embedding, trunk_state = boltz2_trunk(
+            self.joltz2, features,
             recycling_steps=self.recycling_steps,
-            num_sampling_steps=self.sampling_steps,
+            deterministic=self.deterministic,
             initial_recycling_state=self.initial_recycling_state,
+            key=key,
         )
-
-        v, aux = self.loss(
-            sequence=sequence,
-            output=output,
+        output = boltz2_forward_from_trunk(
+            self.joltz2, features, initial_embedding, trunk_state,
+            num_sampling_steps=self.sampling_steps,
+            deterministic=self.deterministic,
             key=key,
         )
 
+        v, aux = self.loss(sequence=sequence, output=output, key=key)
         return v, {self.name: aux}
-
-
-class Boltz2FromTrunkOutput(eqx.Module):
-    joltz2: joltz.Joltz2
-    features: PyTree
-    deterministic: bool
-    key: jax.Array
-    initial_embedding: any
-    trunk_state: TrunkState
-    recycling_steps: int = 0
-    num_sampling_steps: int = 25
-    initial_recycling_state: TrunkState | None = None
-
-    @property
-    def full_sequence(self):
-        return self.features["res_type"][0][:, 2:22]
-
-    @property
-    def asym_id(self):
-        return self.features["asym_id"][0]
-
-    @property
-    def residue_idx(self):
-        return self.features["residue_index"][0]
-
-    @property
-    def distogram_bins(self) -> Float[Array, "64"]:
-        return np.linspace(start=2.0, stop=22.0, num=64)
-
-    @cached_property
-    def distogram_logits(self) -> Float[Array, "N N 64"]:
-        return self.joltz2.distogram_module(self.trunk_state.z)[0, :, :, 0, :]
-
-    @cached_property
-    def structure_coordinates(self):
-        print("JIT compiling structure module...")
-        q, c, to_keys, atom_enc_bias, atom_dec_bias, token_trans_bias = (
-            self.joltz2.diffusion_conditioning(
-                self.trunk_state.s,
-                self.trunk_state.z,
-                self.initial_embedding.relative_position_encoding,
-                self.features,
-            )
-        )
-        with jax.default_matmul_precision("float32"):
-            return self.joltz2.structure_module.sample(
-                s_trunk=self.trunk_state.s,
-                s_inputs=self.initial_embedding.s_inputs,
-                feats=self.features,
-                num_sampling_steps=self.num_sampling_steps,
-                atom_mask=self.features["atom_pad_mask"],
-                multiplicity=1,
-                diffusion_conditioning={
-                    "q": q,
-                    "c": c,
-                    "to_keys": to_keys,
-                    "atom_enc_bias": atom_enc_bias,
-                    "atom_dec_bias": atom_dec_bias,
-                    "token_trans_bias": token_trans_bias,
-                },
-                key=jax.random.fold_in(self.key, 2),
-            )
-
-    @cached_property
-    def confidence_metrics(self) -> joltz.ConfidenceMetrics:
-        print("JIT compiling confidence module...")
-        return self.joltz2.confidence_module(
-            s_inputs=self.initial_embedding.s_inputs,
-            s=self.trunk_state.s,
-            z=self.trunk_state.z,
-            x_pred=self.structure_coordinates,
-            feats=self.features,
-            pred_distogram_logits=self.distogram_logits[None],
-            key=jax.random.fold_in(self.key, 5),
-            deterministic=self.deterministic,
-        )
-
-    @property
-    def plddt(self) -> Float[Array, "N"]:
-        """PLDDT *normalized* to between 0 and 1."""
-        return self.confidence_metrics.plddt[0]
-
-    @property
-    def pae(self) -> Float[Array, "N N"]:
-        return self.confidence_metrics.pae[0]
-
-    @property
-    def pae_logits(self) -> Float[Array, "N N Bins"]:
-        return self.confidence_metrics.pae_logits[0]
-
-    @property
-    def pae_bins(self) -> Float[Array, "Bins"]:
-        end = 32.0
-        num_bins = 64
-        bin_width = end / num_bins
-        return np.arange(start=0.5 * bin_width, stop=end, step=bin_width)
-
-    @property
-    def backbone_coordinates(self) -> Float[Array, "N 4"]:
-        features = jax.tree.map(lambda x: x[0], self.features)
-        # In order these are N, C-alpha, C, O
-        assert ref_atoms["UNK"][:4] == ["N", "CA", "C", "O"]
-        # first step, which is a bit cryptic, is to get the first atom for each token
-        first_atom_idx = jax.vmap(lambda atoms: jnp.nonzero(atoms, size=1)[0][0])(
-            features["atom_to_token"].T
-        )
-        # NOTE: this will completely (and silently) fail if any tokens are non-protein!
-        all_atom_coords = self.structure_coordinates[0]
-        coords = jnp.stack([all_atom_coords[first_atom_idx + i] for i in range(4)], -2)
-        return coords
 
 
 class MultiSampleBoltz2Loss(LossTerm):
@@ -539,40 +400,24 @@ class MultiSampleBoltz2Loss(LossTerm):
 
     def __call__(self, sequence: Float[Array, "N 20"], key=None):
         """Compute the loss for a given sequence."""
-        # Set the binder sequence in the features
         features = set_binder_sequence(sequence, self.features)
 
-        # initialize lazy output object
-        output = Boltz2Output(
-            joltz2=self.joltz2,
-            features=features,
-            deterministic=self.deterministic,
-            key=key,
+        initial_embedding, trunk_state = boltz2_trunk(
+            self.joltz2, features,
             recycling_steps=self.recycling_steps,
-            num_sampling_steps=self.sampling_steps,
+            deterministic=self.deterministic,
             initial_recycling_state=self.initial_recycling_state,
+            key=key,
         )
 
-        # initialize from trunk outputs using vmap
         def apply_loss_to_single_sample(key):
-            from_trunk_output = Boltz2FromTrunkOutput(
-                joltz2=self.joltz2,
-                features=features,
+            output = boltz2_forward_from_trunk(
+                self.joltz2, features, initial_embedding, trunk_state,
+                num_sampling_steps=self.sampling_steps,
                 deterministic=self.deterministic,
                 key=key,
-                initial_embedding=output.initial_embedding,
-                trunk_state=output.trunk_state,
-                recycling_steps=self.recycling_steps,
-                num_sampling_steps=self.sampling_steps,
-                initial_recycling_state=self.initial_recycling_state,
             )
-            v, aux = self.loss(
-                sequence=sequence,
-                output=from_trunk_output,
-                key=key,
-            )
-
-            return v, aux
+            return self.loss(sequence=sequence, output=output, key=key)
 
         vs, auxs = jax.vmap(apply_loss_to_single_sample)(
             jax.random.split(key, self.num_samples)

--- a/src/mosaic/losses/boltz2.py
+++ b/src/mosaic/losses/boltz2.py
@@ -238,7 +238,6 @@ def boltz2_trunk(
     key: jax.Array,
 ):
     """Run embedding + trunk recycling. Returns (initial_embedding, trunk_state)."""
-    print("JIT compiling trunk module...")
     initial_embedding = model.embed_inputs(features)
 
     if initial_recycling_state is None:
@@ -283,7 +282,6 @@ def boltz2_forward_from_trunk(
     """Run distogram, structure, and confidence from pre-computed trunk state."""
     distogram_logits = model.distogram_module(trunk_state.z)[0, :, :, 0, :]
 
-    print("JIT compiling structure module...")
     q, c, to_keys, atom_enc_bias, atom_dec_bias, token_trans_bias = (
         model.diffusion_conditioning(
             trunk_state.s,
@@ -311,7 +309,6 @@ def boltz2_forward_from_trunk(
             key=jax.random.fold_in(key, 2),
         )
 
-    print("JIT compiling confidence module...")
     confidence = model.confidence_module(
         s_inputs=initial_embedding.s_inputs,
         s=trunk_state.s,

--- a/src/mosaic/losses/of3.py
+++ b/src/mosaic/losses/of3.py
@@ -3,25 +3,21 @@
 Provides:
 - Token vocabulary mapping between mosaic's 20-AA and OF3's 32-dim restype
 - Binder sequence injection into OF3 Batch
-- OF3FromTrunkOutput: lazy AbstractStructureOutput wrapping trunk state
+- of3_forward_from_trunk: eager forward returning StructureModelOutput
 - MultiSampleOF3Loss: trunk-once, vmap-over-samples loss term
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from functools import cached_property
-
-import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jaxtyping import Array, Float, Int
+from jaxtyping import Array, Float
 from mosaic.common import LinearCombination, LossTerm
-from mosaic.losses.structure_prediction import AbstractStructureOutput
+from mosaic.losses.structure_prediction import PAE_BINS, StructureModelOutput
 
+import equinox as eqx
 from jopenfold3.batch import Batch
-from jopenfold3.heads.head_modules import ConfidenceOutput
 from jopenfold3.model import InitialEmbedding, OpenFold3, TrunkEmbedding
 
 
@@ -74,104 +70,68 @@ def _bin_centers(bin_min: float, bin_max: float, num_bins: int) -> np.ndarray:
 
 # Distogram: 64 bins, 2.0–22.0 Å
 DISTOGRAM_BINS = _bin_centers(2.0, 22.0, 64)
-# PAE: 64 bins, 0.0–32.0 Å
-PAE_BINS = _bin_centers(0.0, 32.0, 64)
 # pLDDT: 50 bins, 0.0–1.0
 PLDDT_BINS = _bin_centers(0.0, 1.0, 50)
 
 
 # ---------------------------------------------------------------------------
-# OF3FromTrunkOutput — lazy AbstractStructureOutput
+# of3_forward_from_trunk — eager forward returning StructureModelOutput
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class OF3FromTrunkOutput(AbstractStructureOutput):
-    """Lazy structure output from a frozen trunk state.
+def of3_forward_from_trunk(
+    model: OpenFold3,
+    batch: Batch,
+    init_emb: InitialEmbedding,
+    trunk_emb: TrunkEmbedding,
+    sampling_steps: int,
+    key: jax.Array,
+) -> StructureModelOutput:
+    """Run distogram, structure, and confidence from pre-computed trunk state."""
+    z = trunk_emb.z[:, None, ...]
+    distogram_logits = model.aux_heads.distogram(z=z)[0, 0]
 
-    Expensive computations (diffusion sampling, confidence heads) are
-    deferred to first property access via @cached_property, so multiple
-    loss terms sharing the same output don't recompute.
-    """
+    structure_coordinates = model.sample_structures(
+        init_emb, trunk_emb, batch,
+        sampling_steps, num_samples=1,
+        key=key,
+    )
 
-    model: OpenFold3
-    batch: Batch
-    init_emb: InitialEmbedding
-    trunk_emb: TrunkEmbedding
-    sampling_steps: int
-    key: jax.Array
+    confidence = model.confidence_metrics(
+        init_emb, trunk_emb, batch,
+        structure_coordinates, key=key,
+    )
 
-    @property
-    def full_sequence(self) -> Float[Array, "N 20"]:
-        return self.batch.restype[0].astype(jnp.float32) @ jnp.array(_MOSAIC_TO_OF3).T
+    # pLDDT normalized to [0, 1]
+    logits = confidence.plddt_logits[0, 0]  # [N_atom, 50]
+    rep_idx = batch.representative_atom_index[0]  # [N_token]
+    token_logits = logits[rep_idx]  # [N_token, 50]
+    probs = jax.nn.softmax(token_logits, axis=-1)
+    plddt = (probs * jnp.array(PLDDT_BINS)[None, :]).sum(-1)
 
-    @property
-    def asym_id(self) -> Float[Array, "N"]:
-        return self.batch.asym_id[0]
+    # PAE
+    pae_logits = confidence.pae_logits[0, 0]
+    pae_probs = jax.nn.softmax(pae_logits, axis=-1)
+    pae = (pae_probs * jnp.array(PAE_BINS)[None, None, :]).sum(-1)
 
-    @property
-    def residue_idx(self) -> Int[Array, "N"]:
-        return self.batch.residue_index[0]
+    # Backbone coordinates (N, CA, C, O)
+    start = batch.start_atom_index[0].astype(jnp.int32)
+    coords = structure_coordinates[0, 0]  # [N_atom, 3]
+    backbone_coordinates = jnp.stack([coords[start + i] for i in range(4)], axis=-2)
 
-    @property
-    def distogram_bins(self) -> Float[Array, "64"]:
-        return DISTOGRAM_BINS
-
-    @property
-    def pae_bins(self) -> Float[Array, "64"]:
-        return PAE_BINS
-
-
-    @property
-    def distogram_logits(self) -> Float[Array, "N N 64"]:
-        z = self.trunk_emb.z[:, None, ...]
-        return self.model.aux_heads.distogram(z=z)[0, 0]
-
-
-    @cached_property
-    def structure_coordinates(self) -> Array:
-        """[B, S, N_atom, 3] diffusion-sampled atom coordinates."""
-        return self.model.sample_structures(
-            self.init_emb, self.trunk_emb, self.batch,
-            self.sampling_steps, num_samples=1,
-            key=self.key,
-        )
-
-    @cached_property
-    def _confidence(self) -> ConfidenceOutput:
-        return self.model.confidence_metrics(
-            self.init_emb, self.trunk_emb, self.batch,
-            self.structure_coordinates, key=self.key,
-        )
-
-
-    @property
-    def plddt(self) -> Float[Array, "N"]:
-        """Token-level pLDDT normalized to [0, 1]."""
-        # plddt_logits: [B, S, N_atom, 50] — select representative atom per token
-        logits = self._confidence.plddt_logits[0, 0]  # [N_atom, 50]
-        rep_idx = self.batch.representative_atom_index[0]  # [N_token]
-        token_logits = logits[rep_idx]  # [N_token, 50]
-        probs = jax.nn.softmax(token_logits, axis=-1)
-        return (probs * jnp.array(PLDDT_BINS)[None, :]).sum(-1)
-
-    @property
-    def pae(self) -> Float[Array, "N N"]:
-        logits = self.pae_logits  # [N, N, 64]
-        probs = jax.nn.softmax(logits, axis=-1)
-        return (probs * jnp.array(PAE_BINS)[None, None, :]).sum(-1)
-
-    @property
-    def pae_logits(self) -> Float[Array, "N N 64"]:
-        return self._confidence.pae_logits[0, 0]
-
-    @property
-    def backbone_coordinates(self) -> Float[Array, "N 4 3"]:
-        """N, CA, C, O coordinates per token."""
-        start = self.batch.start_atom_index[0].astype(jnp.int32)  # [N_token]
-        coords = self.structure_coordinates[0, 0]  # [N_atom, 3]
-        # First 4 atoms per standard protein residue are N, CA, C, O
-        return jnp.stack([coords[start + i] for i in range(4)], axis=-2)
+    return StructureModelOutput(
+        distogram_logits=distogram_logits,
+        distogram_bins=DISTOGRAM_BINS,
+        plddt=plddt,
+        pae=pae,
+        pae_logits=pae_logits,
+        pae_bins=PAE_BINS,
+        structure_coordinates=structure_coordinates,
+        backbone_coordinates=backbone_coordinates,
+        full_sequence=batch.restype[0].astype(jnp.float32) @ jnp.array(_MOSAIC_TO_OF3).T,
+        asym_id=batch.asym_id[0],
+        residue_idx=batch.residue_index[0],
+    )
 
 
 class MultiSampleOF3Loss(LossTerm):
@@ -188,7 +148,6 @@ class MultiSampleOF3Loss(LossTerm):
     sampling_steps: int = 20
     num_samples: int = 4
     reduction: any = jnp.mean
-    atom_lookup: any = None
 
     def __call__(self, sequence: Float[Array, "N 20"], key):
         batch = set_binder_sequence(sequence, self.batch)
@@ -198,7 +157,7 @@ class MultiSampleOF3Loss(LossTerm):
         )
 
         def single_sample(key):
-            output = OF3FromTrunkOutput(
+            output = of3_forward_from_trunk(
                 model=self.model,
                 batch=batch,
                 init_emb=init_emb,

--- a/src/mosaic/losses/protein_mpnn.py
+++ b/src/mosaic/losses/protein_mpnn.py
@@ -10,7 +10,7 @@ from jaxtyping import Array, Float, Int
 
 from ..common import TOKENS, LossTerm
 from ..proteinmpnn.mpnn import MPNN_ALPHABET, ProteinMPNN
-from .structure_prediction import AbstractStructureOutput
+from .structure_prediction import StructureModelOutput
 
 
 def boltz_to_mpnn_matrix():
@@ -154,7 +154,7 @@ class ProteinMPNNLoss(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         # Get the atoms required for proteinMPNN:
@@ -234,7 +234,7 @@ class ProteinMPNNLoss(LossTerm):
 def jacobi_inverse_fold(
     mpnn: ProteinMPNN,
     binder_length: int,
-    output: AbstractStructureOutput,
+    output: StructureModelOutput,
     temp: float,
     key,
     jacobi_iterations: int = 10,
@@ -324,7 +324,7 @@ class InverseFoldingSequenceRecovery(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         sequences = jax.vmap(

--- a/src/mosaic/losses/protenix.py
+++ b/src/mosaic/losses/protenix.py
@@ -2,8 +2,6 @@ import copy
 
 # set "PROTENIX_DATA_ROOT_DIR" env variable
 import os
-from dataclasses import dataclass
-from functools import cached_property
 from pathlib import Path
 
 import gemmi
@@ -13,14 +11,13 @@ import numpy as np
 from jaxtyping import Array, Float, PyTree
 from protenix.data.constants import PRO_STD_RESIDUES
 from protenix.protenij import (
-    ConfidenceMetrics,
     InitialEmbedding,
     TrunkEmbedding,
 )
 from protenix.protenij import Protenix as Protenij
 
 from mosaic.common import TOKENS, LinearCombination, LossTerm
-from mosaic.losses.structure_prediction import AbstractStructureOutput
+from mosaic.losses.structure_prediction import PAE_BINS, StructureModelOutput
 
 os.environ["PROTENIX_DATA_ROOT_DIR"] = str(Path("~/.protenix").expanduser())
 
@@ -63,7 +60,7 @@ def biotite_array_to_gemmi_struct(atom_array, pred_coord=None, per_atom_plddt=No
     return structure
 
 
-def boltz_to_protenix_matrix():
+def _build_boltz_to_protenix_matrix():
     T = np.zeros((len(TOKENS), 32))
     for i, tok in enumerate(TOKENS):
         protenix_idx = PRO_STD_RESIDUES[
@@ -72,10 +69,12 @@ def boltz_to_protenix_matrix():
         T[i, protenix_idx] = 1
     return T
 
+BOLTZ_TO_PROTENIX = _build_boltz_to_protenix_matrix()
+
 
 def set_binder_sequence(new_sequence: Float[Array, "N 20"], features: PyTree):
     binder_len = new_sequence.shape[0]
-    protenix_sequence = new_sequence @ boltz_to_protenix_matrix()
+    protenix_sequence = new_sequence @ BOLTZ_TO_PROTENIX
     n_msa = features["msa"].shape[0]
     print("n_msa", n_msa)
 
@@ -153,105 +152,74 @@ def get_trunk_state(
     return initial_embedding, body_fn((0, state, key))[1]
 
 
-@dataclass
-class ProtenixFromTrunkOutput(AbstractStructureOutput):
-    model: Protenij
-    features: PyTree
-    key: jax.Array
-    initial_embedding: InitialEmbedding
-    trunk_state: TrunkEmbedding
-    sampling_steps: int = 2
+PROTENIX_DISTOGRAM_BINS = np.linspace(start=2.3125, stop=21.6875, num=64)
 
-    @property
-    def full_sequence(self):
-        return self.features["restype"] @ boltz_to_protenix_matrix().T
 
-    @property
-    def asym_id(self):
-        return self.features["asym_id"]
+def protenix_forward_from_trunk(
+    model: Protenij,
+    features: PyTree,
+    initial_embedding: InitialEmbedding,
+    trunk_state: TrunkEmbedding,
+    sampling_steps: int,
+    key: jax.Array,
+) -> StructureModelOutput:
+    """Run distogram, structure, and confidence from pre-computed trunk state."""
+    distogram_logits = model.distogram_head(trunk_state.z)
 
-    @property
-    def residue_idx(self):
-        return self.features["residue_index"]
+    print("JIT compiling structure module...")
+    structure_coordinates = model.sample_structures(
+        initial_embedding=initial_embedding,
+        trunk_embedding=trunk_state,
+        input_feature_dict=features,
+        N_samples=1,
+        N_steps=sampling_steps,
+        key=key,
+    )
 
-    @property
-    def distogram_bins(self) -> Float[Array, "64"]:
-        return np.linspace(start=2.3125, stop=21.6875, num=64)
+    print("JIT compiling confidence module...")
+    confidence = model.confidence_metrics(
+        initial_embedding=initial_embedding,
+        trunk_embedding=trunk_state,
+        input_feature_dict=features,
+        coordinates=structure_coordinates,
+        key=key,
+    )
 
-    @cached_property
-    def distogram_logits(self) -> Float[Array, "N N 64"]:
-        return self.model.distogram_head(self.trunk_state.z)
+    # pLDDT normalized to [0, 1]
+    plddt = (
+        jax.nn.softmax(confidence.plddt_logits[0][features["atom_rep_atom_idx"]])
+        * jnp.linspace(0, 1, 50)[None, :]
+    ).sum(-1)
 
-    @cached_property
-    def structure_coordinates(self):
-        print("JIT compiling structure module...")
-        return self.model.sample_structures(
-            initial_embedding=self.initial_embedding,
-            trunk_embedding=self.trunk_state,
-            input_feature_dict=self.features,
-            N_samples=1,
-            N_steps=self.sampling_steps,
-            key=self.key,
-        )
+    # PAE
+    pae_logits = confidence.pae_logits[0]
+    pae = (
+        jax.nn.softmax(pae_logits) * PAE_BINS[None, None, :]
+    ).sum(-1)
 
-    @cached_property
-    def confidence_metrics(self) -> ConfidenceMetrics:
-        print("JIT compiling confidence module...")
-        return self.model.confidence_metrics(
-            initial_embedding=self.initial_embedding,
-            trunk_embedding=self.trunk_state,
-            input_feature_dict=self.features,
-            coordinates=self.structure_coordinates,
-            key=self.key,
-        )
+    # Backbone coordinates (N, CA, C, O)
+    n_tokens = features["restype"].shape[0]
+    first_atom_idx = jax.vmap(lambda atoms: jnp.nonzero(atoms, size=1)[0][0])(
+        (features["atom_to_token_idx"][:, None] == jnp.arange(n_tokens)[None, :]).T
+    )
+    all_atom_coords = structure_coordinates[0]
+    backbone_coordinates = jnp.stack(
+        [all_atom_coords[first_atom_idx + i] for i in range(4)], -2
+    )
 
-    @property
-    def plddt(self) -> Float[Array, "N"]:
-        """PLDDT *normalized* to between 0 and 1."""
-        return (
-            jax.nn.softmax(
-                self.confidence_metrics.plddt_logits[0][
-                    self.features["atom_rep_atom_idx"]
-                ]
-            )
-            * jnp.linspace(0, 1, 50)[None, :]
-        ).sum(-1)
-
-    @property
-    def pae(self) -> Float[Array, "N N"]:
-        return (
-            (
-                jax.nn.softmax(self.confidence_metrics.pae_logits)
-                * self.pae_bins[None, None, :]
-            ).sum(-1)
-        ).mean(0)
-
-    @property
-    def pae_logits(self) -> Float[Array, "N N 64"]:
-        return self.confidence_metrics.pae_logits[0]
-
-    @property
-    def pae_bins(self) -> Float[Array, "64"]:
-        end = 32.0
-        num_bins = 64
-        bin_width = end / num_bins
-        return np.arange(start=0.5 * bin_width, stop=end, step=bin_width)
-
-    @property
-    def backbone_coordinates(self) -> Float[Array, "N 4"]:
-        features = self.features
-        # In order these are N, C-alpha, C, O
-        # assert ref_atoms["UNK"][:4] == ["N", "CA", "C", "O"]
-        # first step, which is a bit cryptic, is to get the first atom for each token
-        n_tokens = features["restype"].shape[0]
-        first_atom_idx = jax.vmap(lambda atoms: jnp.nonzero(atoms, size=1)[0][0])(
-            (features["atom_to_token_idx"][:, None] == jnp.arange(n_tokens)[None, :]).T
-        )
-        # NOTE: this will completely (and silently) fail if any tokens are non-protein!
-        # take first diffusion sample?
-        all_atom_coords = self.structure_coordinates[0]
-        coords = jnp.stack([all_atom_coords[first_atom_idx + i] for i in range(4)], -2)
-        return coords
+    return StructureModelOutput(
+        distogram_logits=distogram_logits,
+        distogram_bins=PROTENIX_DISTOGRAM_BINS,
+        plddt=plddt,
+        pae=pae,
+        pae_logits=pae_logits,
+        pae_bins=PAE_BINS,
+        structure_coordinates=structure_coordinates,
+        backbone_coordinates=backbone_coordinates,
+        full_sequence=features["restype"] @ BOLTZ_TO_PROTENIX.T,
+        asym_id=features["asym_id"],
+        residue_idx=features["residue_index"],
+    )
 
 
 class MultiSampleProtenixLoss(LossTerm):
@@ -287,17 +255,17 @@ class MultiSampleProtenixLoss(LossTerm):
 
         # initialize from trunk outputs using vmap
         def apply_loss_to_single_sample(key):
-            from_trunk_output = ProtenixFromTrunkOutput(
+            output = protenix_forward_from_trunk(
                 model=self.model,
                 features=features,
-                key=key,
                 initial_embedding=initial_embedding,
                 trunk_state=trunk_state,
                 sampling_steps=self.sampling_steps,
+                key=key,
             )
             v, aux = self.loss(
                 sequence=sequence,
-                output=from_trunk_output,
+                output=output,
                 key=key,
             )
 

--- a/src/mosaic/losses/protenix.py
+++ b/src/mosaic/losses/protenix.py
@@ -107,8 +107,6 @@ def get_trunk_state(
     key: jax.Array,
 ) -> tuple[InitialEmbedding, TrunkEmbedding]:
     """ Compute trunk embedding."""
-    print("JIT compiling protenix trunk module...")
-
     # manual recycling
     state = initial_recycling_state
     initial_embedding = model.embed_inputs(
@@ -166,7 +164,6 @@ def protenix_forward_from_trunk(
     """Run distogram, structure, and confidence from pre-computed trunk state."""
     distogram_logits = model.distogram_head(trunk_state.z)
 
-    print("JIT compiling structure module...")
     structure_coordinates = model.sample_structures(
         initial_embedding=initial_embedding,
         trunk_embedding=trunk_state,
@@ -176,7 +173,6 @@ def protenix_forward_from_trunk(
         key=key,
     )
 
-    print("JIT compiling confidence module...")
     confidence = model.confidence_metrics(
         initial_embedding=initial_embedding,
         trunk_embedding=trunk_state,

--- a/src/mosaic/losses/structure_prediction.py
+++ b/src/mosaic/losses/structure_prediction.py
@@ -1,80 +1,30 @@
+import equinox as eqx
 import jax
 from jaxtyping import Float, Array, Int
 
 from collections.abc import Callable
-from abc import abstractmethod
 import jax.numpy as jnp
 import numpy as np
-import gemmi
 
 from ..common import LossTerm
 
+# 64 bins, 0.0–32.0 Å, shared across all model backends
+PAE_BINS = np.arange(start=0.25, stop=32.0, step=0.5)
 
-# Each structure prediction model (AF2, boltz, boltz2, etc.) implements this interface for loss functionals
-class AbstractStructureOutput:
-    @property
-    @abstractmethod
-    def distogram_bins(self) -> Float[Array, "Bins"]:
-        raise NotImplementedError
 
-    @property
-    @abstractmethod
-    def distogram_logits(self) -> Float[Array, "N N Bins"]:
-        raise NotImplementedError
+class StructureModelOutput(eqx.Module):
+    distogram_logits: Float[Array, "N N Bins"]
+    distogram_bins: Float[Array, "Bins"]
+    plddt: Float[Array, "N"]
+    pae: Float[Array, "N N"]
+    pae_logits: Float[Array, "N N Bins"]
+    pae_bins: Float[Array, "Bins"]
+    structure_coordinates: Array  # all-atom coords, shape varies by model
+    backbone_coordinates: Float[Array, "N 4 3"]
+    full_sequence: Float[Array, "N 20"]
+    asym_id: Float[Array, "N"]
+    residue_idx: Int[Array, "N"]
 
-    @property
-    @abstractmethod
-    def plddt(self) -> Float[Array, "N"]:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def pae(self) -> Float[Array, "N N"]:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def pae_logits(self) -> Float[Array, "N N Bins"]:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def pae_bins(self) -> Float[Array, "Bins"]:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def backbone_coordinates(self) -> Float[Array, "N 4 3"]:
-        """
-        Backbone coordinates of predicted structure in the order "N, CA, C, O".
-        """
-        raise NotImplementedError
-
-    @property
-    def ptm(self) -> Float[Array, "1"]:
-        return predicted_tm_score(
-            logits=self.pae_logits,
-            bin_centers=self.pae_bins,
-        ).max()
-
-    @property
-    @abstractmethod
-    def full_sequence(self) -> Float[Array, "N 20"]:
-        """
-        Full sequence of the structure, including binder and target(s).
-        """
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def asym_id(self) -> Float[Array, "N"]:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def residue_idx(self) -> Int[Array, "N"]:
-        """Residue index in each chain!"""
-        raise NotImplementedError
 
 
 def interaction_prediction_score(
@@ -180,7 +130,7 @@ class WithinBinderContact(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -222,7 +172,7 @@ class BinderTargetContact(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -260,7 +210,7 @@ class HelixLoss(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -282,7 +232,7 @@ class DistogramRadiusOfGyration(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         # TODO: Why RMSE instead of MAE?
@@ -315,7 +265,7 @@ class MAERadiusOfGyration(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -348,7 +298,7 @@ class DistogramCE(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -371,7 +321,7 @@ class PLDDTLoss(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -383,7 +333,7 @@ class WithinBinderPAE(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -397,7 +347,7 @@ class BinderTargetPAE(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -409,7 +359,7 @@ class TargetBinderPAE(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -421,7 +371,7 @@ class IPTMLoss(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         # binder - target iptm -- we override asym-id in the case of multi-chain targets
@@ -442,7 +392,7 @@ class BinderTargetIPTM(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         # binder - target iptm -- we override asym-id in the case of multi-chain targets
@@ -463,7 +413,7 @@ class BinderPTMLoss(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -484,7 +434,7 @@ class BinderTargetIPSAE(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         N = output.full_sequence.shape[0]
@@ -510,7 +460,7 @@ class TargetBinderIPSAE(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         N = output.full_sequence.shape[0]
@@ -534,7 +484,7 @@ class IPSAE_min(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         bt_ipsae = (
@@ -568,7 +518,7 @@ class ActualRadiusOfGyration(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         binder_len = sequence.shape[0]
@@ -584,7 +534,7 @@ class pTMEnergy(LossTerm):
     def __call__(
         self,
         sequence: Float[Array, "N 20"],
-        output: AbstractStructureOutput,
+        output: StructureModelOutput,
         key,
     ):
         len_binder = sequence.shape[0]

--- a/src/mosaic/models/af2.py
+++ b/src/mosaic/models/af2.py
@@ -419,45 +419,16 @@ class AlphaFold2(StructurePredictionModel):
         recycling_state: state.AlphaFoldState | None = None,
         key,
     ):
-        features = set_binder_sequence(PSSM, features, self.multimer)
-        N = features["aatype"].shape[0]
-
-        if model_idx is None:
-            model_idx = jax.random.randint(key=key, shape=(), minval=0, maxval=5 if self.multimer else 2)
-            key = jax.random.fold_in(key, 0)
-        else:
-            model_idx = jax.device_put(model_idx)
-
-        if recycling_state is None:
-            recycling_state = state.AlphaFoldState(
-                prev_pos=jnp.zeros((N, residue_constants.atom_type_num, 3)),
-                prev_msa_first_row=jnp.zeros((N, 256)),
-                prev_pair=jnp.zeros((N, N, 128)),
-            )
-
-        params = jax.tree.map(lambda v: v[model_idx], self.stacked_parameters)
-
-        # recycling iterations
-        def body_fn(state: state.AlphaFoldState, _):
-            state = jax.tree.map(jax.lax.stop_gradient, state)
-            output = self.af2_forward(
-                params,
-                jax.random.fold_in(key, 1),
-                features=features,
-                previous_rep=state,
-                use_dropout=use_dropout,
-            )
-            return output.recycling_state, output
-
-        _, outputs = jax.lax.scan(
-            body_fn,
-            recycling_state,
-            length=recycling_steps,
+        smo, _ = self._forward_with_raw(
+            PSSM=PSSM,
+            features=features,
+            recycling_steps=recycling_steps,
+            model_idx=model_idx,
+            use_dropout=use_dropout,
+            recycling_state=recycling_state,
+            key=key,
         )
-
-        return af2_output_to_structure_model_output(
-            features, jax.tree.map(lambda v: v[-1], outputs)
-        )
+        return smo
 
     @eqx.filter_jit
     def _forward_with_raw(
@@ -476,7 +447,8 @@ class AlphaFold2(StructurePredictionModel):
         N = features["aatype"].shape[0]
 
         if model_idx is None:
-            model_idx = 0
+            model_idx = jax.random.randint(key=key, shape=(), minval=0, maxval=5 if self.multimer else 2)
+            key = jax.random.fold_in(key, 0)
         else:
             model_idx = jax.device_put(model_idx)
 

--- a/src/mosaic/models/af2.py
+++ b/src/mosaic/models/af2.py
@@ -27,7 +27,7 @@ from tqdm import tqdm
 import haiku as hk
 
 
-from mosaic.structure_prediction import AbstractStructureOutput
+from mosaic.losses.structure_prediction import PAE_BINS, StructureModelOutput
 from ..common import LossTerm, LinearCombination
 
 
@@ -245,52 +245,23 @@ def set_binder_sequence(PSSM, features: dict, multimer: bool=True):
     return out
 
 
-@dataclass
-class AF2Output(AbstractStructureOutput):
-    features: dict
-    output: AFOutput
+AF2_DISTOGRAM_BINS = np.linspace(start=2.3125, stop=21.6875, num=64)
 
-    @property
-    def full_sequence(self):
-        return jax.nn.one_hot(self.features["aatype"], 20)
 
-    @property
-    def asym_id(self):
-        return self.features["asym_id"]
-
-    @property
-    def residue_idx(self):
-        return self.features["residue_index"]
-
-    @property
-    def distogram_bins(self) -> Float[Array, "64"]:
-        return np.linspace(
-            start=2.3125, stop=21.6875, num=64
-        )  # not quite right but whatever
-
-    @property
-    def distogram_logits(self) -> Float[Array, "N N 64"]:
-        return self.output.distogram.logits
-
-    @property
-    def backbone_coordinates(self) -> Float[Array, "N 4 3"]:
-        return self.output.structure_module.final_atom_positions[:, [0, 1, 2, 4], :]
-
-    @property
-    def plddt(self) -> Float[Array, "N"]:
-        return self.output.plddt / 100
-
-    @property
-    def pae(self) -> Float[Array, "N N"]:
-        return self.output.predicted_aligned_error
-
-    @property
-    def pae_logits(self) -> Float[Array, "N N 64"]:
-        return self.output.pae_logits
-
-    @property
-    def pae_bins(self) -> Float[Array, "64"]:
-        return np.linspace(start=0.25, stop=31.75, num=64)
+def af2_output_to_structure_model_output(features: dict, output: AFOutput) -> StructureModelOutput:
+    return StructureModelOutput(
+        distogram_logits=output.distogram.logits,
+        distogram_bins=AF2_DISTOGRAM_BINS,
+        plddt=output.plddt / 100,
+        pae=output.predicted_aligned_error,
+        pae_logits=output.pae_logits,
+        pae_bins=PAE_BINS,
+        structure_coordinates=output.structure_module.final_atom_positions,
+        backbone_coordinates=output.structure_module.final_atom_positions[:, [0, 1, 2, 4], :],
+        full_sequence=jax.nn.one_hot(features["aatype"], 20),
+        asym_id=features["asym_id"],
+        residue_idx=features["residue_index"],
+    )
 
 
 
@@ -484,12 +455,12 @@ class AlphaFold2(StructurePredictionModel):
             length=recycling_steps,
         )
 
-        return AF2Output(
-            features=features, output=jax.tree.map(lambda v: v[-1], outputs)
+        return af2_output_to_structure_model_output(
+            features, jax.tree.map(lambda v: v[-1], outputs)
         )
 
     @eqx.filter_jit
-    def _coords_and_confidences(
+    def _forward_with_raw(
         self,
         *,
         PSSM: None | Float[Array, "N 20"] = None,
@@ -500,22 +471,39 @@ class AlphaFold2(StructurePredictionModel):
         recycling_state: state.AlphaFoldState | None = None,
         key,
     ):
-        output = self.model_output(
-            PSSM=PSSM,
-            features=features,
-            recycling_steps=recycling_steps,
-            model_idx=model_idx,
-            key=key,
-            use_dropout=use_dropout,
-            recycling_state=recycling_state,
-        )
+        """Returns (StructureModelOutput, raw AFOutput) — the raw output is needed for postprocessing in predict."""
+        features = set_binder_sequence(PSSM, features, self.multimer) if PSSM is not None else features
+        N = features["aatype"].shape[0]
 
-        pae = output.pae
-        plddt = output.plddt
-        if PSSM is None:
-            PSSM = jnp.zeros((0, 20))
-        iptm = -IPTMLoss()(PSSM, output, key=jax.random.key(0))[0]
-        return output.output, pae, plddt, iptm
+        if model_idx is None:
+            model_idx = 0
+        else:
+            model_idx = jax.device_put(model_idx)
+
+        if recycling_state is None:
+            recycling_state = state.AlphaFoldState(
+                prev_pos=jnp.zeros((N, residue_constants.atom_type_num, 3)),
+                prev_msa_first_row=jnp.zeros((N, 256)),
+                prev_pair=jnp.zeros((N, N, 128)),
+            )
+
+        params = jax.tree.map(lambda v: v[model_idx], self.stacked_parameters)
+
+        def body_fn(state_val, _):
+            state_val = jax.tree.map(jax.lax.stop_gradient, state_val)
+            output = self.af2_forward(
+                params,
+                jax.random.fold_in(key, 1),
+                features=features,
+                previous_rep=state_val,
+                use_dropout=use_dropout,
+            )
+            return output.recycling_state, output
+
+        _, outputs = jax.lax.scan(body_fn, recycling_state, length=recycling_steps)
+        raw = jax.tree.map(lambda v: v[-1], outputs)
+        smo = af2_output_to_structure_model_output(features, raw)
+        return smo, raw
 
     def predict(
         self,
@@ -530,7 +518,7 @@ class AlphaFold2(StructurePredictionModel):
         recycling_state: state.AlphaFoldState | None = None,
         key,
     ) -> StructurePrediction:
-        (afo, pae, plddt, iptm) = self._coords_and_confidences(
+        output, raw = self._forward_with_raw(
             PSSM=PSSM,
             features=features,
             recycling_steps=recycling_steps,
@@ -540,9 +528,11 @@ class AlphaFold2(StructurePredictionModel):
             recycling_state=recycling_state,
         )
 
-        _, structure = _postprocess_prediction(set_binder_sequence(PSSM, features, self.multimer), afo)
+        _, structure = _postprocess_prediction(set_binder_sequence(PSSM, features, self.multimer), raw)
 
-        return StructurePrediction(st=structure, plddt=plddt, pae=pae, iptm=iptm)
+        seq = PSSM if PSSM is not None else jnp.zeros((0, 20))
+        iptm = -IPTMLoss()(seq, output, key=jax.random.key(0))[0]
+        return StructurePrediction(st=structure, plddt=output.plddt, pae=output.pae, iptm=iptm)
 
 
 

--- a/src/mosaic/models/boltz1.py
+++ b/src/mosaic/models/boltz1.py
@@ -9,7 +9,8 @@ from mosaic.losses.boltz import (
     load_features_and_structure_writer,
     set_binder_sequence,
     Boltz1Loss,
-    Boltz1Output,
+    boltz1_trunk,
+    boltz1_forward_from_trunk,
 )
 
 from mosaic.losses.structure_prediction import IPTMLoss
@@ -17,10 +18,7 @@ from mosaic.losses.structure_prediction import IPTMLoss
 from pathlib import Path
 from jaxtyping import Array, Float, PyTree
 import equinox as eqx
-import gemmi
-import numpy as np
 import jax
-
 import jax.numpy as jnp
 
 
@@ -87,6 +85,7 @@ sequences:"""
             deterministic=True,
         )
 
+    @eqx.filter_jit
     def model_output(
         self,
         *,
@@ -99,42 +98,19 @@ sequences:"""
         if PSSM is not None:
             features = set_binder_sequence(PSSM, features)
 
-        return Boltz1Output(
-            joltz=self.model,
-            features=features,
+        trunk_outputs = boltz1_trunk(
+            self.model, features,
             recycling_steps=recycling_steps
             - 1,  # Really awkward off-by-one issue in Joltz1 :/
-            num_sampling_steps=sampling_steps if sampling_steps is not None else 25,
-            key=key,
             deterministic=True,
-        )
-
-    @eqx.filter_jit
-    def _coords_and_confidences(self,
-        *,
-        PSSM: None | Float[Array, "N 20"] = None,
-        features: PyTree,
-        recycling_steps=1,
-        sampling_steps=None,
-        key,
-    ):
-        output = self.model_output(
-            PSSM=PSSM,
-            features=features,
-            recycling_steps=recycling_steps,
-            sampling_steps=sampling_steps,
             key=key,
         )
-
-        coords = output.structure_outputs.sample_atom_coords
-        pae = output.pae
-        plddt = output.plddt
-        if PSSM is None:
-            PSSM = jnp.zeros((0, 20))
-        iptm = -IPTMLoss()(PSSM, output, key=jax.random.key(0))[0]
-        return coords, pae, plddt, iptm
-
-
+        return boltz1_forward_from_trunk(
+            self.model, features, trunk_outputs,
+            num_sampling_steps=sampling_steps if sampling_steps is not None else 25,
+            deterministic=True,
+            key=key,
+        )
 
     def predict(
         self,
@@ -146,26 +122,20 @@ sequences:"""
         sampling_steps=None,
         key,
     ) -> StructurePrediction:
-        if PSSM is not None:
-            features = set_binder_sequence(PSSM, features)
-
-        coords, pae, plddt, iptm = self._coords_and_confidences(
+        output = self.model_output(
             PSSM=PSSM,
             features=features,
             recycling_steps=recycling_steps,
             sampling_steps=sampling_steps,
             key=key,
         )
-
-        st = gemmi.read_structure(
-            str(writer(np.array(coords)))
-        )
-
+        seq = PSSM if PSSM is not None else jnp.zeros((0, 20))
+        iptm = -IPTMLoss()(seq, output, key=jax.random.key(0))[0]
         return StructurePrediction(
-            st=st,
-            plddt=plddt,
-            pae=pae,
-            iptm=iptm
+            st=writer(output.structure_coordinates),
+            plddt=output.plddt,
+            pae=output.pae,
+            iptm=iptm,
         )
 
 

--- a/src/mosaic/models/boltz2.py
+++ b/src/mosaic/models/boltz2.py
@@ -10,9 +10,10 @@ from mosaic.losses.boltz2 import (
     load_boltz2 as lb,
     load_features_and_structure_writer,
     set_binder_sequence,
+    boltz2_trunk,
+    boltz2_forward_from_trunk,
     Boltz2Loss,
-    Boltz2Output,
-    MultiSampleBoltz2Loss
+    MultiSampleBoltz2Loss,
 )
 
 from pathlib import Path
@@ -162,6 +163,7 @@ class Boltz2(StructurePredictionModel):
         )
 
 
+    @eqx.filter_jit
     def model_output(
         self,
         *,
@@ -174,40 +176,18 @@ class Boltz2(StructurePredictionModel):
         if PSSM is not None:
             features = set_binder_sequence(PSSM, features)
 
-        return Boltz2Output(
-            joltz2=self.model,
-            features=features,
+        initial_embedding, trunk_state = boltz2_trunk(
+            self.model, features,
             recycling_steps=recycling_steps,
-            num_sampling_steps=sampling_steps if sampling_steps is not None else 25,
-            key=key,
             deterministic=True,
-        )
-
-    @eqx.filter_jit
-    def _coords_and_confidences(
-        self,
-        *,
-        PSSM: None | Float[Array, "N 20"] = None,
-        features: PyTree,
-        recycling_steps=1,
-        sampling_steps=None,
-        key,
-    ):
-        output = self.model_output(
-            PSSM=PSSM,
-            features=features,
-            recycling_steps=recycling_steps,
-            sampling_steps=sampling_steps,
             key=key,
         )
-
-        coords = output.structure_coordinates
-        pae = output.pae
-        plddt = output.plddt
-        if PSSM is None:
-            PSSM = jnp.zeros((0, 20))
-        iptm = -IPTMLoss()(PSSM, output, key=jax.random.key(0))[0]
-        return coords, pae, plddt, iptm
+        return boltz2_forward_from_trunk(
+            self.model, features, initial_embedding, trunk_state,
+            num_sampling_steps=sampling_steps if sampling_steps is not None else 25,
+            deterministic=True,
+            key=key,
+        )
 
     def predict(
         self,
@@ -219,12 +199,13 @@ class Boltz2(StructurePredictionModel):
         sampling_steps=None,
         key,
     ):
-        coords, pae, plddt, iptm = self._coords_and_confidences(
+        output = self.model_output(
             PSSM=PSSM,
             features=features,
             recycling_steps=recycling_steps,
             sampling_steps=sampling_steps,
             key=key,
         )
-
-        return StructurePrediction(st=writer(coords), plddt=plddt, pae=pae, iptm=iptm)
+        seq = PSSM if PSSM is not None else jnp.zeros((0, 20))
+        iptm = -IPTMLoss()(seq, output, key=jax.random.key(0))[0]
+        return StructurePrediction(st=writer(output.structure_coordinates), plddt=output.plddt, pae=output.pae, iptm=iptm)

--- a/src/mosaic/models/boltzgen.py
+++ b/src/mosaic/models/boltzgen.py
@@ -34,7 +34,6 @@ from boltzgen.task.predict.data_from_yaml import DataConfig, FromYamlDataModule
 from boltzgen.task.predict.writer import DesignWriter
 from jaxtyping import Array, Float, PyTree
 
-from mosaic.losses.structure_prediction import AbstractStructureOutput
 from ..util import pairwise_distance
 
 
@@ -465,8 +464,7 @@ class CoordsToToken(eqx.Module):
     def __call__(self, coords: Float[Array, "... 3"]):
         return _coords_to_restype(coords, des_idx=self.des_idx)
 
-@dataclass
-class BoltzGenOutput(AbstractStructureOutput):
+class BoltzGenOutput(eqx.Module):
     sample: jax.Array
     features: PyTree
     coords2token: CoordsToToken
@@ -495,9 +493,5 @@ class BoltzGenOutput(AbstractStructureOutput):
     @property
     def structure_coordinates(self):
         return self.sample
-
-    @property
-    def ptm(self):
-        raise NotImplementedError
 
 

--- a/src/mosaic/models/of3.py
+++ b/src/mosaic/models/of3.py
@@ -47,7 +47,7 @@ from jopenfold3.batch import Batch
 from jopenfold3.model import OpenFold3
 from mosaic.losses.of3 import (
     MultiSampleOF3Loss,
-    OF3FromTrunkOutput,
+    of3_forward_from_trunk,
     set_binder_sequence,
 )
 
@@ -593,19 +593,17 @@ class OF3(StructurePredictionModel):
         )
 
 
-    def model_output(self, *, PSSM = None, features, recycling_steps = 1, sampling_steps = None, key):
+    @eqx.filter_jit
+    def model_output(self, *, PSSM=None, features, recycling_steps=1, sampling_steps=None, key):
         if sampling_steps is None:
             sampling_steps = self.default_sampling_steps
-        if PSSM is not None:
-            batch = set_binder_sequence(PSSM, features)
-        else:
-            batch = features
+        batch = set_binder_sequence(PSSM, features) if PSSM is not None else features
         init_emb, trunk_emb = self.model.run_trunk(
             batch,
             recycling_steps + 1,
             key=key,
         )
-        return OF3FromTrunkOutput(
+        return of3_forward_from_trunk(
             model=self.model,
             batch=batch,
             init_emb=init_emb,
@@ -613,29 +611,6 @@ class OF3(StructurePredictionModel):
             sampling_steps=sampling_steps,
             key=key,
         )
-
-    @eqx.filter_jit
-    def _coords_and_confidences(
-        self,
-        *,
-        PSSM: Float[Array, "N 20"] | None = None,
-        features: Batch,
-        recycling_steps: int = 3,
-        sampling_steps: int | None = None,
-        key,
-    ):
-        
-        output = self.model_output(
-            PSSM=PSSM,
-            features=features,
-            recycling_steps=recycling_steps,
-            sampling_steps=sampling_steps,
-            key=key,
-        )
-        coords = output.structure_coordinates[0, 0]
-        seq = PSSM if PSSM is not None else jnp.zeros((0, 20))
-        iptm = -IPTMLoss()(seq, output, key=jax.random.key(0))[0]
-        return (coords, output.plddt, output.pae, iptm)
 
     def predict(
         self,
@@ -647,21 +622,19 @@ class OF3(StructurePredictionModel):
         sampling_steps: int | None = None,
         key,
     ) -> StructurePrediction:
-
-        coords, plddt, pae, iptm = jax.tree.map(
-            np.array,
-            self._coords_and_confidences(
-                PSSM=PSSM,
-                features=features,
-                recycling_steps=recycling_steps,
-                sampling_steps=sampling_steps,
-                key=key,
-            ),
+        output = self.model_output(
+            PSSM=PSSM,
+            features=features,
+            recycling_steps=recycling_steps,
+            sampling_steps=sampling_steps,
+            key=key,
         )
-
+        output = jax.tree.map(np.array, output)
+        seq = PSSM if PSSM is not None else jnp.zeros((0, 20))
+        iptm = -IPTMLoss()(seq, output, key=jax.random.key(0))[0]
         return StructurePrediction(
-            st=_biotite_array_to_gemmi_struct(writer, coords),
-            plddt=plddt,
-            pae=pae,
+            st=_biotite_array_to_gemmi_struct(writer, output.structure_coordinates[0, 0]),
+            plddt=output.plddt,
+            pae=output.pae,
             iptm=iptm,
         )

--- a/src/mosaic/models/protenix.py
+++ b/src/mosaic/models/protenix.py
@@ -12,9 +12,9 @@ from protenix.data.template import ChainInput, featurize
 
 from mosaic.losses.protenix import (
     MultiSampleProtenixLoss,
-    ProtenixFromTrunkOutput,
     biotite_array_to_gemmi_struct,
     get_trunk_state,
+    protenix_forward_from_trunk,
     set_binder_sequence,
 )
 from mosaic.losses.structure_prediction import IPTMLoss
@@ -104,6 +104,7 @@ class Protenix(StructurePredictionModel):
             initial_recycling_state=initial_recycling_state,
         )
 
+    @eqx.filter_jit
     def model_output(
         self,
         *,
@@ -126,40 +127,14 @@ class Protenix(StructurePredictionModel):
             key=key,
         )
 
-        return ProtenixFromTrunkOutput(
+        return protenix_forward_from_trunk(
             model=self.protenix,
             features=features,
-            sampling_steps=sampling_steps,
             initial_embedding=initial_embedding,
             trunk_state=trunk_state,
-            key=key,
-        )
-
-    @eqx.filter_jit
-    def _coords_and_confidences(
-        self,
-        *,
-        PSSM: None | Float[Array, "N 20"] = None,
-        features: PyTree,
-        recycling_steps=1,
-        sampling_steps=None,
-        initial_recycling_state=None,
-        key,
-    ):
-        if sampling_steps is None:
-            sampling_steps = self.default_sample_steps
-        output = self.model_output(
-            PSSM=PSSM,
-            features=features,
-            recycling_steps=recycling_steps,
             sampling_steps=sampling_steps,
-            initial_recycling_state=initial_recycling_state,
             key=key,
         )
-        if PSSM is None:
-            PSSM = jnp.zeros((0, 20))
-        iptm = -IPTMLoss()(PSSM, output, key=jax.random.key(0))[0]
-        return (output.structure_coordinates[0], output.pae, output.plddt, iptm)
 
     def predict(
         self,
@@ -172,9 +147,7 @@ class Protenix(StructurePredictionModel):
         initial_recycling_state=None,
         key,
     ):
-        if sampling_steps is None:
-            sampling_steps = self.default_sample_steps
-        (coords, pae, plddt, iptm) = self._coords_and_confidences(
+        output = self.model_output(
             PSSM=PSSM,
             features=features,
             recycling_steps=recycling_steps,
@@ -182,10 +155,12 @@ class Protenix(StructurePredictionModel):
             initial_recycling_state=initial_recycling_state,
             key=key,
         )
+        seq = PSSM if PSSM is not None else jnp.zeros((0, 20))
+        iptm = -IPTMLoss()(seq, output, key=jax.random.key(0))[0]
         return StructurePrediction(
-            st=biotite_array_to_gemmi_struct(writer, np.array(coords)),
-            plddt=plddt,
-            pae=pae,
+            st=biotite_array_to_gemmi_struct(writer, np.array(output.structure_coordinates[0])),
+            plddt=output.plddt,
+            pae=output.pae,
             iptm=iptm,
         )
 

--- a/src/mosaic/structure_prediction.py
+++ b/src/mosaic/structure_prediction.py
@@ -12,7 +12,7 @@ from jaxtyping import Array, Float, PyTree
 
 from abc import abstractmethod
 
-from mosaic.losses.structure_prediction import AbstractStructureOutput
+from mosaic.losses.structure_prediction import StructureModelOutput
 from mosaic.common import LossTerm, LinearCombination
 
 class PolymerType:
@@ -84,7 +84,7 @@ class StructurePredictionModel(eqx.Module):
         features: PyTree,
         recycling_steps: int = 1,
         sampling_steps: int | None = None,
-        key) -> AbstractStructureOutput:
+        key) -> StructureModelOutput:
         pass
 
 


### PR DESCRIPTION
Tracking trunk/structure/confidence module dependent losses was getting annoying; mostly because model outputs couldn't be easily returned by JIT'd functions. It looks like XLA's DCE pass is now good enough we don't have to do this