### PR TITLE
Add BindCraft-style optimizer

### DIFF
--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -698,25 +698,27 @@ def biohub_optimizer(
     return best_designs[order], best_loss[order]
 
 
-class _ColabDesignLoss(eqx.Module):
-    """
-    loss for ColabDesign implemented as eqx module to stop recompile
-    """
+def _colabdesign_transform(z, soft, temp, hard):
+    """Map ColabDesign logits to the sequence passed to the user's loss."""
+    soft_seq = jax.nn.softmax(z / temp)
+    hard_seq = jax.nn.one_hot(soft_seq.argmax(-1), z.shape[-1])
+    # straight thru estimator
+    hard_seq = jax.lax.stop_gradient(hard_seq - soft_seq) + soft_seq
+    pseudo = soft * soft_seq + (1.0 - soft) * z
+    # if hard true use only hard_seq
+    return hard * hard_seq + (1.0 - hard) * pseudo
 
-    inner: AbstractLoss
-    soft: Array
-    temp: Array
-    hard: Array
 
-    def __call__(self, z, key=None):
-        soft_seq = jax.nn.softmax(z / self.temp)
-        hard_seq = jax.nn.one_hot(soft_seq.argmax(-1), z.shape[-1])
-        # straight thru estimator
-        hard_seq = jax.lax.stop_gradient(hard_seq - soft_seq) + soft_seq
-        pseudo = self.soft * soft_seq + (1.0 - self.soft) * z
-        # if hard true use only hard_seq
-        pseudo = self.hard * hard_seq + (1.0 - self.hard) * pseudo
-        return self.inner(pseudo, key=key)
+# transform grad computed separately so switching optimizers doesn't recompile everything
+@jax.jit
+def _colabdesign_pullback(z, g, soft, temp, hard):
+    """Pull a sequence gradient back to ColabDesign logits."""
+    _, pullback = jax.vjp(
+        lambda z: _colabdesign_transform(z, soft, temp, hard),
+        z,
+    )
+    (g_z,) = pullback(g)
+    return g_z
 
 
 def _seq_grad_norm(g):
@@ -782,14 +784,14 @@ def colabdesign_stage(
         soft = soft_start + (soft_end - soft_start) * frac  # linear ramp
         temp = temp_end + (temp_start - temp_end) * (1 - frac) ** 2  # quadratic anneal
 
-        # arrays here are for compile
-        wrapped = _ColabDesignLoss(
-            inner=loss_function,
-            soft=jnp.asarray(soft, dtype=jnp.float32),
-            temp=jnp.asarray(temp, dtype=jnp.float32),
-            hard=jnp.asarray(hard, dtype=jnp.float32),
-        )
-        (value, aux), g = _eval_loss_and_grad(wrapped, x, key)
+        soft = jnp.asarray(soft, dtype=jnp.float32)
+        temp = jnp.asarray(temp, dtype=jnp.float32)
+        hard = jnp.asarray(hard, dtype=jnp.float32)
+        pseudo = _colabdesign_transform(x, soft, temp, hard)
+        # compute loss gradient
+        (value, aux), g = _eval_loss_and_grad(loss_function, pseudo, key)
+        # apply vjp 
+        g = _colabdesign_pullback(x, g, soft, temp, hard)
         value = float(value)
         key = jax.random.fold_in(key, 0)
 

--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -59,6 +59,12 @@ def _print_iter(iter, aux, v):
         ),
     )
 
