### PR TITLE
Ablang2 loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ wheels/
 
 # Virtual environments
 .venv
+
+.envrc
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,11 @@ dependencies = [
 ]
 
 [dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "ruff>=0.15.12",
+    "ty>=0.0.33",
+]
 jax-cpu = [
   "jax[cpu]",
 ]
@@ -76,6 +81,10 @@ jopenfold3 = { git = "https://github.com/escalante-bio/jopenfold3.git" }
 jproteina-complexa = { git = "https://github.com/escalante-bio/jproteina-complexa.git" }
 boltz = { git = "https://github.com/escalante-bio/boltz.git" }
 boltzgen = { git = "https://github.com/escalante-bio/boltzgen.git" }
+
+[tool.pytest.ini_options]
+markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
+addopts = "-m 'not slow'"
 
 [tool.uv]
 required-environments = ["sys_platform == 'linux' and platform_machine == 'x86_64'"]

--- a/src/mosaic/losses/ablang2.py
+++ b/src/mosaic/losses/ablang2.py
@@ -1,0 +1,127 @@
+from functools import lru_cache
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from mosaic.common import LossTerm, TOKENS
+
+
+def _boltz_to_ablang2_matrix(tokenizer):
+    T = np.zeros((len(TOKENS), len(tokenizer.aa_to_token)))
+    for i, tok in enumerate(TOKENS):
+        idx = tokenizer.aa_to_token[tok]
+        T[i, idx] = 1
+    return T
+
+
+def _load_ablang2():
+    from ablang2.load_model import load_model
+    from jablang import from_torch
+
+    model_pt, tokenizer, _hparams = load_model("ablang2-paired")
+    model_pt.eval()
+    return from_torch(model_pt), tokenizer
+
+
+@lru_cache(maxsize=1)
+def _cached_ablang2_model():
+    return _load_ablang2()
+
+
+class Ablang2PseudoLikelihood(LossTerm):
+    """Pseudo-likelihood loss using the AbLang2 paired model.
+    Formats the concatenated binder sequence as ``<H>|<L>`` (or ``<H>|`` /
+    ``|<L>`` for single-chain) to match ablang2's input convention, and masks
+    special-token logits before log-softmax.
+    """
+
+    model: Any
+    tokenizer: Any
+    chain_slices: tuple[tuple[str, int, int], ...]  # (part_id, start, stop); part_id must be "H" or "L"
+    designable_positions: jax.Array | None
+    token_mapping: jax.Array
+    special_mask: jax.Array
+    mask_onehot: jax.Array
+    vocab_size: int
+    stop_grad: bool = True
+    aux_name: str = "ablang2_ppl"
+
+    def __init__(
+        self,
+        model,
+        tokenizer,
+        chain_slices,
+        designable_positions=None,
+        stop_grad=True,
+        aux_name="ablang2_ppl",
+    ):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.chain_slices = chain_slices
+        self.designable_positions = designable_positions
+        self.stop_grad = stop_grad
+        self.aux_name = aux_name
+        self.token_mapping = jnp.array(_boltz_to_ablang2_matrix(tokenizer))
+        self.vocab_size = len(tokenizer.aa_to_token)
+        special_indices = jnp.array(tokenizer.all_special_tokens, dtype=jnp.int32)
+        self.special_mask = jnp.zeros(self.vocab_size, dtype=bool).at[special_indices].set(True)
+        self.mask_onehot = jax.nn.one_hot(tokenizer.aa_to_token["*"], self.vocab_size)
+
+    def __call__(self, seq_standard_tokens, *, key):
+        del key
+        n = seq_standard_tokens.shape[0]
+        designable_positions = (
+            self.designable_positions if self.designable_positions is not None
+            else jnp.arange(n, dtype=jnp.int32)
+        )
+
+        ablang2_toks = seq_standard_tokens @ self.token_mapping
+        at = self.tokenizer.aa_to_token
+
+        def special(token):
+            return jax.nn.one_hot(jnp.array([at[token]]), self.vocab_size)
+
+        chain_bounds = {cid: (start, stop) for cid, start, stop in self.chain_slices}
+        parts: list[jax.Array] = []
+        sequence_token_indices = jnp.full(n, -1, dtype=jnp.int32)
+        offset = 0
+
+        for part_id in ("H", "|", "L"):
+            if part_id == "|":
+                parts.append(special("|"))
+                offset += 1
+            elif part_id in chain_bounds:
+                start, stop = chain_bounds[part_id]
+                parts.append(special("<"))
+                offset += 1
+                parts.append(ablang2_toks[start:stop])
+                sequence_token_indices = sequence_token_indices.at[start:stop].set(
+                    jnp.arange(offset, offset + stop - start, dtype=jnp.int32)
+                )
+                offset += stop - start
+                parts.append(special(">"))
+                offset += 1
+
+        toks = jnp.concatenate(parts)
+        residue_indices = sequence_token_indices[designable_positions]
+        designable_toks = ablang2_toks[designable_positions]
+        num_designable = designable_positions.shape[0]
+
+        def single_ll(token_index):
+            masked_tokens = toks.at[token_index].set(self.mask_onehot)
+            x = masked_tokens @ self.model.rep.aa_embed_layer.weight
+            x = self.model.rep.encoder_blocks(x[None])
+            x = self.model.rep.layer_norm(x)
+            logits = self.model.head(x)[0]
+            logits = jnp.where(self.special_mask, -1e9, logits[token_index])
+            return jax.nn.log_softmax(logits)
+
+        masked_log_likelihoods = jax.vmap(single_ll)(residue_indices)
+        if self.stop_grad:
+            masked_log_likelihoods = jax.lax.stop_gradient(masked_log_likelihoods)
+        per_position_pll = (masked_log_likelihoods * designable_toks).sum(-1)
+        pll = jnp.sum(per_position_pll) / jnp.maximum(
+            jnp.array(num_designable, dtype=per_position_pll.dtype), 1.0
+        )
+        return -pll, {self.aux_name: jnp.exp(-pll)}

--- a/src/mosaic/losses/ablang2.py
+++ b/src/mosaic/losses/ablang2.py
@@ -31,14 +31,19 @@ def _cached_ablang2_model():
 
 class Ablang2PseudoLikelihood(LossTerm):
     """Pseudo-likelihood loss using the AbLang2 paired model.
+
     Formats the concatenated binder sequence as ``<H>|<L>`` (or ``<H>|`` /
     ``|<L>`` for single-chain) to match ablang2's input convention, and masks
     special-token logits before log-softmax.
+
+    ``heavy_len`` specifies how many leading residues belong to the heavy chain;
+    the remainder are the light chain.  Use ``heavy_len=len(seq)`` for heavy-only
+    and ``heavy_len=0`` for light-only.
     """
 
     model: Any
     tokenizer: Any
-    chain_slices: tuple[tuple[str, int, int], ...]  # (part_id, start, stop); part_id must be "H" or "L"
+    heavy_len: int
     designable_positions: jax.Array | None
     token_mapping: jax.Array
     special_mask: jax.Array
@@ -51,14 +56,14 @@ class Ablang2PseudoLikelihood(LossTerm):
         self,
         model,
         tokenizer,
-        chain_slices,
+        heavy_len,
         designable_positions=None,
         stop_grad=True,
         aux_name="ablang2_ppl",
     ):
         self.model = model
         self.tokenizer = tokenizer
-        self.chain_slices = chain_slices
+        self.heavy_len = heavy_len
         self.designable_positions = designable_positions
         self.stop_grad = stop_grad
         self.aux_name = aux_name
@@ -82,26 +87,25 @@ class Ablang2PseudoLikelihood(LossTerm):
         def special(token):
             return jax.nn.one_hot(jnp.array([at[token]]), self.vocab_size)
 
-        chain_bounds = {cid: (start, stop) for cid, start, stop in self.chain_slices}
         parts: list[jax.Array] = []
         sequence_token_indices = jnp.full(n, -1, dtype=jnp.int32)
         offset = 0
 
-        for part_id in ("H", "|", "L"):
-            if part_id == "|":
-                parts.append(special("|"))
-                offset += 1
-            elif part_id in chain_bounds:
-                start, stop = chain_bounds[part_id]
-                parts.append(special("<"))
-                offset += 1
-                parts.append(ablang2_toks[start:stop])
-                sequence_token_indices = sequence_token_indices.at[start:stop].set(
-                    jnp.arange(offset, offset + stop - start, dtype=jnp.int32)
-                )
-                offset += stop - start
-                parts.append(special(">"))
-                offset += 1
+        if self.heavy_len > 0:
+            parts += [special("<"), ablang2_toks[:self.heavy_len], special(">")]
+            sequence_token_indices = sequence_token_indices.at[:self.heavy_len].set(
+                jnp.arange(offset + 1, offset + 1 + self.heavy_len, dtype=jnp.int32)
+            )
+            offset += self.heavy_len + 2
+
+        parts.append(special("|"))
+        offset += 1
+
+        if self.heavy_len < n:
+            parts += [special("<"), ablang2_toks[self.heavy_len:], special(">")]
+            sequence_token_indices = sequence_token_indices.at[self.heavy_len:].set(
+                jnp.arange(offset + 1, offset + 1 + n - self.heavy_len, dtype=jnp.int32)
+            )
 
         toks = jnp.concatenate(parts)
         residue_indices = sequence_token_indices[designable_positions]

--- a/src/mosaic/losses/ablang2.py
+++ b/src/mosaic/losses/ablang2.py
@@ -1,13 +1,14 @@
-from functools import lru_cache
 from typing import Any
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 from mosaic.common import LossTerm, TOKENS
+from ablang2.load_model import load_model
+from jablang import from_torch
 
 
-def _boltz_to_ablang2_matrix(tokenizer):
+def boltz_to_ablang2_matrix(tokenizer):
     T = np.zeros((len(TOKENS), len(tokenizer.aa_to_token)))
     for i, tok in enumerate(TOKENS):
         idx = tokenizer.aa_to_token[tok]
@@ -15,18 +16,10 @@ def _boltz_to_ablang2_matrix(tokenizer):
     return T
 
 
-def _load_ablang2():
-    from ablang2.load_model import load_model
-    from jablang import from_torch
-
+def load_ablang2():
     model_pt, tokenizer, _hparams = load_model("ablang2-paired")
     model_pt.eval()
     return from_torch(model_pt), tokenizer
-
-
-@lru_cache(maxsize=1)
-def _cached_ablang2_model():
-    return _load_ablang2()
 
 
 class Ablang2PseudoLikelihood(LossTerm):
@@ -67,17 +60,20 @@ class Ablang2PseudoLikelihood(LossTerm):
         self.designable_positions = designable_positions
         self.stop_grad = stop_grad
         self.aux_name = aux_name