+@eqx.filter_jit
+def _eval_loss(loss, x, key):
+    """Forward-only loss eval, useful for semigreedy which doesn't need grad"""
+    return loss(x, key=key)
+
+
 
 # Split this up so changing optim parameters doesn't trigger re-compilation of loss function
 def _eval_loss_and_grad(
@@ -700,3 +706,294 @@ def biohub_optimizer(
     order = np.argsort(best_loss)
 
     return best_designs[order], best_loss[order]
+
+
+class _ColabDesignLoss(eqx.Module):
+    """
+    loss for ColabDesign implemented as eqx module to stop recompile 
+    """
+
+    inner: AbstractLoss
+    soft: Array
+    temp: Array
+    hard: Array
+
+    def __call__(self, z, key=None):
+        soft_seq = jax.nn.softmax(z / self.temp)
+        hard_seq = jax.nn.one_hot(soft_seq.argmax(-1), z.shape[-1])
+        hard_seq = jax.lax.stop_gradient(hard_seq - soft_seq) + soft_seq
+        pseudo = self.soft * soft_seq + (1.0 - self.soft) * z
+        pseudo = self.hard * hard_seq + (1.0 - self.hard) * pseudo
+        return self.inner(pseudo, key=key)
+
+
+def _seq_grad_norm(g):
+    """Lifted from ColabDesign _norm_seq_grad."""
+    eff_L = (jnp.square(g).sum(-1, keepdims=True) > 0).sum(-2, keepdims=True)
+    gn = jnp.linalg.norm(g, axis=(-1, -2), keepdims=True)
+    return g * jnp.sqrt(eff_L) / (gn + 1e-7)
+
+
+def colabdesign_stage(
+    *,
+    loss_function: AbstractLoss,
+    x: Float[Array, "N 20"],
+    n_steps: int,
+    soft_start: float,
+    soft_end: float,
+    temp_start: float,
+    temp_end: float,
+    hard: float,
+    lr: float,
+    step: float = 1.0,
+    norm_seq_grad: bool = True,
+    max_gradient_norm: float | None = None,
+    key=None,
+    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N 20"]], any] | None = None,
+):
+    """
+    One ColabDesign/AfDesign stage: n_steps of normalised SGD on a logit iterate,
+    with soft ramping linearly, temp annealing quadratically, and hard fixed. Logits
+    in and out, so stages chain with no softmax round-trip (see bindcraft_design).
+
+    Args:
+    - loss_function: function to minimize
+    - x: initial logits (N x 20), centered per row on entry
+    - n_steps: number of optimization steps
+    - soft_start, soft_end: linear soft ramp (0 = raw logits, 1 = softmax)
+    - temp_start, temp_end: quadratic temp anneal
+    - hard: straight-through one-hot blend, fixed (0 or 1)
+    - lr: base learning rate (ColabDesign default 0.1)
+    - step: extra ColabDesign step multiplier on the lr scale
+    - norm_seq_grad: normalise the gradient to sqrt(L); else clip at max_gradient_norm
+    - max_gradient_norm: clip norm when norm_seq_grad is False (default sqrt(N))
+    - key: jax random key
+    - trajectory_fn: takes (aux, x) and returns any value
+
+    returns:
+    - x: final logits
+    - trajectory: list of trajectory information if `trajectory_fn` is provided
+    """
+    if max_gradient_norm is None:
+        max_gradient_norm = float(np.sqrt(x.shape[0]))
+    if key is None:
+        key = jax.random.key(np.random.randint(0, 10000))
+
+    x = jnp.asarray(x, dtype=jnp.float32)
+    # Center logits per row: log(pssm) carries a DC offset that softmax ignores but
+    # is off-distribution for the raw-logits stage (soft<1). The mosaic gradient is
+    # row-centered, so x stays zero-mean (re-centering a chained stage is a no-op).
+    x = x - x.mean(-1, keepdims=True)
+    trajectory = []
+
+    for _iter in range(n_steps):
+        start_time = time.time()
+        frac = (_iter + 1) / n_steps
+        soft = soft_start + (soft_end - soft_start) * frac          # linear ramp
+        temp = temp_end + (temp_start - temp_end) * (1 - frac) ** 2  # quadratic anneal
+
+        # arrays here are for compile
+        wrapped = _ColabDesignLoss(
+            inner=loss_function,
+            soft=jnp.asarray(soft, dtype=jnp.float32),
+            temp=jnp.asarray(temp, dtype=jnp.float32),
+            hard=jnp.asarray(hard, dtype=jnp.float32),
+        )
+        (value, aux), g = _eval_loss_and_grad(wrapped, x, key)
+        value = float(value)
+        key = jax.random.fold_in(key, 0)
+
+        if norm_seq_grad:
+            g = _seq_grad_norm(g)
+        else:
+            n = np.sqrt((g**2).sum())
+            if n > max_gradient_norm:
+                g = g * (max_gradient_norm / n)
+
+        lr_scale = step * ((1.0 - soft) + soft * temp)
+        x = x - (lr * lr_scale) * g
+
+        average_nnz = float((jax.nn.softmax(x) > 0.01).sum(-1).mean())
+        aux = {
+            "loss": value,
+            "nnz": average_nnz,
+            "time": time.time() - start_time,
+            "soft": float(soft),
+            "temp": float(temp),
+            "hard": float(hard),
+            "": aux,
+        }
+        if trajectory_fn is not None:
+            trajectory.append(trajectory_fn(aux, x))
+
+        _print_iter(
+            _iter,
+            eqx.filter(aux, lambda v: isinstance(v, float) or v.shape == ()),
+            value,
+        )
+
+    if trajectory_fn is None:
+        return x
+    return x, trajectory
+
+
+def semigreedy_design(
+    *,
+    loss_function: AbstractLoss,
+    pssm: Float[Array, "N 20"],
+    n_steps: int,
+    n_mutations: int,
+    key=None,
+    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N 20"]], any] | None = None,
+):
+    """
+    BindCraft's semigreedy discrete-mutation step. Discretise by taking the argmax(pssm) and then
+    sample proroposals from the pssm. Each step samples n_mutations single-point
+    mutations, evaluates each, and fixes the best (the current sequence is itself a
+    candidate, so non-improving steps leave it unchanged).
+
+    Args:
+    - loss_function: function to minimize
+    - pssm: soft sequence (N x 20); the start (its argmax) and the proposal distribution
+    - n_steps: number of greedy steps
+    - n_mutations: candidate mutations sampled per step (BindCraft's 0.05 * length)
+    - key: jax random key (seeds numpy's proposal sampling)
+    - trajectory_fn: takes (aux, x) and returns any value
+
+    returns:
+    - x: final one-hot sequence (N x 20)
+    - best_x: identical to x (greedy acceptance never regresses)
+    - trajectory: list of trajectory information if `trajectory_fn` is provided
+    """
+    if key is None:
+        key = jax.random.key(np.random.randint(0, 10000))
+    rng = np.random.default_rng(int(jax.random.randint(key, (), 0, 2**31 - 1)))
+
+    probs = np.asarray(pssm, dtype=np.float64)
+    probs = probs / probs.sum(-1, keepdims=True)
+    L, K = probs.shape
+    n_mutations = max(1, int(n_mutations))
+
+    def value_and_aux(seq):
+        (value, aux) = _eval_loss(loss_function, jax.nn.one_hot(jnp.asarray(seq), K), key)
+        return float(value), aux
+
+    seq = np.asarray(pssm.argmax(-1))
+    cur_val, cur_aux = value_and_aux(seq)
+    trajectory = []
+
+    for _iter in range(n_steps):
+        start_time = time.time()
+        best_seq, best_val, best_aux = seq, cur_val, cur_aux
+        for _ in range(n_mutations):
+            pos = int(rng.integers(0, L))
+            aa = int(rng.choice(K, p=probs[pos]))
+            cand = seq.copy()
+            cand[pos] = aa
+            val, aux = value_and_aux(cand)
+            if val < best_val and not np.isnan(val):
+                best_seq, best_val, best_aux = cand, val, aux
+        seq, cur_val, cur_aux = best_seq, best_val, best_aux
+
+        aux = {"loss": cur_val, "nnz": 1.0, "time": time.time() - start_time, "": cur_aux}
+        if trajectory_fn is not None:
+            trajectory.append(trajectory_fn(aux, jax.nn.one_hot(jnp.asarray(seq), K)))
+
+        _print_iter(
+            _iter,
+            eqx.filter(aux, lambda v: isinstance(v, float) or v.shape == ()),
+            cur_val,
+        )
+
+    x = jax.nn.one_hot(jnp.asarray(seq), K)
+    if trajectory_fn is None:
+        return x, x
+    return x, x, trajectory
+
+
+def bindcraft_design(
+    *,
+    loss_function: AbstractLoss,
+    length: int,
+    lr: float = 0.1,
+    logits_iters: tuple[int, int] = (50, 25),
+    soft_iters: int = 45,
+    hard_iters: int = 5,
+    greedy_iters: int = 15,
+    n_mutations: int | None = None,
+    alphabet_size: int = 20,
+    key=None,
+    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N 20"]], any] | None = None,
+):
+    """
+    BindCraft's default 4-stage design. First two stages operate on unconstrained logits
+    which are then hardened to probablities.  We take parameters from default_4stage_multimer.json in Bindcraft
+    Init is ColabDesign's set_seq default (0.01*normal), which is used in Bindcraft. 
+    See ""materials and methods" section here for details
+    https://www.biorxiv.org/content/10.1101/2024.09.30.615802v1
+
+    Args:
+    - loss_function: function to minimize
+    - length: number of residues to design
+    - lr: ColabDesign base learning rate
+    - logits_iters: (logits1, logits2) step counts
+    - soft_iters: steps for the temp-anneal stage
+    - hard_iters: steps for the straight-through stage
+    - greedy_iters: steps for the semigreedy tail
+    - n_mutations: candidates per greedy step (default round(0.05*length))
+    - alphabet_size: token alphabet size
+    - key: jax random key
+    - trajectory_fn: takes (aux, x) and returns any value
+
+    returns:
+    - x: final one-hot sequence (length x alphabet_size)
+    - trajectory: concatenated trajectory information if `trajectory_fn` is provided
+    """
+    if key is None:
+        key = jax.random.key(np.random.randint(0, 10000))
+    if n_mutations is None:
+        n_mutations = max(1, round(0.05 * length))
+
+    n1, n2 = logits_iters
+    # (n_steps, soft_start, soft_end, temp_start, temp_end, hard) per ColabDesign stage.
+    stages = [
+        (n1, 0.0, 0.9, 1.0, 1.0, 0.0),    # logits1
+        (n2, 0.9, 1.0, 1.0, 1.0, 0.0),    # logits2
+        (soft_iters, 1.0, 1.0, 1.0, 1e-2, 0.0),    # soft
+        (hard_iters, 1.0, 1.0, 1e-2, 1e-2, 1.0),   # hard
+    ]
+    keys = jax.random.split(key, len(stages) + 2)
+    k_init, k_sg, stage_keys = keys[0], keys[1], keys[2:]
+
+    # ColabDesign set_seq default: near-uniform, origin-centered logits.
+    x = 0.01 * jax.random.normal(k_init, (length, alphabet_size))
+
+    trajectory = []
+    for (n_steps, s0, s1, t0, t1, hard), k in zip(stages, stage_keys):
+        out = colabdesign_stage(
+            loss_function=loss_function,
+            x=x,
+            n_steps=n_steps,
+            soft_start=s0, soft_end=s1,
+            temp_start=t0, temp_end=t1,
+            hard=hard,
+            lr=lr,
+            key=k,
+            trajectory_fn=trajectory_fn,
+        )
+        x, t = out if trajectory_fn is not None else (out, [])
+        trajectory += t
+
+    # ColabDesign uses the final (post-hard) iterate; softmax to read out a pssm.
+    sg = semigreedy_design(
+        loss_function=loss_function,
+        pssm=jax.nn.softmax(x),
+        n_steps=greedy_iters,
+        n_mutations=n_mutations,
+        key=k_sg,
+        trajectory_fn=trajectory_fn,
+    )
+
+    if trajectory_fn is None:
+        return sg[0]
+    return sg[0], trajectory + sg[2]

--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -54,16 +54,9 @@ def _print_iter(iter, aux, v):
         " ".join(
             f"{jax.tree_util.keystr(k, simple=True, separator='.')}:{v: 0.2f}"
             for (k, v) in jax.tree_util.tree_leaves_with_path(aux)
-            if hasattr(v, "item")
-            or isinstance(v, float)
+            if hasattr(v, "item") or isinstance(v, float)
         ),
     )
-
-@eqx.filter_jit
-def _eval_loss(loss, x, key):
-    """Forward-only loss eval, useful for semigreedy which doesn't need grad"""
-    return loss(x, key=key)
-
 
 
 # Split this up so changing optim parameters doesn't trigger re-compilation of loss function
@@ -114,7 +107,6 @@ def batched_eval(
         return v, aux, g
 
     return jax.vmap(single)(xs, keys)
-
 
 
 # def _proposal(sequence, g, temp, alphabet_size: int = 20):
@@ -379,8 +371,6 @@ def simplex_APGM(
         return x, best_x
     else:
         return x, best_x, trajectory
-
-
 
 
 def batched_simplex_APGM(
@@ -710,7 +700,7 @@ def biohub_optimizer(
 
 class _ColabDesignLoss(eqx.Module):
     """
-    loss for ColabDesign implemented as eqx module to stop recompile 
+    loss for ColabDesign implemented as eqx module to stop recompile
     """
 
     inner: AbstractLoss
@@ -721,10 +711,10 @@ class _ColabDesignLoss(eqx.Module):
     def __call__(self, z, key=None):
         soft_seq = jax.nn.softmax(z / self.temp)
         hard_seq = jax.nn.one_hot(soft_seq.argmax(-1), z.shape[-1])
-        # straight thru estimator 
+        # straight thru estimator
         hard_seq = jax.lax.stop_gradient(hard_seq - soft_seq) + soft_seq
         pseudo = self.soft * soft_seq + (1.0 - self.soft) * z
-        # if hard true use only hard_seq 
+        # if hard true use only hard_seq
         pseudo = self.hard * hard_seq + (1.0 - self.hard) * pseudo
         return self.inner(pseudo, key=key)
 
@@ -789,7 +779,7 @@ def colabdesign_stage(
     for _iter in range(n_steps):
         start_time = time.time()
         frac = (_iter + 1) / n_steps
-        soft = soft_start + (soft_end - soft_start) * frac          # linear ramp
+        soft = soft_start + (soft_end - soft_start) * frac  # linear ramp
         temp = temp_end + (temp_start - temp_end) * (1 - frac) ** 2  # quadratic anneal
 
         # arrays here are for compile
@@ -857,7 +847,7 @@ def bindcraft_design(
     section here: https://www.biorxiv.org/content/10.1101/2024.09.30.615802v1
 
     Note: the bindcraft pipeline also implements an additional discrete optimisation
-    stage, after the gradient bases stages which randomly samples proposals 
+    stage, after the gradient bases stages which randomly samples proposals
     from the pssm at postions the pLDDT indicates the model is uncertain.
 
     Args:
@@ -881,10 +871,10 @@ def bindcraft_design(
     n1, n2 = logits_iters
     # (n_steps, soft_start, soft_end, temp_start, temp_end, hard) per ColabDesign stage.
     stages = [
-        (n1, 0.0, 0.9, 1.0, 1.0, False),    # logits1
-        (n2, 0.9, 1.0, 1.0, 1.0, False),    # logits2
-        (soft_iters, 1.0, 1.0, 1.0, 1e-2, False),    # soft
-        (hard_iters, 1.0, 1.0, 1e-2, 1e-2, True),    # hard
+        (n1, 0.0, 0.9, 1.0, 1.0, False),  # logits1
+        (n2, 0.9, 1.0, 1.0, 1.0, False),  # logits2
+        (soft_iters, 1.0, 1.0, 1.0, 1e-2, False),  # soft
+        (hard_iters, 1.0, 1.0, 1e-2, 1e-2, True),  # hard
     ]
     keys = jax.random.split(key, len(stages) + 1)
     k_init, stage_keys = keys[0], keys[1:]
@@ -898,8 +888,10 @@ def bindcraft_design(
             loss_function=loss_function,
             x=x,
             n_steps=n_steps,
-            soft_start=s0, soft_end=s1,
-            temp_start=t0, temp_end=t1,
+            soft_start=s0,
+            soft_end=s1,
+            temp_start=t0,
+            temp_end=t1,
             hard=hard,
             lr=lr,
             key=k,

--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -731,7 +731,7 @@ def _seq_grad_norm(g):
 def colabdesign_stage(
     *,
     loss_function: AbstractLoss,
-    x: Float[Array, "N 20"],
+    x: Float[Array, "N K"],
     n_steps: int,
     soft_start: float,
     soft_end: float,
@@ -742,7 +742,7 @@ def colabdesign_stage(
     norm_seq_grad: bool = True,
     max_gradient_norm: float | None = None,
     key=None,
-    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N 20"]], any] | None = None,
+    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N K"]], any] | None = None,
 ):
     """
     One ColabDesign/AfDesign stage: n_steps of normalised SGD on a logit iterate,
@@ -751,7 +751,7 @@ def colabdesign_stage(
 
     Args:
     - loss_function: function to minimize
-    - x: initial logits (N x 20), centered per row on entry
+    - x: initial logits (N x K), centered per row on entry
     - n_steps: number of optimization steps
     - soft_start, soft_end: linear soft ramp (0 = raw logits, 1 = softmax)
     - temp_start, temp_end: quadratic temp anneal
@@ -832,72 +832,85 @@ def colabdesign_stage(
 def bindcraft_design(
     *,
     loss_function: AbstractLoss,
-    length: int,
+    x: Float[Array, "N K"],
     lr: float = 0.1,
     logits_iters: tuple[int, int] = (50, 25),
     soft_iters: int = 45,
     hard_iters: int = 5,
-    alphabet_size: int = 20,
     key=None,
-    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N 20"]], any] | None = None,
+    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N K"]], any] | None = None,
 ):
-    """
-    The default 4-stage pipeline from bindcraft.
-    The first two stages operate on unconstrained logits which are then hardened to
-    probabilities. Parameters follow default_4stage_multimer.json in BindCraft; init is
-    ColabDesign's set_seq default (0.01*normal). See the "materials and methods"
-    section here: https://www.biorxiv.org/content/10.1101/2024.09.30.615802v1
+    """Run the default four-stage BindCraft gradient design schedule.
 
-    Note: the bindcraft pipeline also implements an additional discrete optimisation
-    stage, after the gradient bases stages which randomly samples proposals
-    from the pssm at postions the pLDDT indicates the model is uncertain.
+    The caller supplies initial logits. To match the paper initialization, use
+    x = 0.01 * jax.random.normal(key, (N, K)).
+    
+    Parameters follow default_4stage_multimer.json in BindCraft package.
+    See the "materials and methods" section here: https://www.biorxiv.org/content/10.1101/2024.09.30.615802v1
 
     Args:
     - loss_function: function to minimise.
-    - length: number of residues to design.
-    - lr: ColabDesign base learning rate.
-    - logits_iters: (logits1, logits2) step counts.
-    - soft_iters: steps for the temp-anneal stage.
-    - hard_iters: steps for the straight-through stage.
-    - alphabet_size: token alphabet size.
-    - key: jax random key.
-    - trajectory_fn: takes (aux, x) and returns any value.
+    - x: initial logits with shape (N, K).
+    - lr: base learning rate.
+    - logits_iters: step counts for the two logits stages.
+    - soft_iters: step count for the soft stage.
+    - hard_iters: step count for the hard stage.
+    - key: JAX random key.
+    - trajectory_fn: optional callback receiving (aux, x).
 
-    returns:
-    - pssm: final soft sequence, softmax of the post-hard logits (length x alphabet_size).
-    - trajectory: concatenated trajectory information if trajectory_fn is provided.
+    Returns:
+    - pssm: final soft sequence with shape (N, K).
+    - trajectory: concatenated callback results, when requested.
     """
     if key is None:
         key = jax.random.key(np.random.randint(0, 10000))
 
     n1, n2 = logits_iters
-    # (n_steps, soft_start, soft_end, temp_start, temp_end, hard) per ColabDesign stage.
     stages = [
-        (n1, 0.0, 0.9, 1.0, 1.0, False),  # logits1
-        (n2, 0.9, 1.0, 1.0, 1.0, False),  # logits2
-        (soft_iters, 1.0, 1.0, 1.0, 1e-2, False),  # soft
-        (hard_iters, 1.0, 1.0, 1e-2, 1e-2, True),  # hard
+        {
+            "n_steps": n1,
+            "soft_start": 0.0,
+            "soft_end": 0.9,
+            "temp_start": 1.0,
+            "temp_end": 1.0,
+            "hard": False,
+        },
+        {
+            "n_steps": n2,
+            "soft_start": 0.9,
+            "soft_end": 1.0,
+            "temp_start": 1.0,
+            "temp_end": 1.0,
+            "hard": False,
+        },
+        {
+            "n_steps": soft_iters,
+            "soft_start": 1.0,
+            "soft_end": 1.0,
+            "temp_start": 1.0,
+            "temp_end": 1e-2,
+            "hard": False,
+        },
+        {
+            "n_steps": hard_iters,
+            "soft_start": 1.0,
+            "soft_end": 1.0,
+            "temp_start": 1e-2,
+            "temp_end": 1e-2,
+            "hard": True,
+        },
     ]
-    keys = jax.random.split(key, len(stages) + 1)
-    k_init, stage_keys = keys[0], keys[1:]
-
-    # ColabDesign set_seq default: near-uniform, origin-centered logits.
-    x = 0.01 * jax.random.normal(k_init, (length, alphabet_size))
+    stage_keys = jax.random.split(key, len(stages))
 
     trajectory = []
-    for (n_steps, s0, s1, t0, t1, hard), k in zip(stages, stage_keys):
+    for stage, k in zip(stages, stage_keys):
         out = colabdesign_stage(
             loss_function=loss_function,
             x=x,
-            n_steps=n_steps,
-            soft_start=s0,
-            soft_end=s1,
-            temp_start=t0,
-            temp_end=t1,
-            hard=hard,
             lr=lr,
             key=k,
             trajectory_fn=trajectory_fn,
+            **stage,
         )
         x, t = out if trajectory_fn is not None else (out, [])
         trajectory += t

--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -731,7 +731,7 @@ def _seq_grad_norm(g):
 def colabdesign_stage(
     *,
     loss_function: AbstractLoss,
-    x: Float[Array, "N K"],
+    x: Float[Array, "N 20"],
     n_steps: int,
     soft_start: float,
     soft_end: float,
@@ -742,7 +742,7 @@ def colabdesign_stage(
     norm_seq_grad: bool = True,
     max_gradient_norm: float | None = None,
     key=None,
-    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N K"]], any] | None = None,
+    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N 20"]], any] | None = None,
 ):
     """
     One ColabDesign/AfDesign stage: n_steps of normalised SGD on a logit iterate,
@@ -832,13 +832,13 @@ def colabdesign_stage(
 def bindcraft_design(
     *,
     loss_function: AbstractLoss,
-    x: Float[Array, "N K"],
+    x: Float[Array, "N 20"],
     lr: float = 0.1,
     logits_iters: tuple[int, int] = (50, 25),
     soft_iters: int = 45,
     hard_iters: int = 5,
     key=None,
-    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N K"]], any] | None = None,
+    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N 20"]], any] | None = None,
 ):
     """Run the default four-stage BindCraft gradient design schedule.
 

--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -756,7 +756,7 @@ def colabdesign_stage(
     """
     One ColabDesign/AfDesign stage: n_steps of normalised SGD on a logit iterate,
     with soft ramping linearly, temp annealing quadratically, and hard fixed. Logits
-    in and out, so stages chain with no softmax round-trip (see bindcraft_design).
+    in and out, so stages chain with no softmax round-trip (the BindCraft recipe).
 
     Args:
     - loss_function: function to minimize
@@ -839,80 +839,6 @@ def colabdesign_stage(
     return x, trajectory
 
 
-def semigreedy_design(
-    *,
-    loss_function: AbstractLoss,
-    pssm: Float[Array, "N 20"],
-    n_steps: int,
-    n_mutations: int,
-    key=None,
-    trajectory_fn: Callable[tuple[PyTree, Float[Array, "N 20"]], any] | None = None,
-):
-    """
-    BindCraft's semigreedy discrete-mutation step. Discretise by taking the argmax(pssm) and then
-    sample proroposals from the pssm. Each step samples n_mutations single-point
-    mutations, evaluates each, and fixes the best (the current sequence is itself a
-    candidate, so non-improving steps leave it unchanged).
-
-    Args:
-    - loss_function: function to minimize
-    - pssm: soft sequence (N x 20); the start (its argmax) and the proposal distribution
-    - n_steps: number of greedy steps
-    - n_mutations: candidate mutations sampled per step (BindCraft's 0.05 * length)
-    - key: jax random key (seeds numpy's proposal sampling)
-    - trajectory_fn: takes (aux, x) and returns any value
-
-    returns:
-    - x: final one-hot sequence (N x 20)
-    - best_x: identical to x (greedy acceptance never regresses)
-    - trajectory: list of trajectory information if `trajectory_fn` is provided
-    """
-    if key is None:
-        key = jax.random.key(np.random.randint(0, 10000))
-    rng = np.random.default_rng(int(jax.random.randint(key, (), 0, 2**31 - 1)))
-
-    probs = np.asarray(pssm, dtype=np.float64)
-    probs = probs / probs.sum(-1, keepdims=True)
-    L, K = probs.shape
-    n_mutations = max(1, int(n_mutations))
-
-    def value_and_aux(seq):
-        (value, aux) = _eval_loss(loss_function, jax.nn.one_hot(jnp.asarray(seq), K), key)
-        return float(value), aux
-
-    seq = np.asarray(pssm.argmax(-1))
-    cur_val, cur_aux = value_and_aux(seq)
-    trajectory = []
-
-    for _iter in range(n_steps):
-        start_time = time.time()
-        best_seq, best_val, best_aux = seq, cur_val, cur_aux
-        for _ in range(n_mutations):
-            pos = int(rng.integers(0, L))
-            aa = int(rng.choice(K, p=probs[pos]))
-            cand = seq.copy()
-            cand[pos] = aa
-            val, aux = value_and_aux(cand)
-            if val < best_val and not np.isnan(val):
-                best_seq, best_val, best_aux = cand, val, aux
-        seq, cur_val, cur_aux = best_seq, best_val, best_aux
-
-        aux = {"loss": cur_val, "nnz": 1.0, "time": time.time() - start_time, "": cur_aux}
-        if trajectory_fn is not None:
-            trajectory.append(trajectory_fn(aux, jax.nn.one_hot(jnp.asarray(seq), K)))
-
-        _print_iter(
-            _iter,
-            eqx.filter(aux, lambda v: isinstance(v, float) or v.shape == ()),
-            cur_val,
-        )
-
-    x = jax.nn.one_hot(jnp.asarray(seq), K)
-    if trajectory_fn is None:
-        return x, x
-    return x, x, trajectory
-
-
 def bindcraft_design(
     *,
     loss_function: AbstractLoss,
@@ -921,40 +847,38 @@ def bindcraft_design(
     logits_iters: tuple[int, int] = (50, 25),
     soft_iters: int = 45,
     hard_iters: int = 5,
-    greedy_iters: int = 15,
-    n_mutations: int | None = None,
     alphabet_size: int = 20,
     key=None,
     trajectory_fn: Callable[tuple[PyTree, Float[Array, "N 20"]], any] | None = None,
 ):
     """
-    BindCraft's default 4-stage design. First two stages operate on unconstrained logits
-    which are then hardened to probablities.  We take parameters from default_4stage_multimer.json in Bindcraft
-    Init is ColabDesign's set_seq default (0.01*normal), which is used in Bindcraft. 
-    See ""materials and methods" section here for details
-    https://www.biorxiv.org/content/10.1101/2024.09.30.615802v1
+    The default 4-stage gradient pipeline from bindcraft.
+    The first two stages operate on unconstrained logits which are then hardened to
+    probabilities. Parameters follow default_4stage_multimer.json in BindCraft; init is
+    ColabDesign's set_seq default (0.01*normal). See the "materials and methods"
+    section here: https://www.biorxiv.org/content/10.1101/2024.09.30.615802v1
+
+    Note: the bindcraft pipeline also implements an additional discrete optimisation
+    stage, after the gradient bases stages which randomly samples proposals 
+    from the pssm at postions the pLDDT indicates the model is uncertain.
 
     Args:
-    - loss_function: function to minimize
-    - length: number of residues to design
-    - lr: ColabDesign base learning rate
-    - logits_iters: (logits1, logits2) step counts
-    - soft_iters: steps for the temp-anneal stage
-    - hard_iters: steps for the straight-through stage
-    - greedy_iters: steps for the semigreedy tail
-    - n_mutations: candidates per greedy step (default round(0.05*length))
-    - alphabet_size: token alphabet size
-    - key: jax random key
-    - trajectory_fn: takes (aux, x) and returns any value
+    - loss_function: function to minimise.
+    - length: number of residues to design.
+    - lr: ColabDesign base learning rate.
+    - logits_iters: (logits1, logits2) step counts.
+    - soft_iters: steps for the temp-anneal stage.
+    - hard_iters: steps for the straight-through stage.
+    - alphabet_size: token alphabet size.
+    - key: jax random key.
+    - trajectory_fn: takes (aux, x) and returns any value.
 
     returns:
-    - x: final one-hot sequence (length x alphabet_size)
-    - trajectory: concatenated trajectory information if `trajectory_fn` is provided
+    - pssm: final soft sequence, softmax of the post-hard logits (length x alphabet_size).
+    - trajectory: concatenated trajectory information if trajectory_fn is provided.
     """
     if key is None:
         key = jax.random.key(np.random.randint(0, 10000))
-    if n_mutations is None:
-        n_mutations = max(1, round(0.05 * length))
 
     n1, n2 = logits_iters
     # (n_steps, soft_start, soft_end, temp_start, temp_end, hard) per ColabDesign stage.
@@ -964,8 +888,8 @@ def bindcraft_design(
         (soft_iters, 1.0, 1.0, 1.0, 1e-2, False),    # soft
         (hard_iters, 1.0, 1.0, 1e-2, 1e-2, True),    # hard
     ]
-    keys = jax.random.split(key, len(stages) + 2)
-    k_init, k_sg, stage_keys = keys[0], keys[1], keys[2:]
+    keys = jax.random.split(key, len(stages) + 1)
+    k_init, stage_keys = keys[0], keys[1:]
 
     # ColabDesign set_seq default: near-uniform, origin-centered logits.
     x = 0.01 * jax.random.normal(k_init, (length, alphabet_size))
@@ -987,15 +911,7 @@ def bindcraft_design(
         trajectory += t
 
     # ColabDesign uses the final (post-hard) iterate; softmax to read out a pssm.
-    sg = semigreedy_design(
-        loss_function=loss_function,
-        pssm=jax.nn.softmax(x),
-        n_steps=greedy_iters,
-        n_mutations=n_mutations,
-        key=k_sg,
-        trajectory_fn=trajectory_fn,
-    )
-
+    pssm = jax.nn.softmax(x)
     if trajectory_fn is None:
-        return sg[0]
-    return sg[0], trajectory + sg[2]
+        return pssm
+    return pssm, trajectory

--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -721,8 +721,10 @@ class _ColabDesignLoss(eqx.Module):
     def __call__(self, z, key=None):
         soft_seq = jax.nn.softmax(z / self.temp)
         hard_seq = jax.nn.one_hot(soft_seq.argmax(-1), z.shape[-1])
+        # straight thru estimator 
         hard_seq = jax.lax.stop_gradient(hard_seq - soft_seq) + soft_seq
         pseudo = self.soft * soft_seq + (1.0 - self.soft) * z
+        # if hard true use only hard_seq 
         pseudo = self.hard * hard_seq + (1.0 - self.hard) * pseudo
         return self.inner(pseudo, key=key)
 
@@ -743,7 +745,7 @@ def colabdesign_stage(
     soft_end: float,
     temp_start: float,
     temp_end: float,
-    hard: float,
+    hard: bool,
     lr: float,
     step: float = 1.0,
     norm_seq_grad: bool = True,
@@ -762,7 +764,7 @@ def colabdesign_stage(
     - n_steps: number of optimization steps
     - soft_start, soft_end: linear soft ramp (0 = raw logits, 1 = softmax)
     - temp_start, temp_end: quadratic temp anneal
-    - hard: straight-through one-hot blend, fixed (0 or 1)
+    - hard: if True, blend in a straight-through one-hot for the stage
     - lr: base learning rate (ColabDesign default 0.1)
     - step: extra ColabDesign step multiplier on the lr scale
     - norm_seq_grad: normalise the gradient to sqrt(L); else clip at max_gradient_norm
@@ -957,10 +959,10 @@ def bindcraft_design(
     n1, n2 = logits_iters
     # (n_steps, soft_start, soft_end, temp_start, temp_end, hard) per ColabDesign stage.
     stages = [
-        (n1, 0.0, 0.9, 1.0, 1.0, 0.0),    # logits1
-        (n2, 0.9, 1.0, 1.0, 1.0, 0.0),    # logits2
-        (soft_iters, 1.0, 1.0, 1.0, 1e-2, 0.0),    # soft
-        (hard_iters, 1.0, 1.0, 1e-2, 1e-2, 1.0),   # hard
+        (n1, 0.0, 0.9, 1.0, 1.0, False),    # logits1
+        (n2, 0.9, 1.0, 1.0, 1.0, False),    # logits2
+        (soft_iters, 1.0, 1.0, 1.0, 1e-2, False),    # soft
+        (hard_iters, 1.0, 1.0, 1e-2, 1e-2, True),    # hard
     ]
     keys = jax.random.split(key, len(stages) + 2)
     k_init, k_sg, stage_keys = keys[0], keys[1], keys[2:]

--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -747,7 +747,6 @@ def colabdesign_stage(
     temp_end: float,
     hard: bool,
     lr: float,
-    step: float = 1.0,
     norm_seq_grad: bool = True,
     max_gradient_norm: float | None = None,
     key=None,
@@ -766,7 +765,6 @@ def colabdesign_stage(
     - temp_start, temp_end: quadratic temp anneal
     - hard: if True, blend in a straight-through one-hot for the stage
     - lr: base learning rate (ColabDesign default 0.1)
-    - step: extra ColabDesign step multiplier on the lr scale
     - norm_seq_grad: normalise the gradient to sqrt(L); else clip at max_gradient_norm
     - max_gradient_norm: clip norm when norm_seq_grad is False (default sqrt(N))
     - key: jax random key
@@ -812,7 +810,7 @@ def colabdesign_stage(
             if n > max_gradient_norm:
                 g = g * (max_gradient_norm / n)
 
-        lr_scale = step * ((1.0 - soft) + soft * temp)
+        lr_scale = (1.0 - soft) + soft * temp
         x = x - (lr * lr_scale) * g
 
         average_nnz = float((jax.nn.softmax(x) > 0.01).sum(-1).mean())

--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -840,7 +840,7 @@ def bindcraft_design(
     trajectory_fn: Callable[tuple[PyTree, Float[Array, "N 20"]], any] | None = None,
 ):
     """
-    The default 4-stage gradient pipeline from bindcraft.
+    The default 4-stage pipeline from bindcraft.
     The first two stages operate on unconstrained logits which are then hardened to
     probabilities. Parameters follow default_4stage_multimer.json in BindCraft; init is
     ColabDesign's set_seq default (0.01*normal). See the "materials and methods"


### PR DESCRIPTION
This PR adds the BindCraft optimisation pipeline. You can see an overview of their methodology in [the paper](https://www.biorxiv.org/content/10.1101/2024.09.30.615802v1.full.pdf). BindCraft itself is based on colabdesign so lots of the steps are actually ported from there. 

We add two public functions:
- `colabdesign_stage` implements a single stage of colabdesign optimisation. The bindcraft optimisation is made up of 4 such stages. Each stage ramps/anneals the temperature/learning rate between two specified values. In order to jit without recompling the loss each time these change i put the loss in an equinox module. The loss is a composite of different terms depending on if `hard` is true. If so we use the straight thru estimator on the argmaxed sequence, if not we use the pssm mixed with the raw logits, with the proportion pssm being given by `soft` param. Note that when soft is less than 1.0, we will be feeding unconstrained/negative values into the model. The step also does some gradient normalisation.
- `bindcraft_design` this function mirrors the bindcraft optimisation pipeline from their defaults. There are 4 separate stages of continous optimisation. We also copy them in using  gaussian distributed initialisation for the logits. We do not implement the semigreedy discrete optimisation stage. 

Some thing I am unsure about:
- Perhaps, to avoid adding too much code, it might be better to not include the bindcraft_design fuction, and let the user implement that for themself? Or we could put it as an example in the readme?
- Do we need to worry that some models might error when the logits are fed in?
- Should I implement some tests?