-        self.token_mapping = jnp.array(_boltz_to_ablang2_matrix(tokenizer))
+        self.token_mapping = jnp.array(boltz_to_ablang2_matrix(tokenizer))
         self.vocab_size = len(tokenizer.aa_to_token)
         special_indices = jnp.array(tokenizer.all_special_tokens, dtype=jnp.int32)
-        self.special_mask = jnp.zeros(self.vocab_size, dtype=bool).at[special_indices].set(True)
+        self.special_mask = (
+            jnp.zeros(self.vocab_size, dtype=bool).at[special_indices].set(True)
+        )
         self.mask_onehot = jax.nn.one_hot(tokenizer.aa_to_token["*"], self.vocab_size)
 
     def __call__(self, seq_standard_tokens, *, key):
         del key
         n = seq_standard_tokens.shape[0]
         designable_positions = (
-            self.designable_positions if self.designable_positions is not None
+            self.designable_positions
+            if self.designable_positions is not None
             else jnp.arange(n, dtype=jnp.int32)
         )
 
@@ -92,8 +88,8 @@ class Ablang2PseudoLikelihood(LossTerm):
         offset = 0
 
         if self.heavy_len > 0:
-            parts += [special("<"), ablang2_toks[:self.heavy_len], special(">")]
-            sequence_token_indices = sequence_token_indices.at[:self.heavy_len].set(
+            parts += [special("<"), ablang2_toks[: self.heavy_len], special(">")]
+            sequence_token_indices = sequence_token_indices.at[: self.heavy_len].set(
                 jnp.arange(offset + 1, offset + 1 + self.heavy_len, dtype=jnp.int32)
             )
             offset += self.heavy_len + 2
@@ -102,8 +98,8 @@ class Ablang2PseudoLikelihood(LossTerm):
         offset += 1
 
         if self.heavy_len < n:
-            parts += [special("<"), ablang2_toks[self.heavy_len:], special(">")]
-            sequence_token_indices = sequence_token_indices.at[self.heavy_len:].set(
+            parts += [special("<"), ablang2_toks[self.heavy_len :], special(">")]
+            sequence_token_indices = sequence_token_indices.at[self.heavy_len :].set(
                 jnp.arange(offset + 1, offset + 1 + n - self.heavy_len, dtype=jnp.int32)
             )
 

--- a/tests/test_ablang2_loss.py
+++ b/tests/test_ablang2_loss.py
@@ -1,0 +1,186 @@
+import numpy as np
+import torch
+import jax
+import jax.numpy as jnp
+from mosaic.losses import ablang2 as ablang2_loss_mod
+import ablang2
+import mosaic.optimizers as optimizers_module
+from mosaic.common import TOKENS
+
+import pytest
+
+TORCH_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def _default_jax_device():
+    try:
+        return jax.devices("gpu")[0]
+    except RuntimeError:
+        return jax.devices("cpu")[0]
+
+
+@pytest.fixture(autouse=True)
+def _use_gpu():
+    with jax.default_device(_default_jax_device()):
+        yield
+
+
+@pytest.mark.slow
+def test_ablang2_designable_pseudo_likelihood_matches_direct_computation():
+    """Check that Ablang2PseudoLikelihood PPL matches ablang2's
+    ``pretrained(mode='pseudo_log_likelihood')`` on a single heavy chain."""
+    heavy = (
+        "EVQLLESGGEVKKPGASVKVSCRASGYTFRNYGLTWVRQAPGQGLEWMGWISAYNGNTNYAQKFQG"
+        "RVTLTTDTSTSTAYMELRSLRSDDTAVYFCARDVPGHGAAFMDVWGTGTTVTVSS"
+    )
+    n = len(heavy)
+
+    ab2 = ablang2.pretrained("ablang2-paired", device=TORCH_DEVICE)
+    ref_pll = ab2([[heavy, ""]], mode="pseudo_log_likelihood")
+    expected_ppl = float(np.exp(-ref_pll[0]))
+
+    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    seq_standard_tokens = jax.nn.one_hot(
+        jnp.array([TOKENS.index(aa) for aa in heavy], dtype=jnp.int32),
+        len(TOKENS),
+    )
+    loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
+        model=model,
+        tokenizer=tok,
+        chain_slices=(("H", 0, n),),
+        stop_grad=True,
+    )
+    (loss_value, aux), grad = optimizers_module._eval_loss_and_grad(
+        loss_term, seq_standard_tokens, jax.random.key(0)
+    )
+
+    assert float(aux["ablang2_ppl"]) == pytest.approx(expected_ppl, rel=1e-3)
+    assert float(loss_value) == pytest.approx(float(-ref_pll[0]), rel=1e-3)
+    assert grad.shape == seq_standard_tokens.shape
+    assert np.all(np.isfinite(grad))
+    assert np.any(grad != 0)
+
+
+@pytest.mark.slow
+def test_ablang2_designable_pseudo_likelihood_light_only_matches_ablang2():
+    """Check that Ablang2PseudoLikelihood PPL matches ablang2's
+    ``pretrained(mode='pseudo_log_likelihood')`` on a single light chain."""
+    light = (
+        "DIQLTQSPLSLPVTLGQPASISCRSSQSLEASDTNIYLSWFQQRPGQSPRRLIYKISNRDSGVPD"
+        "RFSGSGSGTHFTLRISRVEADDVAVYYCMQGTHWPPAFGQGTKVDIK"
+    )
+    n = len(light)
+
+    ab2 = ablang2.pretrained("ablang2-paired", device=TORCH_DEVICE)
+    ref_pll = ab2([["", light]], mode="pseudo_log_likelihood")
+    expected_ppl = float(np.exp(-ref_pll[0]))
+
+    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    seq_standard_tokens = jax.nn.one_hot(
+        jnp.array([TOKENS.index(aa) for aa in light], dtype=jnp.int32),
+        len(TOKENS),
+    )
+    loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
+        model=model,
+        tokenizer=tok,
+        chain_slices=(("L", 0, n),),
+        stop_grad=True,
+    )
+    (loss_value, aux), grad = optimizers_module._eval_loss_and_grad(
+        loss_term, seq_standard_tokens, jax.random.key(0)
+    )
+
+    assert float(aux["ablang2_ppl"]) == pytest.approx(expected_ppl, rel=1e-3)
+    assert float(loss_value) == pytest.approx(float(-ref_pll[0]), rel=1e-3)
+    assert grad.shape == seq_standard_tokens.shape
+
+
+@pytest.mark.slow
+def test_ablang2_designable_pseudo_likelihood_paired_matches_ablang2():
+    """Check that Ablang2PseudoLikelihood PPL matches ablang2's
+    ``pretrained(mode='pseudo_log_likelihood')`` on a paired heavy+light input."""
+    heavy = (
+        "EVQLLESGGEVKKPGASVKVSCRASGYTFRNYGLTWVRQAPGQGLEWMGWISAYNGNTNYAQKFQG"
+        "RVTLTTDTSTSTAYMELRSLRSDDTAVYFCARDVPGHGAAFMDVWGTGTTVTVSS"
+    )
+    light = (
+        "DIQLTQSPLSLPVTLGQPASISCRSSQSLEASDTNIYLSWFQQRPGQSPRRLIYKISNRDSGVPD"
+        "RFSGSGSGTHFTLRISRVEADDVAVYYCMQGTHWPPAFGQGTKVDIK"
+    )
+    full_seq = heavy + light
+    n = len(full_seq)
+    n_h = len(heavy)
+
+    ab2 = ablang2.pretrained("ablang2-paired", device=TORCH_DEVICE)
+    ref_pll = ab2([[heavy, light]], mode="pseudo_log_likelihood")
+    expected_ppl = float(np.exp(-ref_pll[0]))
+
+    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    seq_standard_tokens = jax.nn.one_hot(
+        jnp.array([TOKENS.index(aa) for aa in full_seq], dtype=jnp.int32),
+        len(TOKENS),
+    )
+    loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
+        model=model,
+        tokenizer=tok,
+        chain_slices=(("H", 0, n_h), ("L", n_h, n)),
+        stop_grad=True,
+    )
+    (loss_value, aux), grad = optimizers_module._eval_loss_and_grad(
+        loss_term, seq_standard_tokens, jax.random.key(0)
+    )
+
+    assert float(aux["ablang2_ppl"]) == pytest.approx(expected_ppl, rel=1e-3)
+    assert float(loss_value) == pytest.approx(float(-ref_pll[0]), rel=1e-3)
+    assert grad.shape == seq_standard_tokens.shape
+
+
+@pytest.mark.slow
+def test_ablang2_designable_pseudo_likelihood_matches_per_residue_aggregation():
+    """Verify that scoring a subset of designable positions matches
+    aggregating ablang2's per-residue PLLs over that subset."""
+
+    heavy = (
+        "EVQLLESGGEVKKPGASVKVSCRASGYTFRNYGLTWVRQAPGQGLEWMGWISAYNGNTNYAQKFQG"
+        "RVTLTTDTSTSTAYMELRSLRSDDTAVYFCARDVPGHGAAFMDVWGTGTTVTVSS"
+    )
+    n = len(heavy)
+    designable = [1, 3, 10, 50]
+
+    ab2 = ablang2.pretrained("ablang2-paired", device=TORCH_DEVICE)
+    labels = ab2.tokenizer(
+        [[heavy, ""]], pad=True, w_extra_tkns=True, device=ab2.used_device
+    )
+    idxs = (
+        ~torch.isin(labels, torch.tensor(ab2.tokenizer.all_special_tokens))
+    ).nonzero()
+    masked_tokens = labels.repeat(len(idxs), 1)
+    for num, idx in enumerate(idxs):
+        masked_tokens[num, idx[1]] = ab2.tokenizer.mask_token
+    with torch.no_grad():
+        logits = ab2.AbLang(masked_tokens)
+    logits[:, :, ab2.tokenizer.all_special_tokens] = -float("inf")
+    logits = torch.stack([logits[num, idx[1]] for num, idx in enumerate(idxs)])
+    labels_flat = labels[:, idxs[:, 1:]].squeeze(2)[0]
+    per_residue_nll = torch.nn.functional.cross_entropy(
+        logits, labels_flat, reduction="none"
+    )
+    expected_loss = float(per_residue_nll[designable].mean())
+
+    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    seq_standard_tokens = jax.nn.one_hot(
+        jnp.array([TOKENS.index(aa) for aa in heavy], dtype=jnp.int32),
+        len(TOKENS),
+    )
+    loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
+        model=model,
+        tokenizer=tok,
+        chain_slices=(("H", 0, n),),
+        designable_positions=jnp.array(designable, dtype=jnp.int32),
+        stop_grad=True,
+    )
+    (loss_value, _), _ = optimizers_module._eval_loss_and_grad(
+        loss_term, seq_standard_tokens, jax.random.key(0)
+    )
+
+    assert float(loss_value) == pytest.approx(expected_loss, rel=1e-3)

--- a/tests/test_ablang2_loss.py
+++ b/tests/test_ablang2_loss.py
@@ -48,7 +48,7 @@ def test_ablang2_designable_pseudo_likelihood_matches_direct_computation():
     loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
-        chain_slices=(("H", 0, n),),
+        heavy_len=n,
         stop_grad=True,
     )
     (loss_value, aux), grad = optimizers_module._eval_loss_and_grad(
@@ -84,7 +84,7 @@ def test_ablang2_designable_pseudo_likelihood_light_only_matches_ablang2():
     loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
-        chain_slices=(("L", 0, n),),
+        heavy_len=0,
         stop_grad=True,
     )
     (loss_value, aux), grad = optimizers_module._eval_loss_and_grad(
@@ -124,7 +124,7 @@ def test_ablang2_designable_pseudo_likelihood_paired_matches_ablang2():
     loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
-        chain_slices=(("H", 0, n_h), ("L", n_h, n)),
+        heavy_len=n_h,
         stop_grad=True,
     )
     (loss_value, aux), grad = optimizers_module._eval_loss_and_grad(
@@ -176,7 +176,7 @@ def test_ablang2_designable_pseudo_likelihood_matches_per_residue_aggregation():
     loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
-        chain_slices=(("H", 0, n),),
+        heavy_len=n,
         designable_positions=jnp.array(designable, dtype=jnp.int32),
         stop_grad=True,
     )
@@ -228,7 +228,7 @@ def test_setpositions_vs_designable_positions_gradients():
     loss_with_dp = ablang2_loss_mod.Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
-        chain_slices=(("H", 0, n),),
+        heavy_len=n,
         designable_positions=variable_positions,
         stop_grad=True,
     )
@@ -251,7 +251,7 @@ def test_setpositions_vs_designable_positions_gradients():
     loss_no_dp = ablang2_loss_mod.Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
-        chain_slices=(("H", 0, n),),
+        heavy_len=n,
         stop_grad=True,
     )
     set_pos_loss = SetPositions(wildtype_tokens, variable_positions, loss_no_dp)
@@ -304,7 +304,7 @@ def test_setpositions_combined_with_designable_positions():
     loss_dp = ablang2_loss_mod.Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
-        chain_slices=(("H", 0, n),),
+        heavy_len=n,
         designable_positions=variable_positions,
         stop_grad=True,
     )
@@ -323,7 +323,7 @@ def test_setpositions_combined_with_designable_positions():
         ablang2_loss_mod.Ablang2PseudoLikelihood(
             model=model,
             tokenizer=tok,
-            chain_slices=(("H", 0, n),),
+            heavy_len=n,
             designable_positions=variable_positions,
             stop_grad=True,
         ),

--- a/tests/test_ablang2_loss.py
+++ b/tests/test_ablang2_loss.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 import jax
 import jax.numpy as jnp
-from mosaic.losses import ablang2 as ablang2_loss_mod
+from mosaic.losses.ablang2 import load_ablang2, Ablang2PseudoLikelihood
 from mosaic.losses.transformations import SetPositions
 import ablang2
 import mosaic.optimizers as optimizers_module
@@ -26,8 +26,21 @@ def _use_gpu():
         yield
 
 
+@pytest.fixture
+def ablang2_jax():
+    model, tok = load_ablang2()
+    return model, tok
+
+
+@pytest.fixture
+def ablang2_torch():
+    return ablang2.pretrained("ablang2-paired", device=TORCH_DEVICE)
+
+
 @pytest.mark.slow
-def test_ablang2_designable_pseudo_likelihood_matches_direct_computation():
+def test_ablang2_designable_pseudo_likelihood_matches_direct_computation(
+    ablang2_jax, ablang2_torch
+):
     """Check that Ablang2PseudoLikelihood PPL matches ablang2's
     ``pretrained(mode='pseudo_log_likelihood')`` on a single heavy chain."""
     heavy = (
@@ -36,16 +49,15 @@ def test_ablang2_designable_pseudo_likelihood_matches_direct_computation():
     )
     n = len(heavy)
 
-    ab2 = ablang2.pretrained("ablang2-paired", device=TORCH_DEVICE)
-    ref_pll = ab2([[heavy, ""]], mode="pseudo_log_likelihood")
+    ref_pll = ablang2_torch([[heavy, ""]], mode="pseudo_log_likelihood")
     expected_ppl = float(np.exp(-ref_pll[0]))
 
-    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    model, tok = ablang2_jax
     seq_standard_tokens = jax.nn.one_hot(
         jnp.array([TOKENS.index(aa) for aa in heavy], dtype=jnp.int32),
         len(TOKENS),
     )
-    loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
+    loss_term = Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
         heavy_len=n,
@@ -63,7 +75,9 @@ def test_ablang2_designable_pseudo_likelihood_matches_direct_computation():
 
 
 @pytest.mark.slow
-def test_ablang2_designable_pseudo_likelihood_light_only_matches_ablang2():
+def test_ablang2_designable_pseudo_likelihood_light_only_matches_ablang2(
+    ablang2_jax, ablang2_torch
+):
     """Check that Ablang2PseudoLikelihood PPL matches ablang2's
     ``pretrained(mode='pseudo_log_likelihood')`` on a single light chain."""
     light = (
@@ -72,16 +86,15 @@ def test_ablang2_designable_pseudo_likelihood_light_only_matches_ablang2():
     )
     n = len(light)
 
-    ab2 = ablang2.pretrained("ablang2-paired", device=TORCH_DEVICE)
-    ref_pll = ab2([["", light]], mode="pseudo_log_likelihood")
+    ref_pll = ablang2_torch([["", light]], mode="pseudo_log_likelihood")
     expected_ppl = float(np.exp(-ref_pll[0]))
 
-    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    model, tok = ablang2_jax
     seq_standard_tokens = jax.nn.one_hot(
         jnp.array([TOKENS.index(aa) for aa in light], dtype=jnp.int32),
         len(TOKENS),
     )
-    loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
+    loss_term = Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
         heavy_len=0,
@@ -97,7 +110,9 @@ def test_ablang2_designable_pseudo_likelihood_light_only_matches_ablang2():
 
 
 @pytest.mark.slow
-def test_ablang2_designable_pseudo_likelihood_paired_matches_ablang2():
+def test_ablang2_designable_pseudo_likelihood_paired_matches_ablang2(
+    ablang2_jax, ablang2_torch
+):
     """Check that Ablang2PseudoLikelihood PPL matches ablang2's
     ``pretrained(mode='pseudo_log_likelihood')`` on a paired heavy+light input."""
     heavy = (
@@ -109,19 +124,17 @@ def test_ablang2_designable_pseudo_likelihood_paired_matches_ablang2():
         "RFSGSGSGTHFTLRISRVEADDVAVYYCMQGTHWPPAFGQGTKVDIK"
     )
     full_seq = heavy + light
-    n = len(full_seq)
     n_h = len(heavy)
 
-    ab2 = ablang2.pretrained("ablang2-paired", device=TORCH_DEVICE)
-    ref_pll = ab2([[heavy, light]], mode="pseudo_log_likelihood")
+    ref_pll = ablang2_torch([[heavy, light]], mode="pseudo_log_likelihood")
     expected_ppl = float(np.exp(-ref_pll[0]))
 
-    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    model, tok = ablang2_jax
     seq_standard_tokens = jax.nn.one_hot(
         jnp.array([TOKENS.index(aa) for aa in full_seq], dtype=jnp.int32),
         len(TOKENS),
     )
-    loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
+    loss_term = Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
         heavy_len=n_h,
@@ -137,10 +150,11 @@ def test_ablang2_designable_pseudo_likelihood_paired_matches_ablang2():
 
 
 @pytest.mark.slow
-def test_ablang2_designable_pseudo_likelihood_matches_per_residue_aggregation():
+def test_ablang2_designable_pseudo_likelihood_matches_per_residue_aggregation(
+    ablang2_jax, ablang2_torch
+):
     """Verify that scoring a subset of designable positions matches
     aggregating ablang2's per-residue PLLs over that subset."""
-
     heavy = (
         "EVQLLESGGEVKKPGASVKVSCRASGYTFRNYGLTWVRQAPGQGLEWMGWISAYNGNTNYAQKFQG"
         "RVTLTTDTSTSTAYMELRSLRSDDTAVYFCARDVPGHGAAFMDVWGTGTTVTVSS"
@@ -148,19 +162,18 @@ def test_ablang2_designable_pseudo_likelihood_matches_per_residue_aggregation():
     n = len(heavy)
     designable = [1, 3, 10, 50]
 
-    ab2 = ablang2.pretrained("ablang2-paired", device=TORCH_DEVICE)
-    labels = ab2.tokenizer(
-        [[heavy, ""]], pad=True, w_extra_tkns=True, device=ab2.used_device
+    labels = ablang2_torch.tokenizer(
+        [[heavy, ""]], pad=True, w_extra_tkns=True, device=ablang2_torch.used_device
     )
     idxs = (
-        ~torch.isin(labels, torch.tensor(ab2.tokenizer.all_special_tokens))
+        ~torch.isin(labels, torch.tensor(ablang2_torch.tokenizer.all_special_tokens))
     ).nonzero()
     masked_tokens = labels.repeat(len(idxs), 1)
     for num, idx in enumerate(idxs):
-        masked_tokens[num, idx[1]] = ab2.tokenizer.mask_token
+        masked_tokens[num, idx[1]] = ablang2_torch.tokenizer.mask_token
     with torch.no_grad():
-        logits = ab2.AbLang(masked_tokens)
-    logits[:, :, ab2.tokenizer.all_special_tokens] = -float("inf")
+        logits = ablang2_torch.AbLang(masked_tokens)
+    logits[:, :, ablang2_torch.tokenizer.all_special_tokens] = -float("inf")
     logits = torch.stack([logits[num, idx[1]] for num, idx in enumerate(idxs)])
     labels_flat = labels[:, idxs[:, 1:]].squeeze(2)[0]
     per_residue_nll = torch.nn.functional.cross_entropy(
@@ -168,12 +181,12 @@ def test_ablang2_designable_pseudo_likelihood_matches_per_residue_aggregation():
     )
     expected_loss = float(per_residue_nll[designable].mean())
 
-    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    model, tok = ablang2_jax
     seq_standard_tokens = jax.nn.one_hot(
         jnp.array([TOKENS.index(aa) for aa in heavy], dtype=jnp.int32),
         len(TOKENS),
     )
-    loss_term = ablang2_loss_mod.Ablang2PseudoLikelihood(
+    loss_term = Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
         heavy_len=n,
@@ -188,7 +201,7 @@ def test_ablang2_designable_pseudo_likelihood_matches_per_residue_aggregation():
 
 
 @pytest.mark.slow
-def test_setpositions_vs_designable_positions_gradients():
+def test_setpositions_vs_designable_positions_gradients(ablang2_jax):
     """Check gradient behaviour when using SetPositions as a wrapper vs designable_positions.
 
     With designable_positions=variable_positions the PLL is averaged over M positions,
@@ -210,22 +223,20 @@ def test_setpositions_vs_designable_positions_gradients():
     n = len(heavy)
     m = len(designable)
 
-    # Build a wildtype string with X at the designable positions
     wildtype_with_x = "".join(
         "X" if i in designable else aa for i, aa in enumerate(heavy)
     )
 
-    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    model, tok = ablang2_jax
     variable_positions = jnp.array(designable, dtype=jnp.int32)
 
-    # Full one-hot sequence (the true amino acids, used as ground truth)
     seq_full = jax.nn.one_hot(
         jnp.array([TOKENS.index(aa) for aa in heavy], dtype=jnp.int32),
         len(TOKENS),
     )
 
     # --- Approach 1: designable_positions passed explicitly ---
-    loss_with_dp = ablang2_loss_mod.Ablang2PseudoLikelihood(
+    loss_with_dp = Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
         heavy_len=n,
@@ -248,7 +259,7 @@ def test_setpositions_vs_designable_positions_gradients():
         [TOKENS.index(aa) if aa != "X" else -1 for aa in wildtype_with_x],
         dtype=jnp.int32,
     )
-    loss_no_dp = ablang2_loss_mod.Ablang2PseudoLikelihood(
+    loss_no_dp = Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
         heavy_len=n,
@@ -271,7 +282,7 @@ def test_setpositions_vs_designable_positions_gradients():
 
 
 @pytest.mark.slow
-def test_setpositions_combined_with_designable_positions():
+def test_setpositions_combined_with_designable_positions(ablang2_jax):
     """SetPositions + designable_positions together should give identical outputs to
     designable_positions alone.
 
@@ -291,7 +302,7 @@ def test_setpositions_combined_with_designable_positions():
         "X" if i in designable else aa for i, aa in enumerate(heavy)
     )
 
-    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    model, tok = ablang2_jax
     variable_positions = jnp.array(designable, dtype=jnp.int32)
 
     seq_full = jax.nn.one_hot(
@@ -301,7 +312,7 @@ def test_setpositions_combined_with_designable_positions():
     seq_variable = seq_full[variable_positions]  # (M, 20)
 
     # --- Approach 1: designable_positions, full sequence input ---
-    loss_dp = ablang2_loss_mod.Ablang2PseudoLikelihood(
+    loss_dp = Ablang2PseudoLikelihood(
         model=model,
         tokenizer=tok,
         heavy_len=n,
@@ -320,7 +331,7 @@ def test_setpositions_combined_with_designable_positions():
     loss_combined = SetPositions(
         wildtype_tokens,
         variable_positions,
-        ablang2_loss_mod.Ablang2PseudoLikelihood(
+        Ablang2PseudoLikelihood(
             model=model,
             tokenizer=tok,
             heavy_len=n,

--- a/tests/test_ablang2_loss.py
+++ b/tests/test_ablang2_loss.py
@@ -3,6 +3,7 @@ import torch
 import jax
 import jax.numpy as jnp
 from mosaic.losses import ablang2 as ablang2_loss_mod
+from mosaic.losses.transformations import SetPositions
 import ablang2
 import mosaic.optimizers as optimizers_module
 from mosaic.common import TOKENS
@@ -184,3 +185,160 @@ def test_ablang2_designable_pseudo_likelihood_matches_per_residue_aggregation():
     )
 
     assert float(loss_value) == pytest.approx(expected_loss, rel=1e-3)
+
+
+@pytest.mark.slow
+def test_setpositions_vs_designable_positions_gradients():
+    """Check gradient behaviour when using SetPositions as a wrapper vs designable_positions.
+
+    With designable_positions=variable_positions the PLL is averaged over M positions,
+    so the gradient at each variable position is proportional to 1/M.
+
+    With SetPositions wrapping and no designable_positions the PLL is averaged over all
+    N positions.  Fixed positions are constants in the computation graph so their gradient
+    w.r.t. the variable-only input is zero, but the normalization denominator is still N.
+    The gradient at variable positions is therefore proportional to 1/N.
+
+    Consequently the two approaches give the same gradient *direction* but differ in
+    magnitude by the factor M/N.  This test verifies both facts.
+    """
+    heavy = (
+        "EVQLLESGGEVKKPGASVKVSCRASGYTFRNYGLTWVRQAPGQGLEWMGWISAYNGNTNYAQKFQG"
+        "RVTLTTDTSTSTAYMELRSLRSDDTAVYFCARDVPGHGAAFMDVWGTGTTVTVSS"
+    )
+    designable = list(range(95, 103))  # 8 positions in CDR3
+    n = len(heavy)
+    m = len(designable)
+
+    # Build a wildtype string with X at the designable positions
+    wildtype_with_x = "".join(
+        "X" if i in designable else aa for i, aa in enumerate(heavy)
+    )
+
+    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    variable_positions = jnp.array(designable, dtype=jnp.int32)
+
+    # Full one-hot sequence (the true amino acids, used as ground truth)
+    seq_full = jax.nn.one_hot(
+        jnp.array([TOKENS.index(aa) for aa in heavy], dtype=jnp.int32),
+        len(TOKENS),
+    )
+
+    # --- Approach 1: designable_positions passed explicitly ---
+    loss_with_dp = ablang2_loss_mod.Ablang2PseudoLikelihood(
+        model=model,
+        tokenizer=tok,
+        chain_slices=(("H", 0, n),),
+        designable_positions=variable_positions,
+        stop_grad=True,
+    )
+    _, grad_full = optimizers_module._eval_loss_and_grad(
+        loss_with_dp, seq_full, jax.random.key(0)
+    )
+    grad_at_variable = np.array(grad_full[variable_positions])  # (M, 20)
+    grad_at_fixed = np.array(
+        grad_full[jnp.array([i for i in range(n) if i not in designable])]
+    )
+
+    # Fixed positions should have zero gradient when designable_positions is set
+    np.testing.assert_allclose(grad_at_fixed, 0.0, atol=1e-6)
+
+    # --- Approach 2: SetPositions wrapping, no designable_positions ---
+    wildtype_tokens = jnp.array(
+        [TOKENS.index(aa) if aa != "X" else -1 for aa in wildtype_with_x],
+        dtype=jnp.int32,
+    )
+    loss_no_dp = ablang2_loss_mod.Ablang2PseudoLikelihood(
+        model=model,
+        tokenizer=tok,
+        chain_slices=(("H", 0, n),),
+        stop_grad=True,
+    )
+    set_pos_loss = SetPositions(wildtype_tokens, variable_positions, loss_no_dp)
+
+    seq_variable = seq_full[variable_positions]  # (M, 20) — variable positions only
+    _, grad_variable = optimizers_module._eval_loss_and_grad(
+        set_pos_loss, seq_variable, jax.random.key(0)
+    )
+
+    # Approach 2 gradient = Approach 1 gradient * (M / N) due to differing normalisers
+    np.testing.assert_allclose(
+        np.array(grad_variable),
+        grad_at_variable * (m / n),
+        rtol=1e-3,
+        atol=1e-4,
+    )
+
+
+@pytest.mark.slow
+def test_setpositions_combined_with_designable_positions():
+    """SetPositions + designable_positions together should give identical outputs to
+    designable_positions alone.
+
+    SetPositions reconstructs the same full sequence that approach 1 already receives
+    (wildtype at fixed positions, optimised values at variable positions), so the inner
+    Ablang2PseudoLikelihood sees exactly the same inputs in both cases.  The normali-
+    sation denominator is M in both cases, so loss values and gradients must match.
+    """
+    heavy = (
+        "EVQLLESGGEVKKPGASVKVSCRASGYTFRNYGLTWVRQAPGQGLEWMGWISAYNGNTNYAQKFQG"
+        "RVTLTTDTSTSTAYMELRSLRSDDTAVYFCARDVPGHGAAFMDVWGTGTTVTVSS"
+    )
+    designable = list(range(95, 103))
+    n = len(heavy)
+
+    wildtype_with_x = "".join(
+        "X" if i in designable else aa for i, aa in enumerate(heavy)
+    )
+
+    model, tok = ablang2_loss_mod._cached_ablang2_model()
+    variable_positions = jnp.array(designable, dtype=jnp.int32)
+
+    seq_full = jax.nn.one_hot(
+        jnp.array([TOKENS.index(aa) for aa in heavy], dtype=jnp.int32),
+        len(TOKENS),
+    )
+    seq_variable = seq_full[variable_positions]  # (M, 20)
+
+    # --- Approach 1: designable_positions, full sequence input ---
+    loss_dp = ablang2_loss_mod.Ablang2PseudoLikelihood(
+        model=model,
+        tokenizer=tok,
+        chain_slices=(("H", 0, n),),
+        designable_positions=variable_positions,
+        stop_grad=True,
+    )
+    (loss_value_dp, _), grad_full = optimizers_module._eval_loss_and_grad(
+        loss_dp, seq_full, jax.random.key(0)
+    )
+
+    # --- Approach 3: SetPositions + designable_positions, variable-only input ---
+    wildtype_tokens = jnp.array(
+        [TOKENS.index(aa) if aa != "X" else -1 for aa in wildtype_with_x],
+        dtype=jnp.int32,
+    )
+    loss_combined = SetPositions(
+        wildtype_tokens,
+        variable_positions,
+        ablang2_loss_mod.Ablang2PseudoLikelihood(
+            model=model,
+            tokenizer=tok,
+            chain_slices=(("H", 0, n),),
+            designable_positions=variable_positions,
+            stop_grad=True,
+        ),
+    )
+    (loss_value_combined, _), grad_variable = optimizers_module._eval_loss_and_grad(
+        loss_combined, seq_variable, jax.random.key(0)
+    )
+
+    # Loss values must be identical
+    assert float(loss_value_combined) == pytest.approx(float(loss_value_dp), rel=1e-3)
+
+    # Gradients at variable positions must be identical
+    np.testing.assert_allclose(
+        np.array(grad_variable),
+        np.array(grad_full[variable_positions]),
+        rtol=1e-3,
+        atol=1e-4,
+    )


### PR DESCRIPTION
Adds ablang2 loss and tests. Supports specifying `designable_positions` which limits the set of residues that the ppl is calculated over.