### PR TITLE
Add model tests, centralize caches, and harden model contracts

### DIFF
--- a/examples/boltz_notebook.py
+++ b/examples/boltz_notebook.py
@@ -318,11 +318,14 @@ def _(FixedStructureInverseFoldingLL, mpnn, soft_pred):
 
 @app.cell
 def _():
-    from mosaic.optimizers import _eval_loss_and_grad
+    # Alias off the leading underscore: marimo treats `_`-prefixed names as
+    # cell-local and mangles them, which breaks the `jacobi` closure when it is
+    # called from another cell.
+    from mosaic.optimizers import _eval_loss_and_grad as eval_loss_and_grad
 
     def jacobi(loss, iters, sequence, key):
         for _ in range(iters):
-            (v, aux), g = _eval_loss_and_grad(loss, jax.nn.one_hot(sequence, 20), key = key)
+            (v, aux), g = eval_loss_and_grad(loss, jax.nn.one_hot(sequence, 20), key=key)
             sequence = g.argmin(-1)
             print(v)
 

--- a/examples/esmfold_minibinder.py
+++ b/examples/esmfold_minibinder.py
@@ -79,8 +79,15 @@ def _(ESMFold2ExperimentalFast, ESMFold2ExperimentalFast2025, eqx, load_esmc):
 
 
 @app.cell
-def _(ESMFold2ExperimentalFast2025):
+def _(ESMFold2ExperimentalFast2025, eqx, esmc):
     validation_model = ESMFold2ExperimentalFast2025()
+    # Dedup ESMC: drop this model's own copy and share the single loaded esmc_6b
+    # (same weights model_0/model_1 use for design) rather than holding a second
+    # ~24GB copy resident -- that duplicate is what OOMs the final predict.
+    validation_model = eqx.tree_at(lambda m: m.esmc, validation_model, None)
+    validation_model = eqx.tree_at(
+        lambda m: m.esmc, validation_model, esmc, is_leaf=lambda l: l is None
+    )
     return (validation_model,)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "flax>=0.10.2",
     "gemmi>=0.6.5",
     "ipymolstar>=0.0.9",
-    "jax>=0.8.1",
+    "jax>=0.8.1,<0.11",
     "joltz",
     "marimo>=0.10.9",
     "matplotlib>=3.10.0",
@@ -29,8 +29,6 @@ dependencies = [
     "protenix",
     "httpx>=0.28.1",
     "joltzgen",
-    "nvidia-cublas-cu12>=12.9.1.4",
-    "nvidia-cusolver-cu12==11.7.3.90",
     "polars>=1.37.1",
     "jopenfold3",
     "jproteina-complexa",
@@ -57,6 +55,8 @@ jax-cpu = [
 ]
 jax-cuda = [
   "jax[cuda]",
+  "nvidia-cublas-cu12>=12.9.1.4",
+  "nvidia-cusolver-cu12==11.7.3.90",
 ]
 jax-tpu= [
   "jax[tpu]",
@@ -94,8 +94,17 @@ jpromera = { git = "https://github.com/escalante-bio/jpromera.git"}
 jopendde = { git = "https://github.com/escalante-bio/jopendde.git" }
 opendde = { git = "https://github.com/escalante-bio/jopendde.git", subdirectory = "OpenDDE" }
 
+[tool.ruff.lint]
+ignore = ["F722"]
+
 [tool.pytest.ini_options]
-markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
+testpaths = ["tests"]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "model_smoke: loads real checkpoints and exercises model featurization",
+    "model_forward: runs model output, prediction, and loss forwards",
+    "opendde_smoke: exercises OpenDDE weight-free featurization",
+]
 addopts = "-m 'not slow'"
 
 [tool.uv]

--- a/src/mosaic/cache.py
+++ b/src/mosaic/cache.py
@@ -1,0 +1,24 @@
+"""Central cache paths for downloaded models and generated data."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def cache_dir(*subdirs: str) -> Path:
+    """Return Mosaic's cache root (or a subdirectory of it) without creating it."""
+    root = Path(os.environ.get("MOSAIC_CACHE_DIR", "~/.cache/mosaic")).expanduser()
+    return root.joinpath(*subdirs)
+
+
+def resolve_cache(override, *subdirs: str, create: bool = False) -> Path:
+    """Resolve a user-supplied cache path, falling back to a cache subdirectory.
+
+    ``override`` of ``None`` uses ``cache_dir(*subdirs)``; otherwise the override
+    is expanded (``~``). With ``create=True`` the directory is created.
+    """
+    path = cache_dir(*subdirs) if override is None else Path(override).expanduser()
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path

--- a/src/mosaic/losses/atom37.py
+++ b/src/mosaic/losses/atom37.py
@@ -28,8 +28,8 @@ ATOM37_INDEX: dict[str, int] = {name: i for i, name in enumerate(ATOM37_NAMES)}
 
 def scatter_atom37(
     atom_coords: Float[Array, "N_atom 3"],
-    atom_to_token: Int[Array, "N_atom"],
-    atom37_idx: Int[Array, "N_atom"],
+    atom_to_token: Int[Array, " N_atom"],
+    atom37_idx: Int[Array, " N_atom"],
     n_token: int,
 ) -> tuple[Float[Array, "N_token 37 3"], Float[Array, "N_token 37"]]:
     """Scatter all-atom coords into a `[n_token, 37, 3]` grid + mask.

--- a/src/mosaic/losses/boltz.py
+++ b/src/mosaic/losses/boltz.py
@@ -27,6 +27,7 @@ from jax import tree
 from jaxtyping import Array, Float, PyTree
 
 from ..common import LinearCombination, LossTerm
+from ..cache import resolve_cache
 
 from .atom37 import ATOM37_INDEX, scatter_atom37
 from .structure_prediction import PAE_BINS, StructureModelOutput
@@ -54,13 +55,14 @@ _BOLTZ_TOKATOM_TO_ATOM37 = _build_boltz_atom37_table()
 
 
 def load_boltz(
-    checkpoint_path: Path = Path("~/.boltz/boltz1_conf.ckpt").expanduser(),
+    checkpoint_path: Path | None = None,
 ):
     predict_args = {
         "recycling_steps": 0,
         "sampling_steps": 25,
         "diffusion_samples": 1,
     }
+    checkpoint_path = resolve_cache(checkpoint_path, "boltz", "boltz1_conf.ckpt")
     if not checkpoint_path.exists():
         print(f"Downloading Boltz checkpoint to {checkpoint_path}")
         cache = checkpoint_path.parent
@@ -331,9 +333,10 @@ sequences:
 
 def load_features_and_structure_writer(
     input_yaml_str: str,
-    cache=Path("~/.boltz/").expanduser(),
+    cache=None,
 ) -> tuple[PyTree, StructureWriter]:
     print("Loading data")
+    cache = resolve_cache(cache, "boltz", create=True)
     out_dir_handle = (
         TemporaryDirectory()
     )  # this is sketchy -- we have to remember not to let this get garbage collected

--- a/src/mosaic/losses/boltz2.py
+++ b/src/mosaic/losses/boltz2.py
@@ -18,8 +18,9 @@ from joltz import TrunkState
 
 
 from ..common import LinearCombination, LossTerm
+from ..cache import resolve_cache
 from .atom37 import ATOM37_INDEX, scatter_atom37
-from .structure_prediction import PAE_BINS, StructureModelOutput
+from .structure_prediction import PAE_BINS, StructureModelOutput, reduce_samples
 
 
 def _build_boltz_atom37_table() -> np.ndarray:
@@ -45,7 +46,8 @@ def _build_boltz_atom37_table() -> np.ndarray:
 _BOLTZ_TOKATOM_TO_ATOM37 = _build_boltz_atom37_table()
 
 
-def load_boltz2(checkpoint_path=Path("~/.boltz/boltz2_conf.ckpt").expanduser()):
+def load_boltz2(checkpoint_path: Path | None = None):
+    checkpoint_path = resolve_cache(checkpoint_path, "boltz", "boltz2_conf.ckpt")
     if not checkpoint_path.exists():
         print(f"Downloading Boltz checkpoint to {checkpoint_path}")
         cache = checkpoint_path.parent
@@ -131,9 +133,10 @@ class StructureWriter:
 
 def load_features_and_structure_writer(
     input_yaml_str: str,
-    cache=Path("~/.boltz/").expanduser(),
+    cache=None,
 ) -> PyTree:
     print("Loading data")
+    cache = resolve_cache(cache, "boltz", create=True)
     out_dir_handle = (
         TemporaryDirectory()
     )  # this is sketchy -- we have to remember not to let this get garbage collected
@@ -459,13 +462,4 @@ class MultiSampleBoltz2Loss(LossTerm):
         vs, auxs = jax.vmap(apply_loss_to_single_sample)(
             jax.random.split(key, self.num_samples)
         )
-        sortperm = jnp.argsort(vs)
-
-        def _sort_if_scalar(v):
-            # Only sort+list per-sample scalar metrics. Non-scalar aux leaves
-            # (predicted structures, full PSSMs, etc.) pass through unchanged.
-            if isinstance(v, jax.Array) and v.shape == (self.num_samples,):
-                return list(v[sortperm])
-            return v
-
-        return self.reduction(vs), jax.tree.map(_sort_if_scalar, auxs)
+        return reduce_samples(vs, auxs, self.reduction, self.num_samples)

--- a/src/mosaic/losses/esmc.py
+++ b/src/mosaic/losses/esmc.py
@@ -19,6 +19,7 @@ import esmjfold2
 from esmjfold2.esmc import ESMCForMaskedLM
 
 from ..common import TOKENS, LossTerm
+from ..cache import cache_dir
 
 ESMC_VOCAB_SIZE = 64
 _CHECKPOINTS = {
@@ -48,7 +49,7 @@ def load_esmc(model_name: str = "esmc_300m", *, dtype=None) -> ESMCForMaskedLM:
 
     checkpoint = _CHECKPOINTS.get(model_name, model_name)
     torch_model = TorchESMC.from_pretrained(
-        checkpoint, dtype=dtype or torch.float32
+        checkpoint, dtype=dtype or torch.float32, cache_dir=cache_dir() / "huggingface"
     ).eval()
     model = esmjfold2.from_torch(torch_model)
     del torch_model

--- a/src/mosaic/losses/esmfold2.py
+++ b/src/mosaic/losses/esmfold2.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import functools
 
 import equinox as eqx
@@ -17,7 +19,11 @@ from esmjfold2.experimental import ESMFold2Experimental as _JaxESMFold2Experimen
 from esmjfold2.esmc import ESMC, ESMCForMaskedLM
 
 from mosaic.common import LossTerm, LinearCombination, TOKENS
-from mosaic.losses.structure_prediction import StructureModelOutput, PAE_BINS
+from mosaic.losses.structure_prediction import (
+    StructureModelOutput,
+    PAE_BINS,
+    reduce_samples,
+)
 from mosaic.losses.atom37 import ATOM37_INDEX, scatter_atom37
 from mosaic.losses.transformations import norm_gradient
 
@@ -50,7 +56,7 @@ class EsmFold2FeaturePack(eqx.Module):
     # Frozen throughout design.
     target_lm_hidden: Float[Array, "B L NL D"]
     # Per-atom mapping to one of 37 atom37 slots (-1 = no slot).
-    atom37_idx: Int[Array, "A"]
+    atom37_idx: Int[Array, " A"]
     # Backbone atom index in the per-atom layout, stacked N/CA/C/O.
     backbone_atom_idx: Int[Array, "4 L"]
     # Whether the forward refreshes the binder in-loop from argmax(PSSM) —
@@ -202,7 +208,7 @@ def esmfold2_forward_from_trunk(
 
 def distogram_bin_centers(
     n_bins: int, min_dist: float, max_dist: float,
-) -> Float[Array, "Bins"]:
+) -> Float[Array, " Bins"]:
     """Midpoints of `linspace(min_dist, max_dist, n_bins + 1)`. The release
     `ESMFold2-Fast` checkpoint uses (2.0, 22.0, 64); `ESMFold2-Experimental-*`
     uses (2.0, 52.0, 128).
@@ -221,9 +227,9 @@ def _to_structure_model_output(
     full_sequence: Float[Array, "L 20"],
     sample_atom_coords: Float[Array, "1 A 3"],
     distogram_logits: Float[Array, "1 L L Bins"],
-    distogram_bins: Float[Array, "Bins"],
+    distogram_bins: Float[Array, " Bins"],
     confidence: dict,
-    atom37_idx: Int[Array, "A"],
+    atom37_idx: Int[Array, " A"],
     backbone_atom_idx: Int[Array, "4 L"],
 ) -> StructureModelOutput:
     """Pack esmjfold2 outputs into mosaic's `StructureModelOutput`.
@@ -264,12 +270,60 @@ def _to_structure_model_output(
 # ---------------------------------------------------------------------------
 
 
+def _prepare_esmfold2_inputs(
+    pack: EsmFold2FeaturePack,
+    pssm: Float[Array, "N 20"] | None,
+    res_type_perm: Float[Array, "20 33"],
+    *,
+    geom_templates: ResidueAtomTemplates | None = None,
+    esmc: ESMC | None = None,
+    esmc_token_of_aa: Int[Array, "20"] | None = None,
+    refresh_lm: bool = False,
+):
+    """Apply sequence-dependent updates shared by single- and multi-sample forwards."""
+    features = pack.features
+    lm_hidden = pack.target_lm_hidden
+    atom37_idx = pack.atom37_idx
+    backbone_atom_idx = pack.backbone_atom_idx
+
+    if pssm is not None:
+        features = set_binder_sequence(pssm, features, res_type_perm)
+        if geom_templates is not None:
+            features, atom37_idx, backbone_atom_idx = refresh_binder_geometry(
+                features, pssm, geom_templates, atom37_idx, backbone_atom_idx
+            )
+        if refresh_lm:
+            lm_hidden = recompute_binder_lm_hidden(
+                esmc, esmc_token_of_aa, lm_hidden, pssm
+            )
+
+    # `full_sequence` carries every token's identity (like every other model
+    # wrapper), not just the binder — `res_type @ res_type_perm.T` inverts the
+    # one-hot `res_type` back to the 20-dim alphabet (target identities included;
+    # consumers such as proteina / protein_mpnn read the target slice). The
+    # binder slots are then set to the exact soft PSSM (the design region).
+    res_type = features.res_type[0]
+    if res_type.ndim == 1:
+        res_type = jax.nn.one_hot(res_type, res_type_perm.shape[1])
+    full_sequence = res_type @ res_type_perm.T
+    if pssm is not None:
+        full_sequence = full_sequence.at[: pssm.shape[0]].set(pssm)
+
+    return (
+        features,
+        lm_hidden,
+        atom37_idx,
+        backbone_atom_idx,
+        full_sequence,
+    )
+
+
 def forward_with_pssm(
     esmf: ESMFold2,
     pack: EsmFold2FeaturePack,
     pssm: Float[Array, "N 20"] | None,
     res_type_perm: Float[Array, "20 33"],
-    distogram_bins: Float[Array, "Bins"],
+    distogram_bins: Float[Array, " Bins"],
     *,
     key,
     num_loops: int,
@@ -294,26 +348,17 @@ def forward_with_pssm(
     the binder chain and splices it into `target_lm_hidden` (see
     `recompute_binder_lm_hidden`); requires `esmc` and `esmc_token_of_aa`.
     """
-    features = pack.features
-    L_total = features.res_type.shape[1]
-
-    # LM features: cached UNK by default; `refresh_lm` recomputes them from the
-    # argmax each step (sequence-tracking).
-    lm_hidden = pack.target_lm_hidden
-    # atom37 / backbone scaffolding tracks the atom layout; the geom refresh
-    # repacks it, so those are rebuilt alongside (the pack's are stale then).
-    atom37_idx = pack.atom37_idx
-    backbone_atom_idx = pack.backbone_atom_idx
-    if pssm is not None:
-        features = set_binder_sequence(pssm, features, res_type_perm)
-        if geom_templates is not None:
-            features, atom37_idx, backbone_atom_idx = refresh_binder_geometry(
-                features, pssm, geom_templates, atom37_idx, backbone_atom_idx
-            )
-        if refresh_lm:
-            lm_hidden = recompute_binder_lm_hidden(
-                esmc, esmc_token_of_aa, lm_hidden, pssm
-            )
+    features, lm_hidden, atom37_idx, backbone_atom_idx, full_sequence = (
+        _prepare_esmfold2_inputs(
+            pack,
+            pssm,
+            res_type_perm,
+            geom_templates=geom_templates,
+            esmc=esmc,
+            esmc_token_of_aa=esmc_token_of_aa,
+            refresh_lm=refresh_lm,
+        )
+    )
 
     k_trunk, k_heads = jax.random.split(key)
     ctx, z = esmfold2_trunk(
@@ -327,19 +372,9 @@ def forward_with_pssm(
         )
     )
 
-    # `full_sequence` carries every token's identity (like every other model
-    # wrapper), not just the binder — `res_type @ res_type_perm.T` inverts the
-    # one-hot `res_type` back to the 20-dim alphabet (target identities included;
-    # consumers such as proteina / protein_mpnn read the target slice). The
-    # binder slots are then set to the exact soft PSSM (the design region).
-    full_seq = features.res_type[0] @ res_type_perm.T
-    if pssm is not None:
-        N = pssm.shape[0]
-        full_seq = full_seq.at[:N].set(pssm)
-
     return _to_structure_model_output(
         features=features,
-        full_sequence=full_seq,
+        full_sequence=full_sequence,
         sample_atom_coords=sample_atom_coords,
         distogram_logits=distogram_logits,
         distogram_bins=distogram_bins,
@@ -350,7 +385,7 @@ def forward_with_pssm(
 
 
 class ESMFold2Loss(LossTerm):
-    """Mosaic-style loss wrapping an ESMFold2 forward.
+    """Mosaic loss sharing one trunk across one or more diffusion samples.
 
     Three optional knobs control how the binder is represented during
     optimization:
@@ -371,10 +406,12 @@ class ESMFold2Loss(LossTerm):
     pack: EsmFold2FeaturePack
     loss: LossTerm | LinearCombination
     res_type_perm: Float[Array, "20 33"]
-    distogram_bins: Float[Array, "Bins"]
+    distogram_bins: Float[Array, " Bins"]
     num_loops: int = eqx.field(static=True)
     num_sampling_steps: int = eqx.field(static=True)
     msa_max_depth: int | None = eqx.field(static=True)
+    num_samples: int = eqx.field(static=True, default=1)
+    reduction: Callable = eqx.field(static=True, default=jnp.mean)
     # In-loop binder geometry refresh. None = fixed placeholder backbone
     # (default). A pytree of arrays, so an ordinary (non-static) leaf.
     geom_templates: ResidueAtomTemplates | None = None
@@ -386,20 +423,54 @@ class ESMFold2Loss(LossTerm):
     refresh_lm: bool = eqx.field(static=True, default=False)
 
     def __call__(self, sequence: Float[Array, "N 20"], *, key):
-        smo = forward_with_pssm(
-            self.esmf, self.pack, sequence,
-            self.res_type_perm,
-            self.distogram_bins,
-            key=key,
-            num_loops=self.num_loops,
-            num_sampling_steps=self.num_sampling_steps,
-            msa_max_depth=self.msa_max_depth,
-            geom_templates=self.geom_templates,
-            esmc=self.esmc,
-            esmc_token_of_aa=self.esmc_token_of_aa,
-            refresh_lm=self.refresh_lm,
+        features, lm_hidden, atom37_idx, backbone_atom_idx, full_sequence = (
+            _prepare_esmfold2_inputs(
+                self.pack,
+                sequence,
+                self.res_type_perm,
+                geom_templates=self.geom_templates,
+                esmc=self.esmc,
+                esmc_token_of_aa=self.esmc_token_of_aa,
+                refresh_lm=self.refresh_lm,
+            )
         )
-        return self.loss(sequence, smo, key=key)
+
+        k_trunk, k_samples = jax.random.split(key)
+        ctx, z = esmfold2_trunk(
+            self.esmf,
+            features,
+            lm_hidden,
+            k_trunk,
+            num_loops=self.num_loops,
+            msa_max_depth=self.msa_max_depth,
+        )
+
+        def single_sample(sample_key):
+            sample_atom_coords, distogram_logits, confidence = (
+                esmfold2_forward_from_trunk(
+                    self.esmf,
+                    ctx,
+                    z,
+                    sample_key,
+                    num_sampling_steps=self.num_sampling_steps,
+                )
+            )
+            output = _to_structure_model_output(
+                features=features,
+                full_sequence=full_sequence,
+                sample_atom_coords=sample_atom_coords,
+                distogram_logits=distogram_logits,
+                distogram_bins=self.distogram_bins,
+                confidence=confidence,
+                atom37_idx=atom37_idx,
+                backbone_atom_idx=backbone_atom_idx,
+            )
+            return self.loss(sequence, output, key=sample_key)
+
+        sample_keys = jax.random.split(k_samples, self.num_samples)
+        values, auxiliary = jax.vmap(single_sample)(sample_keys)
+        return reduce_samples(values, auxiliary, self.reduction, self.num_samples)
+
 
 class StackedEsmFold2(LossTerm):
     """ Share the same ESMC model across multiple ESMFold models to save VRAM."""
@@ -669,9 +740,9 @@ def refresh_binder_geometry(
     features: Features,
     pssm: Float[Array, "N 20"],
     tmpl: ResidueAtomTemplates,
-    atom37_idx: Int[Array, "A"],
+    atom37_idx: Int[Array, " A"],
     backbone_atom_idx: Int[Array, "4 L"],
-) -> tuple[Features, Int[Array, "A"], Int[Array, "4 L"]]:
+) -> tuple[Features, Int[Array, " A"], Int[Array, "4 L"]]:
     """Rebuild the atom axis with the argmax(pssm) binder residues' atoms
     **tightly** packed at the front (native order), the target atoms shifted to
     sit immediately after, and zero-padding at the end.

--- a/src/mosaic/losses/of3.py
+++ b/src/mosaic/losses/of3.py
@@ -14,7 +14,11 @@ import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, Float
 from mosaic.common import LinearCombination, LossTerm
-from mosaic.losses.structure_prediction import PAE_BINS, StructureModelOutput
+from mosaic.losses.structure_prediction import (
+    PAE_BINS,
+    StructureModelOutput,
+    reduce_samples,
+)
 
 import equinox as eqx
 from jopenfold3.batch import Batch
@@ -215,13 +219,4 @@ class MultiSampleOF3Loss(LossTerm):
             return self.loss(sequence=sequence, output=output, key=key)
 
         vs, auxs = jax.vmap(single_sample)(jax.random.split(key, self.num_samples))
-        sortperm = jnp.argsort(vs)
-
-        def _sort_if_scalar(v):
-            # Only sort+list per-sample scalar metrics. Non-scalar aux leaves
-            # (predicted structures, full PSSMs, etc.) pass through unchanged.
-            if isinstance(v, jax.Array) and v.shape == (self.num_samples,):
-                return list(v[sortperm])
-            return v
-
-        return self.reduction(vs), jax.tree.map(_sort_if_scalar, auxs)
+        return reduce_samples(vs, auxs, self.reduction, self.num_samples)

--- a/src/mosaic/losses/opendde.py
+++ b/src/mosaic/losses/opendde.py
@@ -1,22 +1,23 @@
 """Mosaic loss integration for OpenDDE (the `jopendde` JAX/Equinox port).
 
-OpenDDE is an AF3-style all-atom co-folding model, so this mirrors `losses/of3.py`
-(the OpenFold3 backend). The differentiable design signal rides the distogram
+The differentiable design signal rides the distogram
 (`distogram_logits`; cf. `DistogramIPTMProxy`, `BinderTargetContact`); pae/pLDDT
 are consumed as scored values, not as a gradient channel.
 
 The binder is allocated at a fixed poly-Trp (max-atom) budget so a candidate
 panel shares one JIT compile (`OpenDDEModel.binder_features` -> an
-`OpenDDEFeatures`). `set_binder_sequence` injects the designed PSSM *and*
+`OpenDDEDesignFeatures`). `set_binder_sequence` injects the designed PSSM *and*
 rewrites the binder's atom + structural-token features from `argmax(PSSM)` each
 step via `refresh_binder_geometry` (under `stop_gradient`), so the trunk /
 diffusion always see the *designed* residues' side chains -- not the
 placeholder's -- while the gradient still flows only through `restype` /
-`profile` / MSA. `OpenDDEFeatures` carries the per-residue templates + binder
-extents the refresh needs (see `OpenDDEFeatures`, `OpenDDEResidueTemplates`).
+`profile` / MSA. `OpenDDEDesignFeatures` carries atom templates and binder
+extents the refresh needs (see `OpenDDEDesignFeatures`, `OpenDDEAtomTemplates`).
 """
 
 from __future__ import annotations
+
+from collections.abc import Callable
 
 import equinox as eqx
 import jax
@@ -30,7 +31,7 @@ from jopendde.transformer import rearrange_qk_to_dense_trunk
 
 from mosaic.common import TOKENS, LinearCombination, LossTerm
 from mosaic.losses.atom37 import scatter_atom37
-from mosaic.losses.structure_prediction import StructureModelOutput
+from mosaic.losses.structure_prediction import StructureModelOutput, reduce_samples
 
 # OpenDDE `restype` indices 0-19 are the standard AAs in mosaic's TOKENS order
 # ("ARNDCQEGHILKMFPSTWYV"); 20=UNK, 21-30=nucleic, 31=GAP. The mosaic-20 ->
@@ -90,31 +91,19 @@ def _inject_soft_pssm(
 # only through `restype` / `profile` / MSA (the refresh runs under
 # `stop_gradient`).
 #
-# Two variable-length axes are tight-packed at the front (native order), the
-# target's atoms/structural-tokens shifted to sit immediately after, and the
-# tail masked:
-#   * the ATOM axis  -- per-residue atom counts vary with composition;
-#   * the STRUCTURAL-TOKEN axis -- every protein residue emits a backbone + a
-#     sidechain sub-token EXCEPT Gly (backbone only). To keep the structural
-#     token count fixed at 2 per binder residue (so a candidate panel shares one
-#     compile), Gly's absent sidechain token is kept as a *phantom* token that
-#     no atom maps to; empirically it contributes no coordinates and negligible
-#     attention leakage, so no structural-token mask is threaded (all jopendde
-#     `pair_mask=None`).
+# Atom fields are tight-packed at the front of their fixed poly-Trp buffer;
+# target atoms shift after the packed binder and the remaining tail is masked.
+# Structural-token shape remains fixed at two tokens per binder residue. Gly's
+# absent sidechain token is retained as a phantom token with no mapped atom.
 #
-# `ref_pos` is a per-residue reference conformer that the featurizer re-orients
-# randomly every call (centralize -> uniform SO(3) rotation -> U(-1,1)^3
-# translation; the model is trained to be robust to it). The refresh replicates
-# that augmentation under JIT, keyed off the loss key, rather than baking in one
-# fixed orientation. Template conformers are bit-exact to the featurizer's CCD
-# reference (Kabsch RMSD 0). The target keeps its single host-featurized
-# orientation -- constant across a panel, so it introduces no ranking bias.
+# Binder `ref_pos` conformers receive a fresh random rigid augmentation on each
+# loss call. Target conformers retain their featurized orientation.
 
 MAX_ATOMS_PER_RES = 15  # C-terminal Trp; the max atom budget across the 20 AAs.
 MAX_STRUCT_PER_RES = 2  # protein backbone + sidechain sub-token.
 
 
-class OpenDDEResidueTemplates(eqx.Module):
+class OpenDDEAtomTemplates(eqx.Module):
     """Per-residue (mosaic-20 / ``TOKENS`` order) OpenDDE atom + structural-token
     templates, in two contexts: ``int`` (internal / N-terminal) and ``cterm``
     (C-terminal, which carries an extra OXT atom). Built once on the host from
@@ -144,18 +133,17 @@ class OpenDDEResidueTemplates(eqx.Module):
     max_struct: int = eqx.field(static=True, default=MAX_STRUCT_PER_RES)
 
 
-def build_opendde_templates(featurize_one) -> OpenDDEResidueTemplates:
+def build_opendde_atom_templates(featurize_one) -> OpenDDEAtomTemplates:
     """Build the per-residue templates by featurizing each amino acid in a
     tripeptide context and reading its atom block. ``featurize_one(seq)`` returns
-    a jopendde ``Features`` for a single protein chain ``seq`` (see
-    ``OpenDDEModel``); it is called 40 times (20 AAs x 2 contexts) on the host.
+    a jopendde ``Features`` for a single protein chain and is called for 20
+    amino acids in two contexts.
 
     Internal templates come from the middle residue of ``G{aa}G``; C-terminal
-    templates (with OXT) from the last residue of ``GG{aa}``. ``ref_pos`` is
-    context/checkpoint independent, so the result is process-cached by the model.
+    templates (with OXT) from the last residue of ``GG{aa}``.
     """
     print(
-        "build_opendde_templates: featurizing 40 tripeptides on the host "
+        "build_opendde_atom_templates: featurizing 40 tripeptides on the host "
         "(slow); this runs once and is cached to disk."
     )
 
@@ -218,7 +206,7 @@ def build_opendde_templates(featurize_one) -> OpenDDEResidueTemplates:
             if ns < ms:  # Gly: the phantom sidechain token gets a benign frame
                 s_froff[ci, i, 1] = s_froff[ci, i, 0]
 
-    return OpenDDEResidueTemplates(
+    return OpenDDEAtomTemplates(
         ref_pos=jnp.asarray(ref_pos), ref_element=jnp.asarray(ref_el),
         ref_charge=jnp.asarray(ref_ch), ref_atom_name_chars=jnp.asarray(ref_nm),
         n_atoms=jnp.asarray(n_at), disto_off=jnp.asarray(d_off), pae_off=jnp.asarray(p_off),
@@ -244,8 +232,7 @@ def _random_rotations(key: jax.Array, n: int) -> Float[Array, "n 3 3"]:
 
 def _rebuild_dense_trunk(ref_pos, atom_to_token_idx):
     """Rebuild OpenDDE's windowed atom-pair features (`d_lm`, `v_lm`, `pad_info`)
-    from the repacked atoms, mirroring `opendde.model.update_input_feature_dict`
-    (Algorithm 5, lines 1-3): windowed pairwise `ref_pos` differences and a
+    from the repacked atoms: windowed pairwise `ref_pos` differences and a
     same-residue validity mask. `atom_to_token_idx` (one token per residue)
     stands in for `ref_space_uid` -- `v_lm` only tests equality."""
     a2t = atom_to_token_idx.astype(jnp.float32)
@@ -261,7 +248,7 @@ def _rebuild_dense_trunk(ref_pos, atom_to_token_idx):
 def refresh_binder_geometry(
     feat: Features,
     pssm: Float[Array, "L 20"],
-    tmpl: OpenDDEResidueTemplates,
+    tmpl: OpenDDEAtomTemplates,
     key: jax.Array,
     *,
     binder_length: int,
@@ -381,11 +368,11 @@ def refresh_binder_geometry(
     )
 
 
-class OpenDDEFeatures(eqx.Module):
+class OpenDDEDesignFeatures(eqx.Module):
     """A design bundle from `OpenDDEModel.binder_features`: the poly-Trp jopendde
     `Features` together with everything the in-loop refresh needs.
 
-    The inner `Features` is a max-atom (poly-Trp) placeholder; `templates` +
+    The inner `Features` is a max-atom (poly-Trp) placeholder; `atom_templates` +
     `binder_length` / `binder_atom_alloc` are the per-residue conformer tables
     and (static) binder extents `refresh_binder_geometry` consumes. Bundling
     keeps that metadata attached to the features so `set_binder_sequence` can
@@ -394,14 +381,14 @@ class OpenDDEFeatures(eqx.Module):
     """
 
     features: Features
-    templates: OpenDDEResidueTemplates
+    atom_templates: OpenDDEAtomTemplates
     binder_length: int = eqx.field(static=True, default=0)
     binder_atom_alloc: int = eqx.field(static=True, default=0)
 
 
 def set_binder_sequence(
     new_sequence: Float[Array, "N 20"],
-    features: OpenDDEFeatures,
+    features: OpenDDEDesignFeatures,
     key: jax.Array,
 ) -> Features:
     """Set the binder identity of design `features` and refresh its geometry.
@@ -417,15 +404,25 @@ def set_binder_sequence(
     conformers (the featurizer re-orients them every call; the model is trained
     robust to it).
     """
-    if not isinstance(features, OpenDDEFeatures):
+    if not isinstance(features, OpenDDEDesignFeatures):
         raise TypeError(
-            "set_binder_sequence expects OpenDDEFeatures (from "
+            "set_binder_sequence expects OpenDDEDesignFeatures (from "
             "OpenDDEModel.binder_features); got "
             f"{type(features).__name__}. Target-only Features have no binder to set."
         )
+    if new_sequence.shape[-1] != 20:
+        raise ValueError(
+            "OpenDDE binder PSSM must have 20 columns; "
+            f"got {new_sequence.shape[-1]}"
+        )
+    if new_sequence.shape[0] != features.binder_length:
+        raise ValueError(
+            "OpenDDE binder PSSM length does not match design features: "
+            f"expected {features.binder_length}, got {new_sequence.shape[0]}"
+        )
     feat = _inject_soft_pssm(new_sequence, features.features)
     return refresh_binder_geometry(
-        feat, new_sequence, features.templates, key,
+        feat, new_sequence, features.atom_templates, key,
         binder_length=features.binder_length,
         binder_atom_alloc=features.binder_atom_alloc,
     )
@@ -516,17 +513,16 @@ def opendde_forward_from_trunk(
 
 
 class MultiSampleOpenDDELoss(LossTerm):
-    """Run the trunk once, then vmap diffusion/confidence/loss over samples.
+    """Run the trunk once, then vmap diffusion, confidence, and loss.
 
-    Mirrors `MultiSampleOF3Loss`. `vmap` over samples costs `num_samples ×`
-    memory; swap `jax.vmap` for `jax.lax.map` if constrained.
+    Vmap trades memory for throughput across samples.
     """
 
     model: JaxOpenDDE
-    # The design features (poly-Trp binder + refresh templates/extents). Setting
+    # Poly-Trp design features plus atom templates and binder extents. Setting
     # the binder sequence always refreshes its atom + structural-token geometry,
-    # so the trunk sees the designed side chains (see `OpenDDEFeatures`).
-    features: OpenDDEFeatures
+    # so the trunk sees the designed side chains (see `OpenDDEDesignFeatures`).
+    features: OpenDDEDesignFeatures
     loss: LossTerm | LinearCombination
     dense_atom_to_atom37: Int[Array, "32 Adense"]
     num_cycles: int = eqx.field(static=True, default=4)
@@ -535,7 +531,7 @@ class MultiSampleOpenDDELoss(LossTerm):
     pae_bin_params: tuple = eqx.field(static=True, default=(0.0, 32.0, 64))
     plddt_bin_params: tuple = eqx.field(static=True, default=(0.0, 1.0, 50))
     stop_grad_conf_coords: bool = eqx.field(static=True, default=False)
-    reduction: any = jnp.mean
+    reduction: Callable = eqx.field(static=True, default=jnp.mean)
 
     def __call__(self, sequence: Float[Array, "N 20"], key):
         # One geometry draw shared across diffusion samples (the featurizer
@@ -545,22 +541,16 @@ class MultiSampleOpenDDELoss(LossTerm):
         s_inputs, s, z = self.model.get_pairformer_output(feat, self.num_cycles)
 
         def single_sample(key):
+            model_key, loss_key = jax.random.split(key)
             output = opendde_forward_from_trunk(
-                self.model, feat, s_inputs, s, z, key,
+                self.model, feat, s_inputs, s, z, model_key,
                 n_step=self.n_step,
                 dense_atom_to_atom37=self.dense_atom_to_atom37,
                 pae_bin_params=self.pae_bin_params,
                 plddt_bin_params=self.plddt_bin_params,
                 stop_grad_conf_coords=self.stop_grad_conf_coords,
             )
-            return self.loss(sequence=sequence, output=output, key=key)
+            return self.loss(sequence=sequence, output=output, key=loss_key)
 
         vs, auxs = jax.vmap(single_sample)(jax.random.split(key, self.num_samples))
-        sortperm = jnp.argsort(vs)
-
-        def _sort_if_scalar(v):
-            if isinstance(v, jax.Array) and v.shape == (self.num_samples,):
-                return list(v[sortperm])
-            return v
-
-        return self.reduction(vs), jax.tree.map(_sort_if_scalar, auxs)
+        return reduce_samples(vs, auxs, self.reduction, self.num_samples)

--- a/src/mosaic/losses/promera.py
+++ b/src/mosaic/losses/promera.py
@@ -8,7 +8,11 @@ from jaxtyping import Array, Float
 
 from mosaic.common import LinearCombination, LossTerm
 from mosaic.losses.atom37 import ATOM37_INDEX, scatter_atom37
-from mosaic.losses.structure_prediction import PAE_BINS, StructureModelOutput
+from mosaic.losses.structure_prediction import (
+    PAE_BINS,
+    StructureModelOutput,
+    reduce_samples,
+)
 
 from jpromera.config import DIFFUSION, MSAS_PER_TRUNK_ITER, NTOKS
 from jpromera.feats import Feats
@@ -265,14 +269,8 @@ class JPromeraLoss(LossTerm):
         vs, auxs = jax.vmap(apply_loss_to_single_sample)(
             jax.random.split(key, self.num_samples)
         )
-        sortperm = jnp.argsort(vs)
-
-        def _sort_if_scalar(v):
-            if isinstance(v, jax.Array) and v.shape == (self.num_samples,):
-                return list(v[sortperm])
-            return v
-
-        return self.reduction(vs), {self.name: jax.tree.map(_sort_if_scalar, auxs)}
+        reduced, auxs = reduce_samples(vs, auxs, self.reduction, self.num_samples)
+        return reduced, {self.name: auxs}
 
 
 TINYPROT_RES = [

--- a/src/mosaic/losses/protein_mpnn.py
+++ b/src/mosaic/losses/protein_mpnn.py
@@ -260,7 +260,7 @@ def inverse_fold(
 
     gumbel = jax.random.gumbel(key, (binder_length, 20))
 
-    def seq_to_logits(sequence: Int[Array, "N"]):
+    def seq_to_logits(sequence: Int[Array, " N"]):
         full_sequence = output.full_sequence.at[:binder_length].set(
             jax.nn.one_hot(sequence, 20, dtype=jnp.int32)
         )

--- a/src/mosaic/losses/proteina.py
+++ b/src/mosaic/losses/proteina.py
@@ -97,7 +97,7 @@ def _torsion_feat(
 def _sidechain_feat(
     coords: Float[Array, "T 37 3"],
     atom_mask: Float[Array, "T 37"],
-    residue_types: Int[Array, "T"],
+    residue_types: Int[Array, " T"],
 ) -> Float[Array, "T 88"]:
     """Chi-angle one-hot features from atom37 coords.
 
@@ -125,7 +125,7 @@ def inverse_fold(
     denoiser: PyTree,
     decoder: PyTree,
     bb_ca: Float[Array, "N 3"],
-    mask: Bool[Array, "N"],
+    mask: Bool[Array, " N"],
     target: TargetCond,
     key: jax.Array,
 ) -> DecoderOutput:

--- a/src/mosaic/losses/protenix.py
+++ b/src/mosaic/losses/protenix.py
@@ -1,9 +1,5 @@
 import copy
 
-# set "PROTENIX_DATA_ROOT_DIR" env variable
-import os
-from pathlib import Path
-
 import gemmi
 import jax
 import jax.numpy as jnp
@@ -18,9 +14,11 @@ from protenix.protenij import Protenix as Protenij
 
 from mosaic.common import TOKENS, LinearCombination, LossTerm
 from mosaic.losses.atom37 import ATOM37_INDEX, scatter_atom37
-from mosaic.losses.structure_prediction import PAE_BINS, StructureModelOutput
-
-os.environ["PROTENIX_DATA_ROOT_DIR"] = str(Path("~/.protenix").expanduser())
+from mosaic.losses.structure_prediction import (
+    PAE_BINS,
+    StructureModelOutput,
+    reduce_samples,
+)
 
 
 def biotite_atom_to_gemmi_atom(atom):
@@ -302,13 +300,4 @@ class MultiSampleProtenixLoss(LossTerm):
         vs, auxs = jax.vmap(apply_loss_to_single_sample)(
             jax.random.split(key, self.num_samples)
         )
-        sortperm = jnp.argsort(vs)
-
-        def _sort_if_scalar(v):
-            # Only sort+list per-sample scalar metrics. Non-scalar aux leaves
-            # (predicted structures, full PSSMs, etc.) pass through unchanged.
-            if isinstance(v, jax.Array) and v.shape == (self.num_samples,):
-                return list(v[sortperm])
-            return v
-
-        return self.reduction(vs), jax.tree.map(_sort_if_scalar, auxs)
+        return reduce_samples(vs, auxs, self.reduction, self.num_samples)

--- a/src/mosaic/losses/structure_prediction.py
+++ b/src/mosaic/losses/structure_prediction.py
@@ -15,13 +15,36 @@ from ..common import LossTerm
 PAE_BINS = np.arange(start=0.25, stop=32.0, step=0.5)
 
 
+def reduce_samples(values, auxiliary, reduction, num_samples):
+    """Reduce per-sample loss ``values`` and reorder scalar aux metrics.
+
+    ``values`` has shape ``(num_samples,)``. Per-sample scalar aux leaves (also
+    shape ``(num_samples,)``) are sorted into ascending-loss order and returned
+    as lists; non-scalar leaves (predicted structures, full PSSMs, ...) pass
+    through unchanged. Shared by every multi-sample structure-prediction loss.
+
+    The sorted list is returned even for ``num_samples == 1`` (a 1-element
+    list), so aux shape is uniform across sample counts and models. Consumers
+    that look up a metric by key (e.g. ``biohub_optimizer``) match the key
+    anywhere in the tree path so the list wrapping does not hide it.
+    """
+    sortperm = jnp.argsort(values)
+
+    def _sort_if_scalar(value):
+        if isinstance(value, jax.Array) and value.shape == (num_samples,):
+            return list(value[sortperm])
+        return value
+
+    return reduction(values), jax.tree.map(_sort_if_scalar, auxiliary)
+
+
 class StructureModelOutput(eqx.Module):
     distogram_logits: Float[Array, "N N Bins"]
-    distogram_bins: Float[Array, "Bins"]
-    plddt: Float[Array, "N"]
+    distogram_bins: Float[Array, " Bins"]
+    plddt: Float[Array, " N"]
     pae: Float[Array, "N N"]
     pae_logits: Float[Array, "N N Bins"]
-    pae_bins: Float[Array, "Bins"]
+    pae_bins: Float[Array, " Bins"]
     structure_coordinates: Array  # all-atom coords, shape varies by model
     backbone_coordinates: Float[Array, "N 4 3"]
     # Per-token identity, a 20-d distribution in mosaic-20 / `common.TOKENS`
@@ -30,8 +53,8 @@ class StructureModelOutput(eqx.Module):
     # native alphabets coincide here or are remapped to it), so `argmax` indexes
     # the canonical alphabet. Relied on by `to_pdb`, proteina, protein_mpnn.
     full_sequence: Float[Array, "N 20"]
-    asym_id: Float[Array, "N"]
-    residue_idx: Int[Array, "N"]
+    asym_id: Float[Array, " N"]
+    residue_idx: Int[Array, " N"]
     # Canonical atom37 view of the predicted heavy atoms (see
     # `mosaic.losses.atom37.ATOM37_NAMES`, == AlphaFold `atom_types` order).
     # Populated by every model wrapper.
@@ -45,34 +68,50 @@ class StructureModelOutput(eqx.Module):
         Identity comes from `full_sequence` (mosaic-20 order, see field note),
         chains from `asym_id`, atoms + names from `atom37_coords` / `atom37_mask`
         (canonical AF2 `atom_types` order), b-factors from `plddt` (scaled to the
-        0–100 pLDDT convention). Residues are renumbered 1-based *per chain*
-        (PDB convention), independent of each model's internal `residue_idx`.
+        0–100 pLDDT convention), and residue numbers directly from the model's `residue_idx`, without
+        renumbering.
 
         Covers protein complexes only: atom37 is heavy-atom / standard-residue,
         so ligand or non-canonical chains aren't represented (use a model's
         native chain_infos writer for those).
         """
-        from mosaic.alphafold.common.protein import Protein
-        from mosaic.alphafold.common.protein import to_pdb as _to_pdb
+        from mosaic.alphafold.common import residue_constants
+        from mosaic.alphafold.common.protein import PDB_CHAIN_IDS
 
         mask = np.asarray(self.atom37_mask)
         aatype = np.asarray(self.full_sequence).argmax(-1).astype(np.int32)
         asym = np.asarray(self.asym_id).astype(np.int32)
-        # 1-based residue number within each chain (robust to chain ordering).
-        resnum = np.zeros(asym.shape[0], dtype=np.int32)
-        seen: dict[int, int] = {}
-        for i, a in enumerate(asym.tolist()):
-            seen[a] = seen.get(a, 0) + 1
-            resnum[i] = seen[a]
-        prot = Protein(
-            atom_positions=np.asarray(self.atom37_coords),
-            atom_mask=mask,
-            aatype=aatype,
-            residue_index=resnum,
-            chain_index=asym,
-            b_factors=np.asarray(self.plddt)[:, None] * mask * 100.0,
-        )
-        return gemmi.read_pdb_string(_to_pdb(prot))
+        resnum = np.asarray(self.residue_idx).astype(np.int32)
+        coords = np.asarray(self.atom37_coords)
+        confidence = np.asarray(self.plddt) * 100.0
+        restypes = residue_constants.restypes + ["X"]
+
+        structure = gemmi.Structure()
+        model = gemmi.Model("1")
+        for chain_id in dict.fromkeys(asym.tolist()):
+            chain = gemmi.Chain(PDB_CHAIN_IDS[chain_id])
+            for i in np.flatnonzero(asym == chain_id):
+                one_letter = restypes[aatype[i]]
+                residue = gemmi.Residue()
+                residue.name = residue_constants.restype_1to3.get(one_letter, "UNK")
+                residue.seqid = gemmi.SeqId(int(resnum[i]), " ")
+                for atom_name, position, present in zip(
+                    residue_constants.atom_types, coords[i], mask[i]
+                ):
+                    if present < 0.5:
+                        continue
+                    atom = gemmi.Atom()
+                    atom.name = atom_name
+                    atom.element = gemmi.Element(atom_name[0])
+                    atom.pos = gemmi.Position(*map(float, position))
+                    atom.occ = 1.0
+                    atom.b_iso = float(confidence[i])
+                    residue.add_atom(atom)
+                chain.add_residue(residue)
+            model.add_chain(chain)
+        structure.add_model(model)
+        structure.setup_entities()
+        return structure
 
     def chain_pair_iptm(self) -> dict[tuple[int, int], float]:
         """Interface pTM (iPTM) for every unordered pair of chains.
@@ -170,7 +209,7 @@ def predicted_tm_score(
 def contact_cross_entropy(
     distogram_logits: Float[Array, "N N Bins"],
     contact_dist: float,
-    bins: Float[Array, "Bins"],
+    bins: Float[Array, " Bins"],
 ) -> Float[Array, "... N N"]:
     """Compute partial entropy (under distogram) that D_ij < contact_dist."""
     assert bins.shape[-1] == distogram_logits.shape[-1]
@@ -188,7 +227,7 @@ def contact_cross_entropy(
 def contact_log_probability(
     distogram_logits: Float[Array, "... N N 64"],
     contact_dist: float,
-    bins: Float[Array, "Bins"],
+    bins: Float[Array, " Bins"],
 ) -> Float[Array, "... N N"]:
     """Compute log probability (under distogram) that D_ij < contact_dist."""
     assert bins.shape[-1] == distogram_logits.shape[-1]
@@ -324,14 +363,15 @@ class HelixLoss(LossTerm):
         return loss, {"helix": loss}
 
 
-
 class ESMFoldGlobularity(LossTerm):
     target_radius: float | None = None
     clamp_max: float = 27.0
 
-    def __call__(self, sequence: Float[Array, "N 20"], output: StructureModelOutput, key):
+    def __call__(
+        self, sequence: Float[Array, "N 20"], output: StructureModelOutput, key
+    ):
         n = sequence.shape[0]
-        probs = jax.nn.softmax(output.distogram_logits[:n, :n], axis=-1)    # [Lb, Lb, B]
+        probs = jax.nn.softmax(output.distogram_logits[:n, :n], axis=-1)  # [Lb, Lb, B]
         bins = jnp.minimum(output.distogram_bins, self.clamp_max)
         e_sq_dist = (probs * jnp.square(bins)).sum(-1)
         rg = jnp.sqrt(jnp.tril(e_sq_dist, k=-1).sum() / (n * n))

--- a/src/mosaic/losses/transformations.py
+++ b/src/mosaic/losses/transformations.py
@@ -88,8 +88,8 @@ class SetPositions(LossTerm):
     """Precomposes loss functional with function that maps a soft sequence of ONLY VARIABLE positions to a full binder sequence to eliminate constraints/penalties.
     WARNING: Be sure to call `sequence` *after* optimization, e.g. `loss.sequence(jax.nn.softmax(logits))`."""
 
-    wildtype: Int[Array, "N"] = eqx.field(converter=jnp.array)
-    variable_positions: Int[Array, "M"] = eqx.field(converter=jnp.array)
+    wildtype: Int[Array, " N"] = eqx.field(converter=jnp.array)
+    variable_positions: Int[Array, " M"] = eqx.field(converter=jnp.array)
     loss: LossTerm | LinearCombination
 
     def __call__(self, seq: Float[Array, "M 20"], *, key):
@@ -116,7 +116,7 @@ class SetPositions(LossTerm):
 class FixedPositionsPenalty(LossTerm):
     """Penalizes deviation from target at fixed positions using L2^2 loss. Might make optimization more difficult compared to `SetPositions` above, but is simpler"""
 
-    position_mask: Bool[Array, "N"] = eqx.field(converter=jnp.array)
+    position_mask: Bool[Array, " N"] = eqx.field(converter=jnp.array)
     target: Float[Array, "N 20"] = eqx.field(converter=jnp.array)
 
     def __call__(self, seq: Float[Array, "N 20"], *, key):

--- a/src/mosaic/models/af2.py
+++ b/src/mosaic/models/af2.py
@@ -1,3 +1,4 @@
+from mosaic.cache import resolve_cache
 from mosaic.structure_prediction import (
     StructurePredictionModel,
     TargetChain,
@@ -58,13 +59,13 @@ class AFOutput(eqx.Module):
     pae_logits: Float[Array, "N N 64"]
     pae_bin_centers: Float[Array, "64"]
     predicted_lddt_logits: Float[Array, "N 50"]
-    plddt: Float[Array, "N"]
+    plddt: Float[Array, " N"]
     structure_module: StructureModuleOutputs
     recycling_state: state.AlphaFoldState
 
 
-def load_af2(data_dir: str = "~/.alphafold", multimer=True):
-    data_dir = Path(data_dir).expanduser()
+def load_af2(data_dir: str | Path | None = None, multimer=True):
+    data_dir = resolve_cache(data_dir, "alphafold2")
 
     if not (data_dir / "params").exists():
         print(f"Downloading AF2 parameters to {data_dir}/params...")
@@ -379,7 +380,7 @@ class AlphaFold2(StructurePredictionModel):
     stacked_parameters: PyTree
     multimer: bool
 
-    def __init__(self, data_dir: str = "~/.alphafold", multimer=True):
+    def __init__(self, data_dir: str | Path | None = None, multimer=True):
         (forward_function, stacked_params) = load_af2(data_dir=data_dir, multimer=multimer)
         self.af2_forward = forward_function
         self.stacked_parameters = stacked_params

--- a/src/mosaic/models/boltzgen.py
+++ b/src/mosaic/models/boltzgen.py
@@ -35,10 +35,12 @@ from boltzgen.task.predict.writer import DesignWriter
 from jaxtyping import Array, Float, PyTree
 
 from ..util import pairwise_distance
+from ..cache import resolve_cache
 
 
 
-def load_boltzgen(checkpoint_dir=Path("~/.boltz/").expanduser(), model_diverse=True):
+def load_boltzgen(checkpoint_dir: Path | None = None, model_diverse=True):
+    checkpoint_dir = resolve_cache(checkpoint_dir, "boltzgen")
     checkpoints = ["boltzgen1_adherence.ckpt", "boltzgen1_diverse.ckpt"]
     if not all((checkpoint_dir / ckpt).exists() for ckpt in checkpoints):
         print(f"Downloading Boltz folding checkpoints to {checkpoint_dir}")
@@ -269,9 +271,10 @@ class BoltzGenWriter:
 
 def load_features_and_structure_writer(
     yaml_string: str,
-    moldir: Path = Path("~/.boltz/").expanduser() / "mols.zip",
+    moldir: Path | None = None,
     files: dict[str, Path] = {},
 ):
+    moldir = resolve_cache(moldir, "boltzgen", "mols.zip")
     with TemporaryDirectory() as temp_dir:
         with open(f"{temp_dir}/yaml.yaml", "w") as yaml_file:
             yaml_file.write(yaml_string)

--- a/src/mosaic/models/esmfold2.py
+++ b/src/mosaic/models/esmfold2.py
@@ -14,7 +14,8 @@ design) and `Full` (MSA-conditioned, for target prediction) variant:
 
 All expose mosaic's standard `StructurePredictionModel` interface; recycling
 (`recycling_steps`) and diffusion (`sampling_steps`) counts are per-call knobs
-on `build_loss` / `predict`, defaulting to the module globals
+on `build_loss` / `build_multisample_loss` / `predict`, defaulting to the
+module globals
 `_DEFAULT_NUM_LOOPS` / `_DEFAULT_NUM_SAMPLING_STEPS`.
 
 See `mosaic.losses.esmfold2` for the soft-sequence ESMC plumbing this
@@ -26,8 +27,6 @@ from __future__ import annotations
 import dataclasses
 import gc
 import hashlib
-import os
-from pathlib import Path
 
 import equinox as eqx
 import gemmi
@@ -54,6 +53,7 @@ from mosaic.losses.esmfold2 import (
     precompute_target_lm_hidden,
 )
 from mosaic.common import TOKENS
+from mosaic.cache import cache_dir
 from mosaic.losses.structure_prediction import IPTMLoss
 from mosaic.structure_prediction import (
     PolymerType,
@@ -68,25 +68,23 @@ JaxESMFold2 = JaxESMFold2Release | JaxESMFold2Experimental
 _DEFAULT_NUM_LOOPS = 3
 _DEFAULT_NUM_SAMPLING_STEPS = 14
 _DEFAULT_MSA_SERVER = "https://api.colabfold.com"
-_DEFAULT_MSA_CACHE = Path(
-    os.environ.get("MOSAIC_MSA_CACHE", "~/.cache/mosaic/msa")
-).expanduser()
 
 
 def _fetch_msa(sequence: str, max_sequences: int = 8192):
     """Query the ColabFold MSA server (via boltz's MMseqs2 client) for an a3m
     and return an `esm.utils.msa.MSA`. Cached by sequence hash under
-    `MOSAIC_MSA_CACHE` so repeated featurizations skip the network.
+    `MOSAIC_CACHE_DIR/msa` so repeated featurizations skip the network.
     """
     from boltz.data.msa.mmseqs2 import run_mmseqs2
     from esm.utils.msa import MSA
 
-    _DEFAULT_MSA_CACHE.mkdir(parents=True, exist_ok=True)
+    msa_cache = cache_dir() / "msa"
+    msa_cache.mkdir(parents=True, exist_ok=True)
     seq_hash = hashlib.sha256(sequence.encode("utf-8")).hexdigest()[:16]
-    a3m_path = _DEFAULT_MSA_CACHE / f"{seq_hash}.a3m"
+    a3m_path = msa_cache / f"{seq_hash}.a3m"
 
     if not a3m_path.exists():
-        tmp_prefix = _DEFAULT_MSA_CACHE / seq_hash
+        tmp_prefix = msa_cache / seq_hash
         result = run_mmseqs2(
             [sequence],
             prefix=str(tmp_prefix),
@@ -135,7 +133,9 @@ def _load_pretrained(
             esmc_precision="bf16",
         )
 
-    torch_model = TorchModelCls.from_pretrained(checkpoint, **kwargs).eval()
+    torch_model = TorchModelCls.from_pretrained(
+        checkpoint, cache_dir=cache_dir() / "huggingface", **kwargs
+    ).eval()
     torch_model._esmc = torch_model._esmc.to(dtype=torch.float32)
     if hasattr(torch_model, "_esmc_fp8"):
         torch_model._esmc_fp8 = False
@@ -263,7 +263,7 @@ class ESMFold2(StructurePredictionModel):
     esmf: JaxESMFold2
     esmc: ESMC
     res_type_perm: Float[Array, "20 33"]
-    distogram_bins: Float[Array, "Bins"]
+    distogram_bins: Float[Array, " Bins"]
     # ESMC input-id for each mosaic-20 residue (LM re-encoding).
     esmc_token_of_aa: Int[Array, "20"]
     unk_input_id: int = eqx.field(static=True)
@@ -361,6 +361,33 @@ class ESMFold2(StructurePredictionModel):
         first (`eqx.tree_at(lambda m: m.esmc, model, None)`) and splice a shared
         copy back in at call time — see `StackedEsmFold2PLL`.
         """
+        return self.build_multisample_loss(
+            loss=loss,
+            features=features,
+            recycling_steps=recycling_steps,
+            sampling_steps=sampling_steps,
+            num_samples=1,
+            msa_max_depth=msa_max_depth,
+            lm_dropout=lm_dropout,
+        )
+
+    def build_multisample_loss(
+        self,
+        *,
+        loss,
+        features,
+        recycling_steps: int = _DEFAULT_NUM_LOOPS,
+        sampling_steps: int = _DEFAULT_NUM_SAMPLING_STEPS,
+        num_samples: int = 4,
+        reduction=jnp.mean,
+        msa_max_depth: int | None = 1024,
+        lm_dropout: float = 0.0,
+    ):
+        """Build a loss that shares one trunk across multiple diffusion samples.
+
+        If ``lm_dropout`` is nonzero, the samples share one trunk dropout
+        realization; only diffusion and its downstream confidence/loss vary.
+        """
         esmf = self.esmf
         if lm_dropout:
             esmf = dataclasses.replace(esmf, lm_dropout=lm_dropout)
@@ -377,6 +404,8 @@ class ESMFold2(StructurePredictionModel):
             esmc=self.esmc,
             esmc_token_of_aa=self.esmc_token_of_aa,
             refresh_lm=features.refresh,
+            num_samples=num_samples,
+            reduction=reduction,
         )
 
     @eqx.filter_jit

--- a/src/mosaic/models/of3.py
+++ b/src/mosaic/models/of3.py
@@ -53,6 +53,7 @@ from mosaic.losses.of3 import (
 
 from mosaic.common import LinearCombination, LossTerm
 from mosaic.losses.structure_prediction import IPTMLoss
+from mosaic.cache import cache_dir
 from mosaic.structure_prediction import (
     PolymerType,
     StructurePrediction,
@@ -502,7 +503,7 @@ class OF3(StructurePredictionModel):
     def __init__(self, default_sampling_steps: int = 20, default_num_samples: int = 1):
         # load the model...
 
-        jax_model = OpenFold3.load()
+        jax_model = OpenFold3.load(cache_dir() / "openfold3" / "jax" / "of3")
         # Switch to vanilla ODE sampler
         jax_model = eqx.tree_at(
             lambda m: (

--- a/src/mosaic/models/opendde.py
+++ b/src/mosaic/models/opendde.py
@@ -1,37 +1,37 @@
 """Mosaic `StructurePredictionModel` wrapper for OpenDDE (the `jopendde` JAX
 port of Aureka's OpenDDE — an AF3-style all-atom co-folding model).
-
-`OpenDDEModelV1()` loads + converts the released checkpoint via
-`jopendde.Predictor` (only to build the JAX model's weights) and exposes mosaic's
-standard interface. This mirrors `models/of3.py`. Featurization is a separate,
-weight-free step (`_featurize`): it runs OpenDDE's torch data pipeline as plain
-function calls -- no model object, no checkpoint -- so the integration
-environment needs `torch` + the `opendde` package to featurize, but only the
-checkpoint to run the forward. The design loop itself is pure JAX. See
-`mosaic.losses.opendde` for the soft-sequence plumbing.
 """
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import hashlib
-import os
+import json
+import tempfile
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 
 import equinox as eqx
+import gemmi
 import jax
 import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, Float, Int
 
+from jopendde.features import Features
 from jopendde.model import OpenDDE as JaxOpenDDE
 
 from mosaic.common import LinearCombination, LossTerm
+from mosaic.cache import cache_dir
 from mosaic.losses.opendde import (
+    MAX_ATOMS_PER_RES,
+    MAX_STRUCT_PER_RES,
     MultiSampleOpenDDELoss,
-    OpenDDEFeatures,
-    OpenDDEResidueTemplates,
-    build_opendde_templates,
+    OpenDDEDesignFeatures,
+    OpenDDEAtomTemplates,
+    build_opendde_atom_templates,
     set_binder_sequence,
 )
 from mosaic.losses.structure_prediction import IPTMLoss
@@ -45,36 +45,27 @@ from mosaic.structure_prediction import (
 _DEFAULT_NUM_CYCLES = 4
 _DEFAULT_NUM_SAMPLING_STEPS = 20
 
-# opendde_v1 relative-position-encoding constants (config
-# `model.relative_position_encoding`). `generate_relp` is weight-free one-hot
-# index math, so featurization needs only these two ints -- never the checkpoint.
-# They're architecture-level: identical for OpenDDEModelV1 and OpenDDEModelAbag.
+# `opendde_v1` relative-position-encoding parameters.
 _RELP_R_MAX = 32
 _RELP_S_MAX = 2
 
-# Cache the torch-bound Predictor (checkpoint weights) so a repeated model build
-# doesn't reload it. Keyed by (model_name, checkpoint_file). Used ONLY to build
-# the JAX model's weights at construction; featurization is weight-free and needs
-# no Predictor (see `_featurize`).
-_PREDICTOR_CACHE: dict[tuple[str, str | None], object] = {}
-
 _MSA_SERVER = "https://api.colabfold.com"
-_MSA_CACHE = Path(os.environ.get("MOSAIC_MSA_CACHE", "~/.cache/mosaic/msa")).expanduser()
 
 
 def _target_a3m(sequence: str) -> str:
     """Fetch (and cache) an unpaired a3m for `sequence` from the ColabFold MMseqs2
     server, returning the a3m path. Cached by sequence hash under
-    `MOSAIC_MSA_CACHE`. Only called for chains with `use_msa=True`."""
+    `MOSAIC_CACHE_DIR/msa`. Only called for chains with `use_msa=True`."""
     from boltz.data.msa.mmseqs2 import run_mmseqs2
 
-    _MSA_CACHE.mkdir(parents=True, exist_ok=True)
+    msa_cache = cache_dir() / "msa"
+    msa_cache.mkdir(parents=True, exist_ok=True)
     seq_hash = hashlib.sha256(sequence.encode("utf-8")).hexdigest()[:16]
-    a3m_path = _MSA_CACHE / f"{seq_hash}.a3m"
+    a3m_path = msa_cache / f"{seq_hash}.a3m"
     if not a3m_path.exists():
         result = run_mmseqs2(
             [sequence],
-            prefix=str(_MSA_CACHE / seq_hash),
+            prefix=str(msa_cache / seq_hash),
             use_env=True,
             use_filter=True,
             use_pairing=False,
@@ -86,15 +77,13 @@ def _target_a3m(sequence: str) -> str:
     return str(a3m_path)
 
 
-def _get_predictor(model_name: str, checkpoint_file: str | None = None):
-    key = (model_name, checkpoint_file)
-    if key not in _PREDICTOR_CACHE:
-        from jopendde.inference import Predictor
-
-        _PREDICTOR_CACHE[key] = Predictor.from_checkpoint(
-            model_name, checkpoint_file=checkpoint_file
-        )
-    return _PREDICTOR_CACHE[key]
+def _set_asset_cache_dir(configs, cache_root: Path):
+    root = cache_root / "opendde"
+    configs.load_checkpoint_dir = str(root / "checkpoint")
+    configs.data.ccd_components_file = str(root / "common" / "components.cif")
+    configs.data.ccd_components_rdkit_mol_file = str(
+        root / "common" / "components.cif.rdkit_mol.pkl"
+    )
 
 
 def _build_dense_atom_to_atom37() -> np.ndarray:
@@ -128,11 +117,8 @@ def _build_spec(chains: list[TargetChain], *, name: str = "design", seed: int = 
     for c in chains:
         if c.polymer_type != PolymerType.PROTEIN:
             raise NotImplementedError(
-                "OpenDDE wrapper supports protein chains only; got "
-                f"{c.polymer_type}"
+                f"OpenDDE wrapper supports protein chains only; got {c.polymer_type}"
             )
-        if c.template_chain is not None:
-            raise NotImplementedError("OpenDDE wrapper does not support templates.")
         chain = {"sequence": c.sequence, "count": 1}
         if c.use_msa:
             chain["unpairedMsaPath"] = _target_a3m(c.sequence)
@@ -141,49 +127,38 @@ def _build_spec(chains: list[TargetChain], *, name: str = "design", seed: int = 
 
 
 # ---------------------------------------------------------------------------
-# Weight-free featurization
+# Featurization
 # ---------------------------------------------------------------------------
-# Featurization is a *setup*-time operation (build the `Features` once; the JAX
-# design loop never re-featurizes), and it needs no model weights. Upstream
-# `Predictor.featurize` only reaches into the torch model for
-# `relative_position_encoding.generate_relp` -- a `torch.no_grad` block of pure
-# one-hot index math with no learned params. So we run featurization as plain
-# function calls (the torch data pipeline + `generate_relp` + the
-# `update_input_feature_dict` helper), and the wrapper holds no torch object.
 
-_FEATURIZE_CONFIGS = None  # opendde_v1 inference config; built once, holds no weights.
+@lru_cache(maxsize=None)
+def _cached_featurize_config(cache_root: str):
+    """Build the immutable base config for an architecture and cache root."""
+    from opendde.config.inference import (
+        build_inference_config,
+        update_gpu_compatible_configs,
+    )
+    from opendde.utils.download import download_inference_cache
+
+    cfg = build_inference_config(
+        model_name="opendde_v1", fill_required_with_null=True
+    )
+    _set_asset_cache_dir(cfg, Path(cache_root))
+    cfg.use_msa = cfg.use_template = cfg.use_rna_msa = False
+    cfg.triangle_multiplicative = cfg.triangle_attention = "torch"
+    cfg.enable_diffusion_shared_vars_cache = False
+    cfg.enable_efficient_fusion = False
+    cfg = update_gpu_compatible_configs(cfg)
+    download_inference_cache(cfg)
+    return cfg
 
 
 def _featurize_configs():
-    """The `opendde_v1` inference config that drives the featurization data
-    pipeline. Built once per process from `build_inference_config` (no checkpoint
-    load) and reused. It's architecture-level -- identical for V1 and Abag (only
-    the checkpoint weights differ) -- so featurization needs no per-model input."""
-    global _FEATURIZE_CONFIGS
-    if _FEATURIZE_CONFIGS is None:
-        from opendde.config.inference import (
-            build_inference_config,
-            update_gpu_compatible_configs,
-        )
-        from opendde.utils.download import download_inference_cache
-
-        cfg = build_inference_config(model_name="opendde_v1", fill_required_with_null=True)
-        cfg.use_msa = cfg.use_template = cfg.use_rna_msa = False
-        cfg.triangle_multiplicative = cfg.triangle_attention = "torch"
-        cfg.enable_diffusion_shared_vars_cache = False
-        cfg.enable_efficient_fusion = False
-        cfg = update_gpu_compatible_configs(cfg)
-        download_inference_cache(cfg)  # CCD reference data on disk (no weights loaded)
-        _FEATURIZE_CONFIGS = cfg
-    return _FEATURIZE_CONFIGS
+    """Return an isolated `opendde_v1` featurization config."""
+    return copy.deepcopy(_cached_featurize_config(str(cache_dir())))
 
 
 def _relp(feat_dict: dict) -> dict:
-    """Add the weight-free relative-position feature `relp` to a raw feature dict.
-
-    `RelativePositionEncoding.generate_relp` reads only `self.r_max` / `self.s_max`
-    (pure one-hot index math, no learned params), so we invoke it as a function
-    with the opendde_v1 constants instead of constructing the torch module."""
+    """Add the `opendde_v1` relative-position feature to a raw feature dict."""
     import types
 
     from opendde.model.opendde import RelativePositionEncoding
@@ -192,16 +167,66 @@ def _relp(feat_dict: dict) -> dict:
     return RelativePositionEncoding.generate_relp(ns, feat_dict, lazy=False)
 
 
+def _target_template_features(
+    chains: list[TargetChain], *, max_templates: int = 4
+) -> dict[str, np.ndarray] | None:
+    """Convert Mosaic's in-memory Gemmi chains to OpenDDE template features."""
+    if not any(c.template_chain is not None for c in chains):
+        return None
+
+    from opendde.data.constants import ATOM14_PADDED, STD_RESIDUES_WITH_GAP
+    from opendde.data.template.template_featurizer import Templates
+
+    n_res = sum(len(c.sequence) for c in chains)
+    gap = STD_RESIDUES_WITH_GAP["-"]
+    # OpenDDE represents an empty template row with GAP and pads additional rows
+    # with ALA. Padded identities still affect embeddings despite zero masks.
+    aatype = np.zeros((max_templates, n_res), dtype=np.int32)
+    aatype[0] = gap
+    positions = np.zeros((max_templates, n_res, 24, 3), dtype=np.float32)
+    mask = np.zeros((max_templates, n_res, 24), dtype=bool)
+
+    offset = 0
+    for chain in chains:
+        template_chain = chain.template_chain
+        if template_chain is not None:
+            polymer = template_chain.get_polymer()
+            template_sequence = gemmi.one_letter_code([res.name for res in polymer])
+            if template_sequence != chain.sequence:
+                raise ValueError(
+                    "OpenDDE template sequence does not match its target sequence: "
+                    f"{template_sequence!r} != {chain.sequence!r}"
+                )
+            for i, residue in enumerate(polymer):
+                restype = STD_RESIDUES_WITH_GAP.get(
+                    residue.name, STD_RESIDUES_WITH_GAP["UNK"]
+                )
+                aatype[0, offset + i] = restype
+                atom_slots = {
+                    name: j
+                    for j, name in enumerate(ATOM14_PADDED.get(residue.name, ()))
+                    if name
+                }
+                for atom in residue:
+                    atom_name = atom.name.upper()
+                    if atom_name == "SE" and residue.name == "MSE":
+                        atom_name = "SD"
+                    if atom_name in atom_slots:
+                        j = atom_slots[atom_name]
+                        positions[0, offset + i, j] = atom.pos.tolist()
+                        mask[0, offset + i, j] = True
+        offset += len(chain.sequence)
+
+    return Templates(
+        aatype=aatype, atom_positions=positions, atom_mask=mask
+    ).as_opendde_dict()
+
+
 def _featurize(chains: list[TargetChain]):
-    """Featurize protein `chains` into a jopendde `Features`, weight-free.
+    """Featurize protein chains without loading model weights.
 
-    Mirrors `Predictor.featurize` / `_load_batch` minus the model touches: run the
-    torch data pipeline (`get_inference_dataloader`, driven by the shared config),
-    add `relp` (`_relp`), rebuild the windowed atom-pair features
-    (`update_input_feature_dict`), and adapt to `Features`. Returns
-    `(feat, atom_array)`; `atom_array` is the biotite writer for native output."""
-    import copy
-
+    Returns JOpenDDE features and the Biotite atom array for native output.
+    """
     import torch
 
     from opendde.data.inference.infer_dataloader import get_inference_dataloader
@@ -220,13 +245,18 @@ def _featurize(chains: list[TargetChain]):
         cfg.input_json_path = json_path
         cfg.seeds = [seed]
         data, atom_array, err = next(iter(get_inference_dataloader(configs=cfg)))[0]
-        assert not err, err
+        if err:
+            raise RuntimeError(f"OpenDDE featurization failed: {err}")
     raw = copy.deepcopy(data["input_feature_dict"])
     raw["inference_seed"] = torch.tensor(seed, dtype=torch.long)
     with torch.no_grad():
         raw = _relp(raw)
     raw = update_input_feature_dict(raw)
-    return Features.from_dict(_to_numpy(raw)), atom_array
+    raw_np = _to_numpy(raw)
+    template_features = _target_template_features(chains)
+    if template_features is not None:
+        raw_np.update(template_features)
+    return Features.from_dict(raw_np), atom_array
 
 
 class OpenDDEModel(StructurePredictionModel):
@@ -234,14 +264,9 @@ class OpenDDEModel(StructurePredictionModel):
 
     model: JaxOpenDDE
     dense_atom_to_atom37: Int[Array, "32 Adense"]
-    # Per-residue atom/structural templates for the in-loop binder geometry
-    # refresh. Built once at construction; None disables the refresh (binder
-    # keeps its poly-Trp placeholder geometry).
-    templates: OpenDDEResidueTemplates | None = None
-    model_name: str = eqx.field(static=True, default="opendde_v1")
-    # Overriding weight file (e.g. "opendde_abag.pt"); None uses the default for
-    # model_name. Only affects which cached Predictor featurization reloads.
-    checkpoint_file: str | None = eqx.field(static=True, default=None)
+    # Architecture-level residue atom/layout templates used to refresh design
+    # geometry. These are not target-chain structural templates.
+    atom_templates: OpenDDEAtomTemplates
     # (min_bin, max_bin, no_bins) for the confidence heads, read from the
     # checkpoint config at construction (static -> baked into the loss).
     pae_bin_params: tuple = eqx.field(static=True, default=(0.0, 32.0, 64))
@@ -254,52 +279,39 @@ class OpenDDEModel(StructurePredictionModel):
     def target_only_features(self, chains: list[TargetChain]):
         """Featurize real protein chains. Returns `(feat, atom_array)` where `feat`
         is the jopendde `Features` and `atom_array` is the biotite writer for
-        native structure output. Weight-free -- runs the data pipeline directly
-        (`_featurize`), no Predictor / checkpoint needed."""
+        native structure output. Model weights are not loaded by this method."""
         return _featurize(chains)
 
     def binder_features(self, binder_length: int, chains: list[TargetChain]):
-        """Design features: a poly-Trp binder as chain 0, then the targets. The
-        binder occupies token positions `[0, binder_length)` / asym_id 0. Trp is
-        the largest residue, so this allocates the maximum atom budget per
-        position; the in-loop `refresh_binder_geometry` then tight-packs the
-        designed residues' atoms into it each step without a recompile (any
-        shorter sequence fits). Pin a partially-fixed framework with
-        `SetPositions` during optimization.
+        """Featurize a poly-Trp binder followed by target chains for design.
 
-        Returns `OpenDDEFeatures` (not a bare jopendde `Features`): it bundles the
-        poly-Trp features with the per-residue templates + binder extents, so
-        `set_binder_sequence` always refreshes the binder geometry from the
-        designed PSSM (see `OpenDDEFeatures`)."""
+        Returns an `OpenDDEDesignFeatures` bundle whose static binder extents and
+        atom templates allow geometry to be refreshed from each candidate PSSM.
+        """
+        if binder_length < 1:
+            raise ValueError("OpenDDE binder_length must be positive")
         binder = TargetChain(sequence="W" * binder_length, use_msa=False)
         feat, atom_array = self.target_only_features([binder, *chains])
-        return self._as_opendde_features(feat), atom_array
-
-    def _as_opendde_features(self, features) -> OpenDDEFeatures:
-        """Bundle a poly-Trp jopendde `Features` (or pass existing `OpenDDEFeatures`
-        through) into `OpenDDEFeatures`, attaching the model's templates + the
-        (static, host-computed) binder token/atom extents the in-loop refresh needs."""
-        if isinstance(features, OpenDDEFeatures):
-            return features
-        if self.templates is None:
+        observed_length, binder_atom_alloc = _binder_extents(feat)
+        if observed_length != binder_length:
             raise ValueError(
-                "OpenDDE design needs per-residue templates for the in-loop "
-                "geometry refresh, but none were built for this model."
+                "OpenDDE featurization changed the binder length: "
+                f"expected {binder_length}, got {observed_length}"
             )
-        binder_length, binder_atom_alloc = _binder_extents(features)
-        return OpenDDEFeatures(
-            features=features,
-            templates=self.templates,
-            binder_length=binder_length,
+        design_features = OpenDDEDesignFeatures(
+            features=feat,
+            atom_templates=self.atom_templates,
+            binder_length=observed_length,
             binder_atom_alloc=binder_atom_alloc,
         )
+        return design_features, atom_array
 
     # ------------------------------------------------------------------ loss
     def build_loss(
         self,
         *,
         loss: LossTerm | LinearCombination,
-        features,
+        features: OpenDDEDesignFeatures,
         recycling_steps: int = _DEFAULT_NUM_CYCLES,
         sampling_steps: int | None = None,
         stop_grad_conf_coords: bool = False,
@@ -317,7 +329,7 @@ class OpenDDEModel(StructurePredictionModel):
         self,
         *,
         loss: LossTerm | LinearCombination,
-        features,
+        features: OpenDDEDesignFeatures,
         recycling_steps: int = _DEFAULT_NUM_CYCLES,
         sampling_steps: int | None = None,
         num_samples: int = 1,
@@ -326,14 +338,14 @@ class OpenDDEModel(StructurePredictionModel):
     ) -> MultiSampleOpenDDELoss:
         if sampling_steps is None:
             sampling_steps = self.default_sampling_steps
-        # `features` is a design bundle (poly-Trp binder as chain 0, from
-        # `binder_features`); `_as_opendde_features` also wraps a bare `Features`,
-        # attaching templates + the (static, host-computed) binder extents. The
-        # in-loop geometry refresh is always on -- `set_binder_sequence` refreshes
-        # the binder side chains every step.
+        if not isinstance(features, OpenDDEDesignFeatures):
+            raise TypeError(
+                "OpenDDE design losses require OpenDDEDesignFeatures from "
+                f"binder_features(); got {type(features).__name__}"
+            )
         return MultiSampleOpenDDELoss(
             model=self.model,
-            features=self._as_opendde_features(features),
+            features=features,
             loss=loss,
             dense_atom_to_atom37=self.dense_atom_to_atom37,
             num_cycles=recycling_steps,
@@ -351,7 +363,7 @@ class OpenDDEModel(StructurePredictionModel):
         self,
         *,
         PSSM: Float[Array, "N 20"] | None = None,
-        features,
+        features: Features | OpenDDEDesignFeatures,
         recycling_steps: int = _DEFAULT_NUM_CYCLES,
         sampling_steps: int | None = None,
         key,
@@ -366,12 +378,19 @@ class OpenDDEModel(StructurePredictionModel):
             key, geom_key = jax.random.split(key)
             feat = set_binder_sequence(PSSM, features, geom_key)
         else:
-            # No PSSM: fold as featurized (a bare Features, or an OpenDDEFeatures'
+            # No PSSM: fold as featurized (a bare Features, or an OpenDDEDesignFeatures'
             # untouched poly-Trp placeholder geometry).
-            feat = features.features if isinstance(features, OpenDDEFeatures) else features
+            feat = (
+                features.features if isinstance(features, OpenDDEDesignFeatures) else features
+            )
         s_inputs, s, z = self.model.get_pairformer_output(feat, recycling_steps)
         return opendde_forward_from_trunk(
-            self.model, feat, s_inputs, s, z, key,
+            self.model,
+            feat,
+            s_inputs,
+            s,
+            z,
+            key,
             n_step=sampling_steps,
             dense_atom_to_atom37=self.dense_atom_to_atom37,
             pae_bin_params=self.pae_bin_params,
@@ -391,7 +410,7 @@ class OpenDDEModel(StructurePredictionModel):
         """Fold the (binder+)target complex and return scores + a structure,
         written from the canonical atom37 view (`StructureModelOutput.to_structure`).
 
-        `features` is an `OpenDDEFeatures` bundle (from `binder_features`) when
+        `features` is an `OpenDDEDesignFeatures` bundle (from `binder_features`) when
         `PSSM` is given -- the binder geometry is refreshed from the PSSM before
         folding -- or a bare `target_only_features` `Features` for a target-only fold."""
         output = self.model_output(
@@ -424,71 +443,198 @@ def _binder_extents(features) -> tuple[int, int]:
     return binder_length, binder_atom_alloc
 
 
-# Residue templates are CCD conformers + structural-token layout read off the
-# (weight-free, architecture-level) featurizer -- they do NOT depend on the
-# checkpoint, so a single set is shared across all `opendde_v1` checkpoints (V1,
-# Abag, ...). Keyed by the featurization architecture only, matching `_featurize`'s
-# hardcoded config. Backed by a small on-disk npz so a fresh process skips the
-# ~40-featurization host build.
-_TEMPLATE_ARCH = "opendde_v1"
-_TEMPLATE_CACHE: OpenDDEResidueTemplates | None = None
-_TEMPLATE_DISK_CACHE = Path(
-    os.environ.get("MOSAIC_OPENDDE_TEMPLATE_CACHE", "~/.cache/mosaic/opendde_templates")
-).expanduser()
+# Atom templates are architecture data derived from OpenDDE CCD features.
+_ATOM_TEMPLATE_ARCH = "opendde_v1"
+_ATOM_TEMPLATE_SCHEMA_VERSION = 1
+_ATOM_TEMPLATE_CACHE: dict[tuple[str, str, str, int], OpenDDEAtomTemplates] = {}
 
 
-def _template_fields():
+def _jopendde_build_id() -> str:
+    """Return the installed JOpenDDE package revision or version."""
+    try:
+        dist = distribution("jopendde")
+    except PackageNotFoundError:
+        return "unknown"
+    direct_url = dist.read_text("direct_url.json")
+    if direct_url:
+        try:
+            commit = json.loads(direct_url).get("vcs_info", {}).get("commit_id")
+        except json.JSONDecodeError:
+            commit = None
+        if commit:
+            return commit
+    return dist.version
+
+
+def _atom_template_fields() -> list[str]:
     return [
-        f.name for f in dataclasses.fields(OpenDDEResidueTemplates)
-        if f.name not in ("max_atoms", "max_struct")
+        field.name
+        for field in dataclasses.fields(OpenDDEAtomTemplates)
+        if field.name not in ("max_atoms", "max_struct")
     ]
 
 
-def _get_templates() -> OpenDDEResidueTemplates:
-    global _TEMPLATE_CACHE
-    if _TEMPLATE_CACHE is not None:
-        return _TEMPLATE_CACHE
+def _atom_template_shapes() -> dict[str, tuple[int, ...]]:
+    atom = MAX_ATOMS_PER_RES
+    struct = MAX_STRUCT_PER_RES
+    return {
+        "ref_pos": (2, 20, atom, 3),
+        "ref_element": (2, 20, atom, 128),
+        "ref_charge": (2, 20, atom),
+        "ref_atom_name_chars": (2, 20, atom, 4, 64),
+        "n_atoms": (2, 20),
+        "disto_off": (2, 20),
+        "pae_off": (2, 20),
+        "a_struct_tok": (2, 20, atom),
+        "a_struct_tokatom": (2, 20, atom),
+        "s_disto_off": (2, 20, struct),
+        "s_pae_off": (2, 20, struct),
+        "s_frame_off": (2, 20, struct, 3),
+        "s_valid": (2, 20, struct),
+    }
 
-    disk = _TEMPLATE_DISK_CACHE / f"{_TEMPLATE_ARCH}.npz"
-    if disk.exists():
-        data = np.load(disk)
-        tmpl = OpenDDEResidueTemplates(**{k: jnp.asarray(data[k]) for k in _template_fields()})
+
+def _validate_atom_template_cache(data, build_id: str) -> dict[str, np.ndarray]:
+    metadata = {
+        "_schema_version": str(_ATOM_TEMPLATE_SCHEMA_VERSION),
+        "_architecture": _ATOM_TEMPLATE_ARCH,
+        "_jopendde_build": build_id,
+    }
+    for name, expected in metadata.items():
+        if name not in data or str(np.asarray(data[name]).item()) != expected:
+            raise ValueError(f"invalid OpenDDE atom-template metadata: {name}")
+
+    arrays = {}
+    float_fields = {"ref_pos", "ref_element", "ref_charge", "ref_atom_name_chars"}
+    for name, shape in _atom_template_shapes().items():
+        if name not in data:
+            raise ValueError(f"missing OpenDDE atom-template field: {name}")
+        value = np.asarray(data[name])
+        if value.shape != shape:
+            raise ValueError(
+                f"invalid OpenDDE atom-template shape for {name}: "
+                f"expected {shape}, got {value.shape}"
+            )
+        expected_kind = "f" if name in float_fields else "i"
+        if value.dtype.kind != expected_kind:
+            raise ValueError(
+                f"invalid OpenDDE atom-template dtype for {name}: {value.dtype}"
+            )
+        arrays[name] = value
+    return arrays
+
+
+def _write_atom_template_cache(
+    path: Path, templates: OpenDDEAtomTemplates, build_id: str
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        name: np.asarray(getattr(templates, name))
+        for name in _atom_template_fields()
+    }
+    payload.update(
+        {
+            "_schema_version": np.asarray(str(_ATOM_TEMPLATE_SCHEMA_VERSION)),
+            "_architecture": np.asarray(_ATOM_TEMPLATE_ARCH),
+            "_jopendde_build": np.asarray(build_id),
+        }
+    )
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False
+        ) as handle:
+            temporary = Path(handle.name)
+            np.savez(handle, **payload)
+        temporary.replace(path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def _load_atom_template_cache(
+    path: Path, build_id: str
+) -> OpenDDEAtomTemplates:
+    with np.load(path, allow_pickle=False) as data:
+        arrays = _validate_atom_template_cache(data, build_id)
+    return OpenDDEAtomTemplates(
+        **{name: jnp.asarray(value) for name, value in arrays.items()}
+    )
+
+
+def _build_atom_template_cache(
+    path: Path, build_id: str
+) -> OpenDDEAtomTemplates:
+    def featurize_one(sequence: str):
+        features, _ = _featurize(
+            [TargetChain(sequence=sequence, use_msa=False)]
+        )
+        return features
+
+    templates = build_opendde_atom_templates(featurize_one)
+    _write_atom_template_cache(path, templates, build_id)
+    return templates
+
+
+def _get_atom_templates() -> OpenDDEAtomTemplates:
+    root = cache_dir()
+    build_id = _jopendde_build_id()
+    cache_key = (
+        _ATOM_TEMPLATE_ARCH,
+        str(root),
+        build_id,
+        _ATOM_TEMPLATE_SCHEMA_VERSION,
+    )
+    if cache_key in _ATOM_TEMPLATE_CACHE:
+        return _ATOM_TEMPLATE_CACHE[cache_key]
+
+    filename = (
+        f"{_ATOM_TEMPLATE_ARCH}-v{_ATOM_TEMPLATE_SCHEMA_VERSION}-"
+        f"{build_id[:12]}.npz"
+    )
+    path = root / "opendde" / "atom_templates" / filename
+    if path.exists():
+        try:
+            templates = _load_atom_template_cache(path, build_id)
+        except (OSError, ValueError, KeyError):
+            path.unlink(missing_ok=True)
+            templates = _build_atom_template_cache(path, build_id)
     else:
-        # Weight-free: the templates are CCD conformers read off the featurization
-        # data pipeline, so building them never loads the checkpoint.
-        def featurize_one(seq: str):
-            feat, _ = _featurize([TargetChain(sequence=seq, use_msa=False)])
-            return feat
+        templates = _build_atom_template_cache(path, build_id)
 
-        tmpl = build_opendde_templates(featurize_one)
-        disk.parent.mkdir(parents=True, exist_ok=True)
-        np.savez(disk, **{k: np.asarray(getattr(tmpl, k)) for k in _template_fields()})
-
-    _TEMPLATE_CACHE = tmpl
-    return tmpl
+    _ATOM_TEMPLATE_CACHE[cache_key] = templates
+    return templates
 
 
 def _build_model(model_name: str, checkpoint_file: str | None = None) -> OpenDDEModel:
-    predictor = _get_predictor(model_name, checkpoint_file)
+    from jopendde.inference import Predictor
+
+    predictor = Predictor.from_checkpoint(
+        model_name,
+        checkpoint_file=checkpoint_file,
+        asset_cache_dir=cache_dir() / "opendde",
+    )
     sp = predictor.summary_params
     return OpenDDEModel(
         model=predictor.model,
         dense_atom_to_atom37=jnp.array(_build_dense_atom_to_atom37()),
-        templates=_get_templates(),
-        model_name=model_name,
-        checkpoint_file=checkpoint_file,
+        atom_templates=_get_atom_templates(),
         pae_bin_params=tuple(sp.pae_bins),
         plddt_bin_params=tuple(sp.plddt_bins),
     )
 
 
 def OpenDDEModelV1() -> OpenDDEModel:
-    """Load the released `opendde_v1` checkpoint (single-sequence, no MSA/template)
-    as a mosaic backend."""
-    return _build_model("opendde_v1")
+    return _build_model(
+        "opendde_v1",
+        checkpoint_file="opendde.pt",
+    )
 
 
 def OpenDDEModelAbag() -> OpenDDEModel:
     """Load the ABAG-optimized weights (`opendde_abag.pt`) for antibody-antigen
-    complexes. Same `opendde_v1` architecture, different checkpoint."""
-    return _build_model("opendde_v1", checkpoint_file="opendde_abag.pt")
+    complexes."""
+    return _build_model(
+        "opendde_v1",
+        checkpoint_file="opendde_abag.pt",
+    )

--- a/src/mosaic/models/promera.py
+++ b/src/mosaic/models/promera.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import tempfile
+from copy import deepcopy
 
 import equinox as eqx
 import jax
@@ -9,6 +10,8 @@ import numpy as np
 from jaxtyping import Array, Float, PyTree
 
 from mosaic.losses.structure_prediction import IPTMLoss
+from mosaic.cache import cache_dir
+from mosaic.common import TOKENS
 from mosaic.structure_prediction import (
     PolymerType,
     StructurePrediction,
@@ -19,7 +22,7 @@ from mosaic.structure_prediction import (
 from jpromera.config import DIFFUSION
 from jpromera.features import build_msas, copy_coords, featurize
 from jpromera.model import JPromera as _JPromera
-from jpromera.serialize import load_pretrained
+from jpromera.serialize import load_model as load_promera_model
 from mosaic.losses.promera import (
     _DEFAULT_SAMPLING_STEPS,
     MosaicFeatures,
@@ -35,13 +38,23 @@ _POLY = {
 
 
 class _StructureWriter:
-    def __init__(self, struct):
+    def __init__(self, struct, schema):
         self.struct = struct
+        self.schema = schema
 
-    def __call__(self, coords) -> "gemmi.Structure":
+    def __call__(self, coords, binder_pssm=None) -> "gemmi.Structure":
         import gemmi
 
-        s = copy_coords(self.struct, np.asarray(coords))
+        struct = self.struct
+        if binder_pssm is not None:
+            schema = deepcopy(self.schema)
+            binder_id = next(iter(schema))
+            binder_sequence = "".join(
+                TOKENS[index] for index in np.asarray(binder_pssm).argmax(-1)
+            )
+            schema[binder_id]["sequence"] = binder_sequence
+            _features, struct = featurize(schema, build_msa=False)
+        s = copy_coords(struct, np.asarray(coords))
         with tempfile.NamedTemporaryFile(suffix=".cif") as f:
             s.to_mmcif(f.name, metadata=False)
             return gemmi.read_structure(f.name)
@@ -52,6 +65,23 @@ def _schema(chains: list[TargetChain]) -> dict:
         cid: {"type": _POLY[c.polymer_type], "sequence": c.sequence}
         for cid, c in zip("ABCDEFGHIJKLMNOPQRSTUVWXYZ", chains)
     }
+
+
+def load_pretrained():
+    from huggingface_hub import hf_hub_download
+
+    cache = cache_dir() / "promera"
+    stem = hf_hub_download(
+        repo_id="escalante-bio/jpromera",
+        filename="promera_2606.eqx",
+        cache_dir=cache,
+    )[: -len(".eqx")]
+    hf_hub_download(
+        repo_id="escalante-bio/jpromera",
+        filename="promera_2606.skeleton.pkl",
+        cache_dir=cache,
+    )
+    return load_promera_model(stem)
 
 
 class JPromeraModel(StructurePredictionModel):
@@ -76,7 +106,7 @@ class JPromeraModel(StructurePredictionModel):
             build_msas(want)
         feats, struct = featurize(schema, build_msa=False)
         mf = MosaicFeatures.of(feats, binder_len=binder_len)
-        return mf, _StructureWriter(struct)
+        return mf, _StructureWriter(struct, schema)
 
     def target_only_features(self, chains: list[TargetChain]):
         return self._features(list(chains))
@@ -169,7 +199,7 @@ class JPromeraModel(StructurePredictionModel):
         else:
             iptm = jnp.nan
         return StructurePrediction(
-            st=writer(output.structure_coordinates),
+            st=writer(output.structure_coordinates, binder_pssm=PSSM),
             plddt=output.plddt,
             pae=output.pae,
             iptm=iptm,

--- a/src/mosaic/models/proteina.py
+++ b/src/mosaic/models/proteina.py
@@ -36,7 +36,7 @@ _LATENT_DIM = 8
 class ScoredDesign(eqx.Module):
     """A decoded + scored design candidate."""
     decoder_output: DecoderOutput
-    sequence: Int[Array, "N"]             # hard sequence (mosaic token order)
+    sequence: Int[Array, " N"]             # hard sequence (mosaic token order)
     loss: Float[Array, ""]               # loss (lower = better)
     aux: dict                             # full auxiliary output from loss_fn
     bb: Float[Array, "N 3"]              # backbone CA (Angstroms)
@@ -54,10 +54,10 @@ def _denoise(
     model: LocalLatentsTransformer,
     state: DenoiseState,
     key: Key[Array, ""],
-    mask: Bool[Array, "N"],
+    mask: Bool[Array, " N"],
     cfg: SamplingConfig,
-    ts_bb: Float[Array, "S+1"],
-    ts_lat: Float[Array, "S+1"],
+    ts_bb: Float[Array, " S+1"],
+    ts_lat: Float[Array, " S+1"],
     start_step: Int[Array, ""],
     end_step: Int[Array, ""],
     target: TargetCond,
@@ -82,7 +82,7 @@ def _score_batch(
     loss_fn: LossTerm,
     bbs: Float[Array, "C N 3"],
     lats: Float[Array, "C N D"],
-    mask: Bool[Array, "N"],
+    mask: Bool[Array, " N"],
     keys: Key[Array, "C 2"],
 ) -> ScoredDesign:
     """Decode + score candidates.  Returns batched ``ScoredDesign [C, ...]``."""
@@ -104,7 +104,7 @@ def beam_search(
     model: LocalLatentsTransformer,
     decoder: DecoderTransformer,
     loss_fn: LossTerm,
-    mask: Bool[Array, "N"],
+    mask: Bool[Array, " N"],
     key: Key[Array, ""],
     target: TargetCond,
     *,

--- a/src/mosaic/models/protenix.py
+++ b/src/mosaic/models/protenix.py
@@ -1,10 +1,9 @@
-# TODO: figure out how to NOT produce MSA for a target chain
 # Note we use a vanilla ODE sampler for the structure module by default!
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
-from protenix.backend import load_model as backend_load_model
+import protenix.backend as protenix_backend
 from jaxtyping import Array, Float, PyTree
 
 from protenix.data.template import ChainInput, featurize
@@ -17,6 +16,7 @@ from mosaic.losses.protenix import (
     set_binder_sequence,
 )
 from mosaic.losses.structure_prediction import IPTMLoss
+from mosaic.cache import cache_dir
 from mosaic.structure_prediction import (
     PolymerType,
     StructurePrediction,
@@ -41,7 +41,8 @@ def install_protenix_msa_auth_fix():
 install_protenix_msa_auth_fix()
 
 def load_model(name="protenix_mini_default_v0.5.0"):
-    jax_model = backend_load_model(name)
+    protenix_backend._CACHE_DIR = str(cache_dir() / "protenix")
+    jax_model = protenix_backend.load_model(name)
     # set gamma0, step_scale_eta, and N_steps to match the vanilla ODE sampler settings
     jax_model = eqx.tree_at(lambda m: (m.gamma0, m.step_scale_eta, m.noise_scale_lambda, m.N_steps), jax_model, (0.0, 1.0, 1.0, 20))
 
@@ -172,7 +173,9 @@ class Protenix(StructurePredictionModel):
         seq = PSSM if PSSM is not None else jnp.zeros((0, 20))
         iptm = -IPTMLoss()(seq, output, key=jax.random.key(0))[0]
         return StructurePrediction(
-            st=biotite_array_to_gemmi_struct(writer, np.array(output.structure_coordinates[0])),
+            st=biotite_array_to_gemmi_struct(
+                writer, np.array(output.structure_coordinates[0])
+            ),
             plddt=output.plddt,
             pae=output.pae,
             iptm=iptm,

--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -13,6 +13,35 @@ from mosaic.common import LinearCombination, LossTerm
 AbstractLoss = LossTerm | LinearCombination
 
 
+def _ranking_leaf(aux, ranking_aux_name: str):
+    """Locate the ranking-metric leaf in a loss's ``aux`` tree, or ``None``.
+
+    ``ranking_aux_name`` is matched as a dict key ANYWHERE in the path, so the
+    lookup is robust to nesting and to ``reduce_samples`` wrapping per-sample
+    scalar metrics into loss-sorted lists (which appends a ``SequenceKey`` and
+    would defeat a terminal-key match). When the metric is such a per-sample
+    list, the best sample -- list index 0, since aux is sorted ascending by
+    loss -- is returned.
+    """
+    matches = [
+        (path, leaf)
+        for path, leaf in jax.tree_util.tree_leaves_with_path(aux)
+        if any(getattr(k, "key", None) == ranking_aux_name for k in path)
+    ]
+    if not matches:
+        return None
+    if len(matches) == 1:
+        return matches[0][1]
+
+    def _trailing_seq_idx(path):
+        for k in reversed(path):
+            if isinstance(k, jax.tree_util.SequenceKey):
+                return k.idx
+        return 0
+
+    return min(matches, key=lambda pl: _trailing_seq_idx(pl[0]))[1]
+
+
 def _print_iter(iter, aux, v):
     # first filter out anything that isn't a float or has number of dimensions > 0
     aux = eqx.filter(
@@ -68,7 +97,7 @@ def batched_eval(
     loss: AbstractLoss,
     xs: Float[Array, "B N K"],
     keys: jax.Array,
-) -> tuple[Float[Array, "B"], PyTree, Float[Array, "B N K"]]:
+) -> tuple[Float[Array, " B"], PyTree, Float[Array, "B N K"]]:
     """Evaluate loss+grad for B sequences with B keys."""
     assert xs.ndim == 3, f"xs must be 3D [B, N, K], got {xs.ndim}D"
 
@@ -100,7 +129,7 @@ def _proposal(sequence, g, temp, alphabet_size: int = 20):
 
 def gradient_MCMC(
     loss,
-    sequence: Int[Array, "N"],
+    sequence: Int[Array, " N"],
     temp=0.001,
     proposal_temp=0.01,
     max_path_length=2,
@@ -478,7 +507,7 @@ def _topb_unseen_mutations(seq, g, seen, b):
 
 def batch_greedy_descent(
     loss: AbstractLoss,
-    sequence: Int[Array, "N"],
+    sequence: Int[Array, " N"],
     *,
     batch_size: int = 16,
     steps: int = 100,
@@ -602,16 +631,13 @@ def biohub_optimizer(
 
     def get_ranking_values(values, aux):
         nonlocal _warned_ranking
-        ranking_leaves = [leaf for (path, leaf) in jax.tree_util.tree_leaves_with_path(aux) if getattr(path[-1], "key", None) == ranking_aux_name]
-        if len(ranking_leaves) == 0:
+        leaf = _ranking_leaf(aux, ranking_aux_name)
+        if leaf is None:
             if not _warned_ranking:
                 print(f"Warning: biohub_optimizer ranking by loss value, not {ranking_aux_name}")
                 _warned_ranking = True
             return values
-        elif len(ranking_leaves) == 1:
-            return ranking_leaves[0]
-        else:
-            raise ValueError(f"biohub_optimizer found multiple leaves with key {ranking_aux_name}")
+        return leaf
 
 
     assert logits.ndim == 3, "biohub_optimizer is batched, `logits` must have shape [B, N, 20]"

--- a/src/mosaic/proteinmpnn/mpnn.py
+++ b/src/mosaic/proteinmpnn/mpnn.py
@@ -300,9 +300,9 @@ class ProteinFeatures(AbstractFromTorch):
     def _call_single(
         self,
         X: Float[Array, "L 4 3"],
-        residue_idx: Int[Array, "L"],
-        chain_idx: Int[Array, "L"],
-        mask: Bool[Array, "L"],
+        residue_idx: Int[Array, " L"],
+        chain_idx: Int[Array, " L"],
+        mask: Bool[Array, " L"],
         *,
         key: jax.random.PRNGKey,
     ):
@@ -413,9 +413,9 @@ class ProteinMPNN(AbstractFromTorch):
         self,
         *,
         X: Float[Array, "N 4 3"],
-        mask: Bool[Array, "N"],
-        residue_idx: Int[Array, "N"],
-        chain_encoding_all: Int[Array, "N"],
+        mask: Bool[Array, " N"],
+        residue_idx: Int[Array, " N"],
+        chain_encoding_all: Int[Array, " N"],
         key
     ):
         # add batch dimension :/
@@ -439,8 +439,8 @@ class ProteinMPNN(AbstractFromTorch):
         h_V,
         h_E,
         E_idx,
-        decoding_order: Float[Array, "N"],
-        mask: Bool[Array, "N"],
+        decoding_order: Float[Array, " N"],
+        mask: Bool[Array, " N"],
     ):
         # add batch dim to S, decoding_order, mask
         S, decoding_order, mask  = jax.tree.map(lambda x: x[None], (S, decoding_order, mask))
@@ -486,10 +486,10 @@ class ProteinMPNN(AbstractFromTorch):
         self,
         X: Float[Array, "N 4 3"],
         S: Float[Array, "N 23"],
-        mask: Bool[Array, "N"],
-        residue_idx: Int[Array, "N"],
-        chain_encoding_all: Int[Array, "N"],
-        decoding_order: Float[Array, "N"],
+        mask: Bool[Array, " N"],
+        residue_idx: Int[Array, " N"],
+        chain_encoding_all: Int[Array, " N"],
+        decoding_order: Float[Array, " N"],
         *,
         key=None,
     ):
@@ -500,10 +500,10 @@ class ProteinMPNN(AbstractFromTorch):
 
             X: Float[Array, "N 4 3"] - Coordinates of the atoms in the protein in the order N, C-alpha, C, O
             S: Float[Array, "N 23"] - Sequence as one-hot matrix
-            mask: Bool[Array, "N"] - Mask of valid positions
-            residue_idx: Int[Array, "N"] - Residue index *WITH* gaps of at least 100 between chains
-            chain_encoding_all: Int[Array, "N"] - Chain index as int, e.g. [0 0 0 1 1 1 1 2 2 2]
-            decoding_order: Float[Array, "N"] - Autoregressive decoding order
+            mask: Bool[Array, " N"] - Mask of valid positions
+            residue_idx: Int[Array, " N"] - Residue index *WITH* gaps of at least 100 between chains
+            chain_encoding_all: Int[Array, " N"] - Chain index as int, e.g. [0 0 0 1 1 1 1 2 2 2]
+            decoding_order: Float[Array, " N"] - Autoregressive decoding order
 
         Returns:
 

--- a/src/mosaic/stability_model/train.py
+++ b/src/mosaic/stability_model/train.py
@@ -24,7 +24,7 @@ dataset = load_from_disk("../EsmTherm/datasets/dataset")
 
 
 class Datum(eqx.Module):
-    tokens: Int[Array, "N"]
+    tokens: Int[Array, " N"]
     deltaG: Float
 
 

--- a/src/mosaic/structure_prediction.py
+++ b/src/mosaic/structure_prediction.py
@@ -30,7 +30,7 @@ class TargetChain:
 
 class StructurePrediction(eqx.Module):
     st: gemmi.Structure
-    plddt: Float[Array, "N"]
+    plddt: Float[Array, " N"]
     pae: Float[Array, "N N"]
     iptm: float
     model_output: StructureModelOutput

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+These tests are fully vibed.

--- a/tests/data/1ubq.cif
+++ b/tests/data/1ubq.cif
@@ -1,0 +1,2237 @@
+data_1UBQ
+# 
+_entry.id   1UBQ 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.386 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+_database_2.pdbx_database_accession 
+_database_2.pdbx_DOI 
+PDB   1UBQ         pdb_00001ubq 10.2210/pdb1ubq/pdb 
+WWPDB D_1000176905 ?            ?                   
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 1987-04-16 
+2 'Structure model' 1 1 2008-03-24 
+3 'Structure model' 1 2 2011-07-13 
+4 'Structure model' 1 3 2024-02-14 
+# 
+_pdbx_audit_revision_details.ordinal             1 
+_pdbx_audit_revision_details.revision_ordinal    1 
+_pdbx_audit_revision_details.data_content_type   'Structure model' 
+_pdbx_audit_revision_details.provider            repository 
+_pdbx_audit_revision_details.type                'Initial release' 
+_pdbx_audit_revision_details.description         ? 
+_pdbx_audit_revision_details.details             ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1 2 'Structure model' 'Version format compliance' 
+2 3 'Structure model' 'Version format compliance' 
+3 4 'Structure model' 'Data collection'           
+4 4 'Structure model' 'Database references'       
+5 4 'Structure model' Other                       
+# 
+loop_
+_pdbx_audit_revision_category.ordinal 
+_pdbx_audit_revision_category.revision_ordinal 
+_pdbx_audit_revision_category.data_content_type 
+_pdbx_audit_revision_category.category 
+1 4 'Structure model' chem_comp_atom       
+2 4 'Structure model' chem_comp_bond       
+3 4 'Structure model' database_2           
+4 4 'Structure model' pdbx_database_status 
+# 
+loop_
+_pdbx_audit_revision_item.ordinal 
+_pdbx_audit_revision_item.revision_ordinal 
+_pdbx_audit_revision_item.data_content_type 
+_pdbx_audit_revision_item.item 
+1 4 'Structure model' '_database_2.pdbx_DOI'                
+2 4 'Structure model' '_database_2.pdbx_database_accession' 
+3 4 'Structure model' '_pdbx_database_status.process_site'  
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.entry_id                        1UBQ 
+_pdbx_database_status.recvd_initial_deposition_date   1987-01-02 
+_pdbx_database_status.deposit_site                    ? 
+_pdbx_database_status.process_site                    BNL 
+_pdbx_database_status.status_code_sf                  REL 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.SG_entry                        ? 
+_pdbx_database_status.status_code_cs                  ? 
+_pdbx_database_status.pdb_format_compatible           Y 
+_pdbx_database_status.status_code_nmr_data            ? 
+_pdbx_database_status.methods_development_category    ? 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Vijay-Kumar, S.' 1 
+'Bugg, C.E.'      2 
+'Cook, W.J.'      3 
+# 
+loop_
+_citation.id 
+_citation.title 
+_citation.journal_abbrev 
+_citation.journal_volume 
+_citation.page_first 
+_citation.page_last 
+_citation.year 
+_citation.journal_id_ASTM 
+_citation.country 
+_citation.journal_id_ISSN 
+_citation.journal_id_CSD 
+_citation.book_publisher 
+_citation.pdbx_database_id_PubMed 
+_citation.pdbx_database_id_DOI 
+primary 'Structure of ubiquitin refined at 1.8 A resolution.'                                                 J.Mol.Biol. 194 531  
+544 1987 JMOBAK UK 0022-2836 0070 ? 3041007 '10.1016/0022-2836(87)90679-6' 
+1       'Comparison of the Three-Dimensional Structures of Human, Yeast, and Oat Ubiquitin'                   J.Biol.Chem. 262 
+6396 ?   1987 JBCHA3 US 0021-9258 0071 ? ?       ?                              
+2       'Three-Dimensional Structure of Ubiquitin at 2.8 Angstroms Resolution'                                
+Proc.Natl.Acad.Sci.USA 82  3582 ?   1985 PNASA6 US 0027-8424 0040 ? ?       ?                              
+3       'Crystallization and Preliminary X-Ray Investigation of Ubiquitin, a Non-Histone Chromosomal Protein' J.Mol.Biol. 130 353  
+?   1979 JMOBAK UK 0022-2836 0070 ? ?       ?                              
+4       'Molecular Conservation of 74 Amino Acid Sequence of Ubiquitin between Cattle and Man'                Nature 255 423  ?   
+1975 NATUAS UK 0028-0836 0006 ? ?       ?                              
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+_citation_author.identifier_ORCID 
+primary 'Vijay-Kumar, S.'   1  ? 
+primary 'Bugg, C.E.'        2  ? 
+primary 'Cook, W.J.'        3  ? 
+1       'Vijay-Kumar, S.'   4  ? 
+1       'Bugg, C.E.'        5  ? 
+1       'Wilkinson, K.D.'   6  ? 
+1       'Vierstra, R.D.'    7  ? 
+1       'Hatfield, P.M.'    8  ? 
+1       'Cook, W.J.'        9  ? 
+2       'Vijay-Kumar, S.'   10 ? 
+2       'Bugg, C.E.'        11 ? 
+2       'Wilkinson, K.D.'   12 ? 
+2       'Cook, W.J.'        13 ? 
+3       'Cook, W.J.'        14 ? 
+3       'Suddath, F.L.'     15 ? 
+3       'Bugg, C.E.'        16 ? 
+3       'Goldstein, G.'     17 ? 
+4       'Schlesinger, D.H.' 18 ? 
+4       'Goldstein, G.'     19 ? 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer man UBIQUITIN 8576.831 1  ? ? ? ? 
+2 water   nat water     18.015   58 ? ? ? ? 
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           'polypeptide(L)' 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   no 
+_entity_poly.pdbx_seq_one_letter_code       MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG 
+_entity_poly.pdbx_seq_one_letter_code_can   MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG 
+_entity_poly.pdbx_strand_id                 A 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+_pdbx_entity_nonpoly.entity_id   2 
+_pdbx_entity_nonpoly.name        water 
+_pdbx_entity_nonpoly.comp_id     HOH 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1  MET n 
+1 2  GLN n 
+1 3  ILE n 
+1 4  PHE n 
+1 5  VAL n 
+1 6  LYS n 
+1 7  THR n 
+1 8  LEU n 
+1 9  THR n 
+1 10 GLY n 
+1 11 LYS n 
+1 12 THR n 
+1 13 ILE n 
+1 14 THR n 
+1 15 LEU n 
+1 16 GLU n 
+1 17 VAL n 
+1 18 GLU n 
+1 19 PRO n 
+1 20 SER n 
+1 21 ASP n 
+1 22 THR n 
+1 23 ILE n 
+1 24 GLU n 
+1 25 ASN n 
+1 26 VAL n 
+1 27 LYS n 
+1 28 ALA n 
+1 29 LYS n 
+1 30 ILE n 
+1 31 GLN n 
+1 32 ASP n 
+1 33 LYS n 
+1 34 GLU n 
+1 35 GLY n 
+1 36 ILE n 
+1 37 PRO n 
+1 38 PRO n 
+1 39 ASP n 
+1 40 GLN n 
+1 41 GLN n 
+1 42 ARG n 
+1 43 LEU n 
+1 44 ILE n 
+1 45 PHE n 
+1 46 ALA n 
+1 47 GLY n 
+1 48 LYS n 
+1 49 GLN n 
+1 50 LEU n 
+1 51 GLU n 
+1 52 ASP n 
+1 53 GLY n 
+1 54 ARG n 
+1 55 THR n 
+1 56 LEU n 
+1 57 SER n 
+1 58 ASP n 
+1 59 TYR n 
+1 60 ASN n 
+1 61 ILE n 
+1 62 GLN n 
+1 63 LYS n 
+1 64 GLU n 
+1 65 SER n 
+1 66 THR n 
+1 67 LEU n 
+1 68 HIS n 
+1 69 LEU n 
+1 70 VAL n 
+1 71 LEU n 
+1 72 ARG n 
+1 73 LEU n 
+1 74 ARG n 
+1 75 GLY n 
+1 76 GLY n 
+# 
+_entity_src_gen.entity_id                          1 
+_entity_src_gen.pdbx_src_id                        1 
+_entity_src_gen.pdbx_alt_source_flag               sample 
+_entity_src_gen.pdbx_seq_type                      ? 
+_entity_src_gen.pdbx_beg_seq_num                   ? 
+_entity_src_gen.pdbx_end_seq_num                   ? 
+_entity_src_gen.gene_src_common_name               human 
+_entity_src_gen.gene_src_genus                     Homo 
+_entity_src_gen.pdbx_gene_src_gene                 ? 
+_entity_src_gen.gene_src_species                   ? 
+_entity_src_gen.gene_src_strain                    ? 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'Homo sapiens' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     9606 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      ? 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     ? 
+_entity_src_gen.host_org_genus                     ? 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   ? 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               ? 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          ? 
+_entity_src_gen.pdbx_host_org_vector               ? 
+_entity_src_gen.host_org_details                   ? 
+_entity_src_gen.expression_system_id               ? 
+_entity_src_gen.plasmid_name                       ? 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking' y ALANINE         ? 'C3 H7 N O2'     89.093  
+ARG 'L-peptide linking' y ARGININE        ? 'C6 H15 N4 O2 1' 175.209 
+ASN 'L-peptide linking' y ASPARAGINE      ? 'C4 H8 N2 O3'    132.118 
+ASP 'L-peptide linking' y 'ASPARTIC ACID' ? 'C4 H7 N O4'     133.103 
+GLN 'L-peptide linking' y GLUTAMINE       ? 'C5 H10 N2 O3'   146.144 
+GLU 'L-peptide linking' y 'GLUTAMIC ACID' ? 'C5 H9 N O4'     147.129 
+GLY 'peptide linking'   y GLYCINE         ? 'C2 H5 N O2'     75.067  
+HIS 'L-peptide linking' y HISTIDINE       ? 'C6 H10 N3 O2 1' 156.162 
+HOH non-polymer         . WATER           ? 'H2 O'           18.015  
+ILE 'L-peptide linking' y ISOLEUCINE      ? 'C6 H13 N O2'    131.173 
+LEU 'L-peptide linking' y LEUCINE         ? 'C6 H13 N O2'    131.173 
+LYS 'L-peptide linking' y LYSINE          ? 'C6 H15 N2 O2 1' 147.195 
+MET 'L-peptide linking' y METHIONINE      ? 'C5 H11 N O2 S'  149.211 
+PHE 'L-peptide linking' y PHENYLALANINE   ? 'C9 H11 N O2'    165.189 
+PRO 'L-peptide linking' y PROLINE         ? 'C5 H9 N O2'     115.130 
+SER 'L-peptide linking' y SERINE          ? 'C3 H7 N O3'     105.093 
+THR 'L-peptide linking' y THREONINE       ? 'C4 H9 N O3'     119.119 
+TYR 'L-peptide linking' y TYROSINE        ? 'C9 H11 N O3'    181.189 
+VAL 'L-peptide linking' y VALINE          ? 'C5 H11 N O2'    117.146 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1  MET 1  1  1  MET MET A . n 
+A 1 2  GLN 2  2  2  GLN GLN A . n 
+A 1 3  ILE 3  3  3  ILE ILE A . n 
+A 1 4  PHE 4  4  4  PHE PHE A . n 
+A 1 5  VAL 5  5  5  VAL VAL A . n 
+A 1 6  LYS 6  6  6  LYS LYS A . n 
+A 1 7  THR 7  7  7  THR THR A . n 
+A 1 8  LEU 8  8  8  LEU LEU A . n 
+A 1 9  THR 9  9  9  THR THR A . n 
+A 1 10 GLY 10 10 10 GLY GLY A . n 
+A 1 11 LYS 11 11 11 LYS LYS A . n 
+A 1 12 THR 12 12 12 THR THR A . n 
+A 1 13 ILE 13 13 13 ILE ILE A . n 
+A 1 14 THR 14 14 14 THR THR A . n 
+A 1 15 LEU 15 15 15 LEU LEU A . n 
+A 1 16 GLU 16 16 16 GLU GLU A . n 
+A 1 17 VAL 17 17 17 VAL VAL A . n 
+A 1 18 GLU 18 18 18 GLU GLU A . n 
+A 1 19 PRO 19 19 19 PRO PRO A . n 
+A 1 20 SER 20 20 20 SER SER A . n 
+A 1 21 ASP 21 21 21 ASP ASP A . n 
+A 1 22 THR 22 22 22 THR THR A . n 
+A 1 23 ILE 23 23 23 ILE ILE A . n 
+A 1 24 GLU 24 24 24 GLU GLU A . n 
+A 1 25 ASN 25 25 25 ASN ASN A . n 
+A 1 26 VAL 26 26 26 VAL VAL A . n 
+A 1 27 LYS 27 27 27 LYS LYS A . n 
+A 1 28 ALA 28 28 28 ALA ALA A . n 
+A 1 29 LYS 29 29 29 LYS LYS A . n 
+A 1 30 ILE 30 30 30 ILE ILE A . n 
+A 1 31 GLN 31 31 31 GLN GLN A . n 
+A 1 32 ASP 32 32 32 ASP ASP A . n 
+A 1 33 LYS 33 33 33 LYS LYS A . n 
+A 1 34 GLU 34 34 34 GLU GLU A . n 
+A 1 35 GLY 35 35 35 GLY GLY A . n 
+A 1 36 ILE 36 36 36 ILE ILE A . n 
+A 1 37 PRO 37 37 37 PRO PRO A . n 
+A 1 38 PRO 38 38 38 PRO PRO A . n 
+A 1 39 ASP 39 39 39 ASP ASP A . n 
+A 1 40 GLN 40 40 40 GLN GLN A . n 
+A 1 41 GLN 41 41 41 GLN GLN A . n 
+A 1 42 ARG 42 42 42 ARG ARG A . n 
+A 1 43 LEU 43 43 43 LEU LEU A . n 
+A 1 44 ILE 44 44 44 ILE ILE A . n 
+A 1 45 PHE 45 45 45 PHE PHE A . n 
+A 1 46 ALA 46 46 46 ALA ALA A . n 
+A 1 47 GLY 47 47 47 GLY GLY A . n 
+A 1 48 LYS 48 48 48 LYS LYS A . n 
+A 1 49 GLN 49 49 49 GLN GLN A . n 
+A 1 50 LEU 50 50 50 LEU LEU A . n 
+A 1 51 GLU 51 51 51 GLU GLU A . n 
+A 1 52 ASP 52 52 52 ASP ASP A . n 
+A 1 53 GLY 53 53 53 GLY GLY A . n 
+A 1 54 ARG 54 54 54 ARG ARG A . n 
+A 1 55 THR 55 55 55 THR THR A . n 
+A 1 56 LEU 56 56 56 LEU LEU A . n 
+A 1 57 SER 57 57 57 SER SER A . n 
+A 1 58 ASP 58 58 58 ASP ASP A . n 
+A 1 59 TYR 59 59 59 TYR TYR A . n 
+A 1 60 ASN 60 60 60 ASN ASN A . n 
+A 1 61 ILE 61 61 61 ILE ILE A . n 
+A 1 62 GLN 62 62 62 GLN GLN A . n 
+A 1 63 LYS 63 63 63 LYS LYS A . n 
+A 1 64 GLU 64 64 64 GLU GLU A . n 
+A 1 65 SER 65 65 65 SER SER A . n 
+A 1 66 THR 66 66 66 THR THR A . n 
+A 1 67 LEU 67 67 67 LEU LEU A . n 
+A 1 68 HIS 68 68 68 HIS HIS A . n 
+A 1 69 LEU 69 69 69 LEU LEU A . n 
+A 1 70 VAL 70 70 70 VAL VAL A . n 
+A 1 71 LEU 71 71 71 LEU LEU A . n 
+A 1 72 ARG 72 72 72 ARG ARG A . n 
+A 1 73 LEU 73 73 73 LEU LEU A . n 
+A 1 74 ARG 74 74 74 ARG ARG A . n 
+A 1 75 GLY 75 75 75 GLY GLY A . n 
+A 1 76 GLY 76 76 76 GLY GLY A . n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+B 2 HOH 1  77  1  HOH HOH A . 
+B 2 HOH 2  78  2  HOH HOH A . 
+B 2 HOH 3  79  3  HOH HOH A . 
+B 2 HOH 4  80  4  HOH HOH A . 
+B 2 HOH 5  81  5  HOH HOH A . 
+B 2 HOH 6  82  6  HOH HOH A . 
+B 2 HOH 7  83  7  HOH HOH A . 
+B 2 HOH 8  84  8  HOH HOH A . 
+B 2 HOH 9  85  9  HOH HOH A . 
+B 2 HOH 10 86  10 HOH HOH A . 
+B 2 HOH 11 87  11 HOH HOH A . 
+B 2 HOH 12 88  12 HOH HOH A . 
+B 2 HOH 13 89  13 HOH HOH A . 
+B 2 HOH 14 90  14 HOH HOH A . 
+B 2 HOH 15 91  15 HOH HOH A . 
+B 2 HOH 16 92  16 HOH HOH A . 
+B 2 HOH 17 93  17 HOH HOH A . 
+B 2 HOH 18 94  18 HOH HOH A . 
+B 2 HOH 19 95  19 HOH HOH A . 
+B 2 HOH 20 96  20 HOH HOH A . 
+B 2 HOH 21 97  21 HOH HOH A . 
+B 2 HOH 22 98  22 HOH HOH A . 
+B 2 HOH 23 99  23 HOH HOH A . 
+B 2 HOH 24 100 24 HOH HOH A . 
+B 2 HOH 25 101 25 HOH HOH A . 
+B 2 HOH 26 102 26 HOH HOH A . 
+B 2 HOH 27 103 27 HOH HOH A . 
+B 2 HOH 28 104 28 HOH HOH A . 
+B 2 HOH 29 105 29 HOH HOH A . 
+B 2 HOH 30 106 30 HOH HOH A . 
+B 2 HOH 31 107 31 HOH HOH A . 
+B 2 HOH 32 108 32 HOH HOH A . 
+B 2 HOH 33 109 33 HOH HOH A . 
+B 2 HOH 34 110 34 HOH HOH A . 
+B 2 HOH 35 111 35 HOH HOH A . 
+B 2 HOH 36 112 36 HOH HOH A . 
+B 2 HOH 37 113 37 HOH HOH A . 
+B 2 HOH 38 114 38 HOH HOH A . 
+B 2 HOH 39 115 39 HOH HOH A . 
+B 2 HOH 40 116 40 HOH HOH A . 
+B 2 HOH 41 117 41 HOH HOH A . 
+B 2 HOH 42 118 42 HOH HOH A . 
+B 2 HOH 43 119 43 HOH HOH A . 
+B 2 HOH 44 120 44 HOH HOH A . 
+B 2 HOH 45 121 45 HOH HOH A . 
+B 2 HOH 46 122 46 HOH HOH A . 
+B 2 HOH 47 123 47 HOH HOH A . 
+B 2 HOH 48 124 48 HOH HOH A . 
+B 2 HOH 49 125 49 HOH HOH A . 
+B 2 HOH 50 126 50 HOH HOH A . 
+B 2 HOH 51 127 51 HOH HOH A . 
+B 2 HOH 52 128 52 HOH HOH A . 
+B 2 HOH 53 129 53 HOH HOH A . 
+B 2 HOH 54 130 54 HOH HOH A . 
+B 2 HOH 55 131 55 HOH HOH A . 
+B 2 HOH 56 132 56 HOH HOH A . 
+B 2 HOH 57 133 57 HOH HOH A . 
+B 2 HOH 58 134 58 HOH HOH A . 
+# 
+_software.name             PROLSQ 
+_software.classification   refinement 
+_software.version          . 
+_software.citation_id      ? 
+_software.pdbx_ordinal     1 
+# 
+_cell.entry_id           1UBQ 
+_cell.length_a           50.840 
+_cell.length_b           42.770 
+_cell.length_c           28.950 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        90.00 
+_cell.Z_PDB              4 
+_cell.pdbx_unique_axis   ? 
+_cell.length_a_esd       ? 
+_cell.length_b_esd       ? 
+_cell.length_c_esd       ? 
+_cell.angle_alpha_esd    ? 
+_cell.angle_beta_esd     ? 
+_cell.angle_gamma_esd    ? 
+# 
+_symmetry.entry_id                         1UBQ 
+_symmetry.space_group_name_H-M             'P 21 21 21' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                19 
+_symmetry.space_group_name_Hall            ? 
+# 
+_exptl.entry_id          1UBQ 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   ? 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      1.83 
+_exptl_crystal.density_percent_sol   32.94 
+_exptl_crystal.description           ? 
+_exptl_crystal.F_000                 ? 
+_exptl_crystal.preparation           ? 
+# 
+_diffrn.id                     1 
+_diffrn.ambient_temp           ? 
+_diffrn.ambient_temp_details   ? 
+_diffrn.crystal_id             1 
+# 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.monochromator                    ? 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   ? 
+_diffrn_radiation.pdbx_diffrn_protocol             ? 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   . 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_refine.entry_id                                 1UBQ 
+_refine.ls_number_reflns_obs                     ? 
+_refine.ls_number_reflns_all                     ? 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          ? 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.ls_d_res_low                             ? 
+_refine.ls_d_res_high                            1.8 
+_refine.ls_percent_reflns_obs                    ? 
+_refine.ls_R_factor_obs                          0.1760000 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_R_work                       ? 
+_refine.ls_R_factor_R_free                       ? 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 ? 
+_refine.ls_number_reflns_R_free                  ? 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_restraints                     ? 
+_refine.occupancy_min                            ? 
+_refine.occupancy_max                            ? 
+_refine.B_iso_mean                               ? 
+_refine.aniso_B[1][1]                            ? 
+_refine.aniso_B[2][2]                            ? 
+_refine.aniso_B[3][3]                            ? 
+_refine.aniso_B[1][2]                            ? 
+_refine.aniso_B[1][3]                            ? 
+_refine.aniso_B[2][3]                            ? 
+_refine.solvent_model_details                    ? 
+_refine.solvent_model_param_ksol                 ? 
+_refine.solvent_model_param_bsol                 ? 
+_refine.pdbx_ls_cross_valid_method               ? 
+_refine.details                                  ? 
+_refine.pdbx_starting_model                      ? 
+_refine.pdbx_method_to_determine_struct          ? 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_stereochemistry_target_values       ? 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            ? 
+_refine.pdbx_overall_ESU_R_Free                  ? 
+_refine.overall_SU_ML                            ? 
+_refine.overall_SU_B                             ? 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.ls_redundancy_reflns_obs                 ? 
+_refine.pdbx_overall_ESU_R                       ? 
+_refine.pdbx_overall_phase_error                 ? 
+_refine.B_iso_min                                ? 
+_refine.B_iso_max                                ? 
+_refine.correlation_coeff_Fo_to_Fc               ? 
+_refine.correlation_coeff_Fo_to_Fc_free          ? 
+_refine.pdbx_solvent_vdw_probe_radii             ? 
+_refine.pdbx_solvent_ion_probe_radii             ? 
+_refine.pdbx_solvent_shrinkage_radii             ? 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.overall_SU_R_free                        ? 
+_refine.ls_wR_factor_R_free                      ? 
+_refine.ls_wR_factor_R_work                      ? 
+_refine.overall_FOM_free_R_set                   ? 
+_refine.overall_FOM_work_R_set                   ? 
+_refine.pdbx_diffrn_id                           1 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        602 
+_refine_hist.pdbx_number_atoms_nucleic_acid   0 
+_refine_hist.pdbx_number_atoms_ligand         0 
+_refine_hist.number_atoms_solvent             58 
+_refine_hist.number_atoms_total               660 
+_refine_hist.d_res_high                       1.8 
+_refine_hist.d_res_low                        . 
+# 
+loop_
+_refine_ls_restr.type 
+_refine_ls_restr.dev_ideal 
+_refine_ls_restr.dev_ideal_target 
+_refine_ls_restr.weight 
+_refine_ls_restr.number 
+_refine_ls_restr.pdbx_refine_id 
+_refine_ls_restr.pdbx_restraint_function 
+p_bond_d    0.016 ? ? ? 'X-RAY DIFFRACTION' ? 
+p_angle_deg 1.5   ? ? ? 'X-RAY DIFFRACTION' ? 
+# 
+_database_PDB_matrix.entry_id          1UBQ 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.00000 
+_database_PDB_matrix.origx_vector[2]   0.00000 
+_database_PDB_matrix.origx_vector[3]   0.00000 
+# 
+_struct.entry_id                  1UBQ 
+_struct.title                     'STRUCTURE OF UBIQUITIN REFINED AT 1.8 ANGSTROMS RESOLUTION' 
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        1UBQ 
+_struct_keywords.pdbx_keywords   'CHROMOSOMAL PROTEIN' 
+_struct_keywords.text            'CHROMOSOMAL PROTEIN' 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 2 ? 
+# 
+_struct_ref.id                         1 
+_struct_ref.db_name                    UNP 
+_struct_ref.db_code                    UBIQ_HUMAN 
+_struct_ref.entity_id                  1 
+_struct_ref.pdbx_db_accession          P62988 
+_struct_ref.pdbx_align_begin           1 
+_struct_ref.pdbx_seq_one_letter_code   MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG 
+_struct_ref.pdbx_db_isoform            ? 
+# 
+_struct_ref_seq.align_id                      1 
+_struct_ref_seq.ref_id                        1 
+_struct_ref_seq.pdbx_PDB_id_code              1UBQ 
+_struct_ref_seq.pdbx_strand_id                A 
+_struct_ref_seq.seq_align_beg                 1 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code   ? 
+_struct_ref_seq.seq_align_end                 76 
+_struct_ref_seq.pdbx_seq_align_end_ins_code   ? 
+_struct_ref_seq.pdbx_db_accession             P62988 
+_struct_ref_seq.db_align_beg                  1 
+_struct_ref_seq.pdbx_db_align_beg_ins_code    ? 
+_struct_ref_seq.db_align_end                  76 
+_struct_ref_seq.pdbx_db_align_end_ins_code    ? 
+_struct_ref_seq.pdbx_auth_seq_align_beg       1 
+_struct_ref_seq.pdbx_auth_seq_align_end       76 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   monomeric 
+_pdbx_struct_assembly.oligomeric_count     1 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A,B 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+_struct_biol.id        1 
+_struct_biol.details   ? 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1 H1 ILE A 23 ? GLU A 34 ? ILE A 23 GLU A 34 1 ? 12 
+HELX_P HELX_P2 H2 LEU A 56 ? TYR A 59 ? LEU A 56 TYR A 59 5 ? 4  
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+_struct_sheet.id               BET 
+_struct_sheet.type             ? 
+_struct_sheet.number_strands   5 
+_struct_sheet.details          ? 
+# 
+loop_
+_struct_sheet_order.sheet_id 
+_struct_sheet_order.range_id_1 
+_struct_sheet_order.range_id_2 
+_struct_sheet_order.offset 
+_struct_sheet_order.sense 
+BET 1 2 ? anti-parallel 
+BET 2 3 ? parallel      
+BET 3 4 ? anti-parallel 
+BET 4 5 ? anti-parallel 
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+BET 1 GLY A 10 ? VAL A 17 ? GLY A 10 VAL A 17 
+BET 2 MET A 1  ? THR A 7  ? MET A 1  THR A 7  
+BET 3 GLU A 64 ? ARG A 72 ? GLU A 64 ARG A 72 
+BET 4 GLN A 40 ? PHE A 45 ? GLN A 40 PHE A 45 
+BET 5 LYS A 48 ? LEU A 50 ? LYS A 48 LEU A 50 
+# 
+loop_
+_pdbx_validate_symm_contact.id 
+_pdbx_validate_symm_contact.PDB_model_num 
+_pdbx_validate_symm_contact.auth_atom_id_1 
+_pdbx_validate_symm_contact.auth_asym_id_1 
+_pdbx_validate_symm_contact.auth_comp_id_1 
+_pdbx_validate_symm_contact.auth_seq_id_1 
+_pdbx_validate_symm_contact.PDB_ins_code_1 
+_pdbx_validate_symm_contact.label_alt_id_1 
+_pdbx_validate_symm_contact.site_symmetry_1 
+_pdbx_validate_symm_contact.auth_atom_id_2 
+_pdbx_validate_symm_contact.auth_asym_id_2 
+_pdbx_validate_symm_contact.auth_comp_id_2 
+_pdbx_validate_symm_contact.auth_seq_id_2 
+_pdbx_validate_symm_contact.PDB_ins_code_2 
+_pdbx_validate_symm_contact.label_alt_id_2 
+_pdbx_validate_symm_contact.site_symmetry_2 
+_pdbx_validate_symm_contact.dist 
+1 1 OE2 A GLU 16 ? ? 1_555 NH1 A ARG 72 ? ? 1_554 2.02 
+2 1 NZ  A LYS 48 ? ? 1_555 OXT A GLY 76 ? ? 4_467 2.16 
+# 
+loop_
+_pdbx_validate_rmsd_angle.id 
+_pdbx_validate_rmsd_angle.PDB_model_num 
+_pdbx_validate_rmsd_angle.auth_atom_id_1 
+_pdbx_validate_rmsd_angle.auth_asym_id_1 
+_pdbx_validate_rmsd_angle.auth_comp_id_1 
+_pdbx_validate_rmsd_angle.auth_seq_id_1 
+_pdbx_validate_rmsd_angle.PDB_ins_code_1 
+_pdbx_validate_rmsd_angle.label_alt_id_1 
+_pdbx_validate_rmsd_angle.auth_atom_id_2 
+_pdbx_validate_rmsd_angle.auth_asym_id_2 
+_pdbx_validate_rmsd_angle.auth_comp_id_2 
+_pdbx_validate_rmsd_angle.auth_seq_id_2 
+_pdbx_validate_rmsd_angle.PDB_ins_code_2 
+_pdbx_validate_rmsd_angle.label_alt_id_2 
+_pdbx_validate_rmsd_angle.auth_atom_id_3 
+_pdbx_validate_rmsd_angle.auth_asym_id_3 
+_pdbx_validate_rmsd_angle.auth_comp_id_3 
+_pdbx_validate_rmsd_angle.auth_seq_id_3 
+_pdbx_validate_rmsd_angle.PDB_ins_code_3 
+_pdbx_validate_rmsd_angle.label_alt_id_3 
+_pdbx_validate_rmsd_angle.angle_value 
+_pdbx_validate_rmsd_angle.angle_target_value 
+_pdbx_validate_rmsd_angle.angle_deviation 
+_pdbx_validate_rmsd_angle.angle_standard_deviation 
+_pdbx_validate_rmsd_angle.linker_flag 
+1 1 CA A LEU 15 ? ? CB A LEU 15 ? ? CG  A LEU 15 ? ? 129.31 115.30 14.01 2.30 N 
+2 1 CD A ARG 54 ? ? NE A ARG 54 ? ? CZ  A ARG 54 ? ? 135.97 123.60 12.37 1.40 N 
+3 1 NE A ARG 54 ? ? CZ A ARG 54 ? ? NH1 A ARG 54 ? ? 125.77 120.30 5.47  0.50 N 
+# 
+loop_
+_chem_comp_atom.comp_id 
+_chem_comp_atom.atom_id 
+_chem_comp_atom.type_symbol 
+_chem_comp_atom.pdbx_aromatic_flag 
+_chem_comp_atom.pdbx_stereo_config 
+_chem_comp_atom.pdbx_ordinal 
+ALA N    N N N 1   
+ALA CA   C N S 2   
+ALA C    C N N 3   
+ALA O    O N N 4   
+ALA CB   C N N 5   
+ALA OXT  O N N 6   
+ALA H    H N N 7   
+ALA H2   H N N 8   
+ALA HA   H N N 9   
+ALA HB1  H N N 10  
+ALA HB2  H N N 11  
+ALA HB3  H N N 12  
+ALA HXT  H N N 13  
+ARG N    N N N 14  
+ARG CA   C N S 15  
+ARG C    C N N 16  
+ARG O    O N N 17  
+ARG CB   C N N 18  
+ARG CG   C N N 19  
+ARG CD   C N N 20  
+ARG NE   N N N 21  
+ARG CZ   C N N 22  
+ARG NH1  N N N 23  
+ARG NH2  N N N 24  
+ARG OXT  O N N 25  
+ARG H    H N N 26  
+ARG H2   H N N 27  
+ARG HA   H N N 28  
+ARG HB2  H N N 29  
+ARG HB3  H N N 30  
+ARG HG2  H N N 31  
+ARG HG3  H N N 32  
+ARG HD2  H N N 33  
+ARG HD3  H N N 34  
+ARG HE   H N N 35  
+ARG HH11 H N N 36  
+ARG HH12 H N N 37  
+ARG HH21 H N N 38  
+ARG HH22 H N N 39  
+ARG HXT  H N N 40  
+ASN N    N N N 41  
+ASN CA   C N S 42  
+ASN C    C N N 43  
+ASN O    O N N 44  
+ASN CB   C N N 45  
+ASN CG   C N N 46  
+ASN OD1  O N N 47  
+ASN ND2  N N N 48  
+ASN OXT  O N N 49  
+ASN H    H N N 50  
+ASN H2   H N N 51  
+ASN HA   H N N 52  
+ASN HB2  H N N 53  
+ASN HB3  H N N 54  
+ASN HD21 H N N 55  
+ASN HD22 H N N 56  
+ASN HXT  H N N 57  
+ASP N    N N N 58  
+ASP CA   C N S 59  
+ASP C    C N N 60  
+ASP O    O N N 61  
+ASP CB   C N N 62  
+ASP CG   C N N 63  
+ASP OD1  O N N 64  
+ASP OD2  O N N 65  
+ASP OXT  O N N 66  
+ASP H    H N N 67  
+ASP H2   H N N 68  
+ASP HA   H N N 69  
+ASP HB2  H N N 70  
+ASP HB3  H N N 71  
+ASP HD2  H N N 72  
+ASP HXT  H N N 73  
+GLN N    N N N 74  
+GLN CA   C N S 75  
+GLN C    C N N 76  
+GLN O    O N N 77  
+GLN CB   C N N 78  
+GLN CG   C N N 79  
+GLN CD   C N N 80  
+GLN OE1  O N N 81  
+GLN NE2  N N N 82  
+GLN OXT  O N N 83  
+GLN H    H N N 84  
+GLN H2   H N N 85  
+GLN HA   H N N 86  
+GLN HB2  H N N 87  
+GLN HB3  H N N 88  
+GLN HG2  H N N 89  
+GLN HG3  H N N 90  
+GLN HE21 H N N 91  
+GLN HE22 H N N 92  
+GLN HXT  H N N 93  
+GLU N    N N N 94  
+GLU CA   C N S 95  
+GLU C    C N N 96  
+GLU O    O N N 97  
+GLU CB   C N N 98  
+GLU CG   C N N 99  
+GLU CD   C N N 100 
+GLU OE1  O N N 101 
+GLU OE2  O N N 102 
+GLU OXT  O N N 103 
+GLU H    H N N 104 
+GLU H2   H N N 105 
+GLU HA   H N N 106 
+GLU HB2  H N N 107 
+GLU HB3  H N N 108 
+GLU HG2  H N N 109 
+GLU HG3  H N N 110 
+GLU HE2  H N N 111 
+GLU HXT  H N N 112 
+GLY N    N N N 113 
+GLY CA   C N N 114 
+GLY C    C N N 115 
+GLY O    O N N 116 
+GLY OXT  O N N 117 
+GLY H    H N N 118 
+GLY H2   H N N 119 
+GLY HA2  H N N 120 
+GLY HA3  H N N 121 
+GLY HXT  H N N 122 
+HIS N    N N N 123 
+HIS CA   C N S 124 
+HIS C    C N N 125 
+HIS O    O N N 126 
+HIS CB   C N N 127 
+HIS CG   C Y N 128 
+HIS ND1  N Y N 129 
+HIS CD2  C Y N 130 
+HIS CE1  C Y N 131 
+HIS NE2  N Y N 132 
+HIS OXT  O N N 133 
+HIS H    H N N 134 
+HIS H2   H N N 135 
+HIS HA   H N N 136 
+HIS HB2  H N N 137 
+HIS HB3  H N N 138 
+HIS HD1  H N N 139 
+HIS HD2  H N N 140 
+HIS HE1  H N N 141 
+HIS HE2  H N N 142 
+HIS HXT  H N N 143 
+HOH O    O N N 144 
+HOH H1   H N N 145 
+HOH H2   H N N 146 
+ILE N    N N N 147 
+ILE CA   C N S 148 
+ILE C    C N N 149 
+ILE O    O N N 150 
+ILE CB   C N S 151 
+ILE CG1  C N N 152 
+ILE CG2  C N N 153 
+ILE CD1  C N N 154 
+ILE OXT  O N N 155 
+ILE H    H N N 156 
+ILE H2   H N N 157 
+ILE HA   H N N 158 
+ILE HB   H N N 159 
+ILE HG12 H N N 160 
+ILE HG13 H N N 161 
+ILE HG21 H N N 162 
+ILE HG22 H N N 163 
+ILE HG23 H N N 164 
+ILE HD11 H N N 165 
+ILE HD12 H N N 166 
+ILE HD13 H N N 167 
+ILE HXT  H N N 168 
+LEU N    N N N 169 
+LEU CA   C N S 170 
+LEU C    C N N 171 
+LEU O    O N N 172 
+LEU CB   C N N 173 
+LEU CG   C N N 174 
+LEU CD1  C N N 175 
+LEU CD2  C N N 176 
+LEU OXT  O N N 177 
+LEU H    H N N 178 
+LEU H2   H N N 179 
+LEU HA   H N N 180 
+LEU HB2  H N N 181 
+LEU HB3  H N N 182 
+LEU HG   H N N 183 
+LEU HD11 H N N 184 
+LEU HD12 H N N 185 
+LEU HD13 H N N 186 
+LEU HD21 H N N 187 
+LEU HD22 H N N 188 
+LEU HD23 H N N 189 
+LEU HXT  H N N 190 
+LYS N    N N N 191 
+LYS CA   C N S 192 
+LYS C    C N N 193 
+LYS O    O N N 194 
+LYS CB   C N N 195 
+LYS CG   C N N 196 
+LYS CD   C N N 197 
+LYS CE   C N N 198 
+LYS NZ   N N N 199 
+LYS OXT  O N N 200 
+LYS H    H N N 201 
+LYS H2   H N N 202 
+LYS HA   H N N 203 
+LYS HB2  H N N 204 
+LYS HB3  H N N 205 
+LYS HG2  H N N 206 
+LYS HG3  H N N 207 
+LYS HD2  H N N 208 
+LYS HD3  H N N 209 
+LYS HE2  H N N 210 
+LYS HE3  H N N 211 
+LYS HZ1  H N N 212 
+LYS HZ2  H N N 213 
+LYS HZ3  H N N 214 
+LYS HXT  H N N 215 
+MET N    N N N 216 
+MET CA   C N S 217 
+MET C    C N N 218 
+MET O    O N N 219 
+MET CB   C N N 220 
+MET CG   C N N 221 
+MET SD   S N N 222 
+MET CE   C N N 223 
+MET OXT  O N N 224 
+MET H    H N N 225 
+MET H2   H N N 226 
+MET HA   H N N 227 
+MET HB2  H N N 228 
+MET HB3  H N N 229 
+MET HG2  H N N 230 
+MET HG3  H N N 231 
+MET HE1  H N N 232 
+MET HE2  H N N 233 
+MET HE3  H N N 234 
+MET HXT  H N N 235 
+PHE N    N N N 236 
+PHE CA   C N S 237 
+PHE C    C N N 238 
+PHE O    O N N 239 
+PHE CB   C N N 240 
+PHE CG   C Y N 241 
+PHE CD1  C Y N 242 
+PHE CD2  C Y N 243 
+PHE CE1  C Y N 244 
+PHE CE2  C Y N 245 
+PHE CZ   C Y N 246 
+PHE OXT  O N N 247 
+PHE H    H N N 248 
+PHE H2   H N N 249 
+PHE HA   H N N 250 
+PHE HB2  H N N 251 
+PHE HB3  H N N 252 
+PHE HD1  H N N 253 
+PHE HD2  H N N 254 
+PHE HE1  H N N 255 
+PHE HE2  H N N 256 
+PHE HZ   H N N 257 
+PHE HXT  H N N 258 
+PRO N    N N N 259 
+PRO CA   C N S 260 
+PRO C    C N N 261 
+PRO O    O N N 262 
+PRO CB   C N N 263 
+PRO CG   C N N 264 
+PRO CD   C N N 265 
+PRO OXT  O N N 266 
+PRO H    H N N 267 
+PRO HA   H N N 268 
+PRO HB2  H N N 269 
+PRO HB3  H N N 270 
+PRO HG2  H N N 271 
+PRO HG3  H N N 272 
+PRO HD2  H N N 273 
+PRO HD3  H N N 274 
+PRO HXT  H N N 275 
+SER N    N N N 276 
+SER CA   C N S 277 
+SER C    C N N 278 
+SER O    O N N 279 
+SER CB   C N N 280 
+SER OG   O N N 281 
+SER OXT  O N N 282 
+SER H    H N N 283 
+SER H2   H N N 284 
+SER HA   H N N 285 
+SER HB2  H N N 286 
+SER HB3  H N N 287 
+SER HG   H N N 288 
+SER HXT  H N N 289 
+THR N    N N N 290 
+THR CA   C N S 291 
+THR C    C N N 292 
+THR O    O N N 293 
+THR CB   C N R 294 
+THR OG1  O N N 295 
+THR CG2  C N N 296 
+THR OXT  O N N 297 
+THR H    H N N 298 
+THR H2   H N N 299 
+THR HA   H N N 300 
+THR HB   H N N 301 
+THR HG1  H N N 302 
+THR HG21 H N N 303 
+THR HG22 H N N 304 
+THR HG23 H N N 305 
+THR HXT  H N N 306 
+TYR N    N N N 307 
+TYR CA   C N S 308 
+TYR C    C N N 309 
+TYR O    O N N 310 
+TYR CB   C N N 311 
+TYR CG   C Y N 312 
+TYR CD1  C Y N 313 
+TYR CD2  C Y N 314 
+TYR CE1  C Y N 315 
+TYR CE2  C Y N 316 
+TYR CZ   C Y N 317 
+TYR OH   O N N 318 
+TYR OXT  O N N 319 
+TYR H    H N N 320 
+TYR H2   H N N 321 
+TYR HA   H N N 322 
+TYR HB2  H N N 323 
+TYR HB3  H N N 324 
+TYR HD1  H N N 325 
+TYR HD2  H N N 326 
+TYR HE1  H N N 327 
+TYR HE2  H N N 328 
+TYR HH   H N N 329 
+TYR HXT  H N N 330 
+VAL N    N N N 331 
+VAL CA   C N S 332 
+VAL C    C N N 333 
+VAL O    O N N 334 
+VAL CB   C N N 335 
+VAL CG1  C N N 336 
+VAL CG2  C N N 337 
+VAL OXT  O N N 338 
+VAL H    H N N 339 
+VAL H2   H N N 340 
+VAL HA   H N N 341 
+VAL HB   H N N 342 
+VAL HG11 H N N 343 
+VAL HG12 H N N 344 
+VAL HG13 H N N 345 
+VAL HG21 H N N 346 
+VAL HG22 H N N 347 
+VAL HG23 H N N 348 
+VAL HXT  H N N 349 
+# 
+loop_
+_chem_comp_bond.comp_id 
+_chem_comp_bond.atom_id_1 
+_chem_comp_bond.atom_id_2 
+_chem_comp_bond.value_order 
+_chem_comp_bond.pdbx_aromatic_flag 
+_chem_comp_bond.pdbx_stereo_config 
+_chem_comp_bond.pdbx_ordinal 
+ALA N   CA   sing N N 1   
+ALA N   H    sing N N 2   
+ALA N   H2   sing N N 3   
+ALA CA  C    sing N N 4   
+ALA CA  CB   sing N N 5   
+ALA CA  HA   sing N N 6   
+ALA C   O    doub N N 7   
+ALA C   OXT  sing N N 8   
+ALA CB  HB1  sing N N 9   
+ALA CB  HB2  sing N N 10  
+ALA CB  HB3  sing N N 11  
+ALA OXT HXT  sing N N 12  
+ARG N   CA   sing N N 13  
+ARG N   H    sing N N 14  
+ARG N   H2   sing N N 15  
+ARG CA  C    sing N N 16  
+ARG CA  CB   sing N N 17  
+ARG CA  HA   sing N N 18  
+ARG C   O    doub N N 19  
+ARG C   OXT  sing N N 20  
+ARG CB  CG   sing N N 21  
+ARG CB  HB2  sing N N 22  
+ARG CB  HB3  sing N N 23  
+ARG CG  CD   sing N N 24  
+ARG CG  HG2  sing N N 25  
+ARG CG  HG3  sing N N 26  
+ARG CD  NE   sing N N 27  
+ARG CD  HD2  sing N N 28  
+ARG CD  HD3  sing N N 29  
+ARG NE  CZ   sing N N 30  
+ARG NE  HE   sing N N 31  
+ARG CZ  NH1  sing N N 32  
+ARG CZ  NH2  doub N N 33  
+ARG NH1 HH11 sing N N 34  
+ARG NH1 HH12 sing N N 35  
+ARG NH2 HH21 sing N N 36  
+ARG NH2 HH22 sing N N 37  
+ARG OXT HXT  sing N N 38  
+ASN N   CA   sing N N 39  
+ASN N   H    sing N N 40  
+ASN N   H2   sing N N 41  
+ASN CA  C    sing N N 42  
+ASN CA  CB   sing N N 43  
+ASN CA  HA   sing N N 44  
+ASN C   O    doub N N 45  
+ASN C   OXT  sing N N 46  
+ASN CB  CG   sing N N 47  
+ASN CB  HB2  sing N N 48  
+ASN CB  HB3  sing N N 49  
+ASN CG  OD1  doub N N 50  
+ASN CG  ND2  sing N N 51  
+ASN ND2 HD21 sing N N 52  
+ASN ND2 HD22 sing N N 53  
+ASN OXT HXT  sing N N 54  
+ASP N   CA   sing N N 55  
+ASP N   H    sing N N 56  
+ASP N   H2   sing N N 57  
+ASP CA  C    sing N N 58  
+ASP CA  CB   sing N N 59  
+ASP CA  HA   sing N N 60  
+ASP C   O    doub N N 61  
+ASP C   OXT  sing N N 62  
+ASP CB  CG   sing N N 63  
+ASP CB  HB2  sing N N 64  
+ASP CB  HB3  sing N N 65  
+ASP CG  OD1  doub N N 66  
+ASP CG  OD2  sing N N 67  
+ASP OD2 HD2  sing N N 68  
+ASP OXT HXT  sing N N 69  
+GLN N   CA   sing N N 70  
+GLN N   H    sing N N 71  
+GLN N   H2   sing N N 72  
+GLN CA  C    sing N N 73  
+GLN CA  CB   sing N N 74  
+GLN CA  HA   sing N N 75  
+GLN C   O    doub N N 76  
+GLN C   OXT  sing N N 77  
+GLN CB  CG   sing N N 78  
+GLN CB  HB2  sing N N 79  
+GLN CB  HB3  sing N N 80  
+GLN CG  CD   sing N N 81  
+GLN CG  HG2  sing N N 82  
+GLN CG  HG3  sing N N 83  
+GLN CD  OE1  doub N N 84  
+GLN CD  NE2  sing N N 85  
+GLN NE2 HE21 sing N N 86  
+GLN NE2 HE22 sing N N 87  
+GLN OXT HXT  sing N N 88  
+GLU N   CA   sing N N 89  
+GLU N   H    sing N N 90  
+GLU N   H2   sing N N 91  
+GLU CA  C    sing N N 92  
+GLU CA  CB   sing N N 93  
+GLU CA  HA   sing N N 94  
+GLU C   O    doub N N 95  
+GLU C   OXT  sing N N 96  
+GLU CB  CG   sing N N 97  
+GLU CB  HB2  sing N N 98  
+GLU CB  HB3  sing N N 99  
+GLU CG  CD   sing N N 100 
+GLU CG  HG2  sing N N 101 
+GLU CG  HG3  sing N N 102 
+GLU CD  OE1  doub N N 103 
+GLU CD  OE2  sing N N 104 
+GLU OE2 HE2  sing N N 105 
+GLU OXT HXT  sing N N 106 
+GLY N   CA   sing N N 107 
+GLY N   H    sing N N 108 
+GLY N   H2   sing N N 109 
+GLY CA  C    sing N N 110 
+GLY CA  HA2  sing N N 111 
+GLY CA  HA3  sing N N 112 
+GLY C   O    doub N N 113 
+GLY C   OXT  sing N N 114 
+GLY OXT HXT  sing N N 115 
+HIS N   CA   sing N N 116 
+HIS N   H    sing N N 117 
+HIS N   H2   sing N N 118 
+HIS CA  C    sing N N 119 
+HIS CA  CB   sing N N 120 
+HIS CA  HA   sing N N 121 
+HIS C   O    doub N N 122 
+HIS C   OXT  sing N N 123 
+HIS CB  CG   sing N N 124 
+HIS CB  HB2  sing N N 125 
+HIS CB  HB3  sing N N 126 
+HIS CG  ND1  sing Y N 127 
+HIS CG  CD2  doub Y N 128 
+HIS ND1 CE1  doub Y N 129 
+HIS ND1 HD1  sing N N 130 
+HIS CD2 NE2  sing Y N 131 
+HIS CD2 HD2  sing N N 132 
+HIS CE1 NE2  sing Y N 133 
+HIS CE1 HE1  sing N N 134 
+HIS NE2 HE2  sing N N 135 
+HIS OXT HXT  sing N N 136 
+HOH O   H1   sing N N 137 
+HOH O   H2   sing N N 138 
+ILE N   CA   sing N N 139 
+ILE N   H    sing N N 140 
+ILE N   H2   sing N N 141 
+ILE CA  C    sing N N 142 
+ILE CA  CB   sing N N 143 
+ILE CA  HA   sing N N 144 
+ILE C   O    doub N N 145 
+ILE C   OXT  sing N N 146 
+ILE CB  CG1  sing N N 147 
+ILE CB  CG2  sing N N 148 
+ILE CB  HB   sing N N 149 
+ILE CG1 CD1  sing N N 150 
+ILE CG1 HG12 sing N N 151 
+ILE CG1 HG13 sing N N 152 
+ILE CG2 HG21 sing N N 153 
+ILE CG2 HG22 sing N N 154 
+ILE CG2 HG23 sing N N 155 
+ILE CD1 HD11 sing N N 156 
+ILE CD1 HD12 sing N N 157 
+ILE CD1 HD13 sing N N 158 
+ILE OXT HXT  sing N N 159 
+LEU N   CA   sing N N 160 
+LEU N   H    sing N N 161 
+LEU N   H2   sing N N 162 
+LEU CA  C    sing N N 163 
+LEU CA  CB   sing N N 164 
+LEU CA  HA   sing N N 165 
+LEU C   O    doub N N 166 
+LEU C   OXT  sing N N 167 
+LEU CB  CG   sing N N 168 
+LEU CB  HB2  sing N N 169 
+LEU CB  HB3  sing N N 170 
+LEU CG  CD1  sing N N 171 
+LEU CG  CD2  sing N N 172 
+LEU CG  HG   sing N N 173 
+LEU CD1 HD11 sing N N 174 
+LEU CD1 HD12 sing N N 175 
+LEU CD1 HD13 sing N N 176 
+LEU CD2 HD21 sing N N 177 
+LEU CD2 HD22 sing N N 178 
+LEU CD2 HD23 sing N N 179 
+LEU OXT HXT  sing N N 180 
+LYS N   CA   sing N N 181 
+LYS N   H    sing N N 182 
+LYS N   H2   sing N N 183 
+LYS CA  C    sing N N 184 
+LYS CA  CB   sing N N 185 
+LYS CA  HA   sing N N 186 
+LYS C   O    doub N N 187 
+LYS C   OXT  sing N N 188 
+LYS CB  CG   sing N N 189 
+LYS CB  HB2  sing N N 190 
+LYS CB  HB3  sing N N 191 
+LYS CG  CD   sing N N 192 
+LYS CG  HG2  sing N N 193 
+LYS CG  HG3  sing N N 194 
+LYS CD  CE   sing N N 195 
+LYS CD  HD2  sing N N 196 
+LYS CD  HD3  sing N N 197 
+LYS CE  NZ   sing N N 198 
+LYS CE  HE2  sing N N 199 
+LYS CE  HE3  sing N N 200 
+LYS NZ  HZ1  sing N N 201 
+LYS NZ  HZ2  sing N N 202 
+LYS NZ  HZ3  sing N N 203 
+LYS OXT HXT  sing N N 204 
+MET N   CA   sing N N 205 
+MET N   H    sing N N 206 
+MET N   H2   sing N N 207 
+MET CA  C    sing N N 208 
+MET CA  CB   sing N N 209 
+MET CA  HA   sing N N 210 
+MET C   O    doub N N 211 
+MET C   OXT  sing N N 212 
+MET CB  CG   sing N N 213 
+MET CB  HB2  sing N N 214 
+MET CB  HB3  sing N N 215 
+MET CG  SD   sing N N 216 
+MET CG  HG2  sing N N 217 
+MET CG  HG3  sing N N 218 
+MET SD  CE   sing N N 219 
+MET CE  HE1  sing N N 220 
+MET CE  HE2  sing N N 221 
+MET CE  HE3  sing N N 222 
+MET OXT HXT  sing N N 223 
+PHE N   CA   sing N N 224 
+PHE N   H    sing N N 225 
+PHE N   H2   sing N N 226 
+PHE CA  C    sing N N 227 
+PHE CA  CB   sing N N 228 
+PHE CA  HA   sing N N 229 
+PHE C   O    doub N N 230 
+PHE C   OXT  sing N N 231 
+PHE CB  CG   sing N N 232 
+PHE CB  HB2  sing N N 233 
+PHE CB  HB3  sing N N 234 
+PHE CG  CD1  doub Y N 235 
+PHE CG  CD2  sing Y N 236 
+PHE CD1 CE1  sing Y N 237 
+PHE CD1 HD1  sing N N 238 
+PHE CD2 CE2  doub Y N 239 
+PHE CD2 HD2  sing N N 240 
+PHE CE1 CZ   doub Y N 241 
+PHE CE1 HE1  sing N N 242 
+PHE CE2 CZ   sing Y N 243 
+PHE CE2 HE2  sing N N 244 
+PHE CZ  HZ   sing N N 245 
+PHE OXT HXT  sing N N 246 
+PRO N   CA   sing N N 247 
+PRO N   CD   sing N N 248 
+PRO N   H    sing N N 249 
+PRO CA  C    sing N N 250 
+PRO CA  CB   sing N N 251 
+PRO CA  HA   sing N N 252 
+PRO C   O    doub N N 253 
+PRO C   OXT  sing N N 254 
+PRO CB  CG   sing N N 255 
+PRO CB  HB2  sing N N 256 
+PRO CB  HB3  sing N N 257 
+PRO CG  CD   sing N N 258 
+PRO CG  HG2  sing N N 259 
+PRO CG  HG3  sing N N 260 
+PRO CD  HD2  sing N N 261 
+PRO CD  HD3  sing N N 262 
+PRO OXT HXT  sing N N 263 
+SER N   CA   sing N N 264 
+SER N   H    sing N N 265 
+SER N   H2   sing N N 266 
+SER CA  C    sing N N 267 
+SER CA  CB   sing N N 268 
+SER CA  HA   sing N N 269 
+SER C   O    doub N N 270 
+SER C   OXT  sing N N 271 
+SER CB  OG   sing N N 272 
+SER CB  HB2  sing N N 273 
+SER CB  HB3  sing N N 274 
+SER OG  HG   sing N N 275 
+SER OXT HXT  sing N N 276 
+THR N   CA   sing N N 277 
+THR N   H    sing N N 278 
+THR N   H2   sing N N 279 
+THR CA  C    sing N N 280 
+THR CA  CB   sing N N 281 
+THR CA  HA   sing N N 282 
+THR C   O    doub N N 283 
+THR C   OXT  sing N N 284 
+THR CB  OG1  sing N N 285 
+THR CB  CG2  sing N N 286 
+THR CB  HB   sing N N 287 
+THR OG1 HG1  sing N N 288 
+THR CG2 HG21 sing N N 289 
+THR CG2 HG22 sing N N 290 
+THR CG2 HG23 sing N N 291 
+THR OXT HXT  sing N N 292 
+TYR N   CA   sing N N 293 
+TYR N   H    sing N N 294 
+TYR N   H2   sing N N 295 
+TYR CA  C    sing N N 296 
+TYR CA  CB   sing N N 297 
+TYR CA  HA   sing N N 298 
+TYR C   O    doub N N 299 
+TYR C   OXT  sing N N 300 
+TYR CB  CG   sing N N 301 
+TYR CB  HB2  sing N N 302 
+TYR CB  HB3  sing N N 303 
+TYR CG  CD1  doub Y N 304 
+TYR CG  CD2  sing Y N 305 
+TYR CD1 CE1  sing Y N 306 
+TYR CD1 HD1  sing N N 307 
+TYR CD2 CE2  doub Y N 308 
+TYR CD2 HD2  sing N N 309 
+TYR CE1 CZ   doub Y N 310 
+TYR CE1 HE1  sing N N 311 
+TYR CE2 CZ   sing Y N 312 
+TYR CE2 HE2  sing N N 313 
+TYR CZ  OH   sing N N 314 
+TYR OH  HH   sing N N 315 
+TYR OXT HXT  sing N N 316 
+VAL N   CA   sing N N 317 
+VAL N   H    sing N N 318 
+VAL N   H2   sing N N 319 
+VAL CA  C    sing N N 320 
+VAL CA  CB   sing N N 321 
+VAL CA  HA   sing N N 322 
+VAL C   O    doub N N 323 
+VAL C   OXT  sing N N 324 
+VAL CB  CG1  sing N N 325 
+VAL CB  CG2  sing N N 326 
+VAL CB  HB   sing N N 327 
+VAL CG1 HG11 sing N N 328 
+VAL CG1 HG12 sing N N 329 
+VAL CG1 HG13 sing N N 330 
+VAL CG2 HG21 sing N N 331 
+VAL CG2 HG22 sing N N 332 
+VAL CG2 HG23 sing N N 333 
+VAL OXT HXT  sing N N 334 
+# 
+_atom_sites.entry_id                    1UBQ 
+_atom_sites.fract_transf_matrix[1][1]   .019670 
+_atom_sites.fract_transf_matrix[1][2]   0.000000 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   .023381 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   .034542 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+C 
+N 
+O 
+S 
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1   N N   . MET A 1 1  ? 27.340 24.430 2.614  1.00 9.67  ? 1   MET A N   1 
+ATOM   2   C CA  . MET A 1 1  ? 26.266 25.413 2.842  1.00 10.38 ? 1   MET A CA  1 
+ATOM   3   C C   . MET A 1 1  ? 26.913 26.639 3.531  1.00 9.62  ? 1   MET A C   1 
+ATOM   4   O O   . MET A 1 1  ? 27.886 26.463 4.263  1.00 9.62  ? 1   MET A O   1 
+ATOM   5   C CB  . MET A 1 1  ? 25.112 24.880 3.649  1.00 13.77 ? 1   MET A CB  1 
+ATOM   6   C CG  . MET A 1 1  ? 25.353 24.860 5.134  1.00 16.29 ? 1   MET A CG  1 
+ATOM   7   S SD  . MET A 1 1  ? 23.930 23.959 5.904  1.00 17.17 ? 1   MET A SD  1 
+ATOM   8   C CE  . MET A 1 1  ? 24.447 23.984 7.620  1.00 16.11 ? 1   MET A CE  1 
+ATOM   9   N N   . GLN A 1 2  ? 26.335 27.770 3.258  1.00 9.27  ? 2   GLN A N   1 
+ATOM   10  C CA  . GLN A 1 2  ? 26.850 29.021 3.898  1.00 9.07  ? 2   GLN A CA  1 
+ATOM   11  C C   . GLN A 1 2  ? 26.100 29.253 5.202  1.00 8.72  ? 2   GLN A C   1 
+ATOM   12  O O   . GLN A 1 2  ? 24.865 29.024 5.330  1.00 8.22  ? 2   GLN A O   1 
+ATOM   13  C CB  . GLN A 1 2  ? 26.733 30.148 2.905  1.00 14.46 ? 2   GLN A CB  1 
+ATOM   14  C CG  . GLN A 1 2  ? 26.882 31.546 3.409  1.00 17.01 ? 2   GLN A CG  1 
+ATOM   15  C CD  . GLN A 1 2  ? 26.786 32.562 2.270  1.00 20.10 ? 2   GLN A CD  1 
+ATOM   16  O OE1 . GLN A 1 2  ? 27.783 33.160 1.870  1.00 21.89 ? 2   GLN A OE1 1 
+ATOM   17  N NE2 . GLN A 1 2  ? 25.562 32.733 1.806  1.00 19.49 ? 2   GLN A NE2 1 
+ATOM   18  N N   . ILE A 1 3  ? 26.849 29.656 6.217  1.00 5.87  ? 3   ILE A N   1 
+ATOM   19  C CA  . ILE A 1 3  ? 26.235 30.058 7.497  1.00 5.07  ? 3   ILE A CA  1 
+ATOM   20  C C   . ILE A 1 3  ? 26.882 31.428 7.862  1.00 4.01  ? 3   ILE A C   1 
+ATOM   21  O O   . ILE A 1 3  ? 27.906 31.711 7.264  1.00 4.61  ? 3   ILE A O   1 
+ATOM   22  C CB  . ILE A 1 3  ? 26.344 29.050 8.645  1.00 6.55  ? 3   ILE A CB  1 
+ATOM   23  C CG1 . ILE A 1 3  ? 27.810 28.748 8.999  1.00 4.72  ? 3   ILE A CG1 1 
+ATOM   24  C CG2 . ILE A 1 3  ? 25.491 27.771 8.287  1.00 5.58  ? 3   ILE A CG2 1 
+ATOM   25  C CD1 . ILE A 1 3  ? 27.967 28.087 10.417 1.00 10.83 ? 3   ILE A CD1 1 
+ATOM   26  N N   . PHE A 1 4  ? 26.214 32.097 8.771  1.00 4.55  ? 4   PHE A N   1 
+ATOM   27  C CA  . PHE A 1 4  ? 26.772 33.436 9.197  1.00 4.68  ? 4   PHE A CA  1 
+ATOM   28  C C   . PHE A 1 4  ? 27.151 33.362 10.650 1.00 5.30  ? 4   PHE A C   1 
+ATOM   29  O O   . PHE A 1 4  ? 26.350 32.778 11.395 1.00 5.58  ? 4   PHE A O   1 
+ATOM   30  C CB  . PHE A 1 4  ? 25.695 34.498 8.946  1.00 4.83  ? 4   PHE A CB  1 
+ATOM   31  C CG  . PHE A 1 4  ? 25.288 34.609 7.499  1.00 7.97  ? 4   PHE A CG  1 
+ATOM   32  C CD1 . PHE A 1 4  ? 24.147 33.966 7.038  1.00 6.69  ? 4   PHE A CD1 1 
+ATOM   33  C CD2 . PHE A 1 4  ? 26.136 35.346 6.640  1.00 8.34  ? 4   PHE A CD2 1 
+ATOM   34  C CE1 . PHE A 1 4  ? 23.812 34.031 5.677  1.00 9.10  ? 4   PHE A CE1 1 
+ATOM   35  C CE2 . PHE A 1 4  ? 25.810 35.392 5.267  1.00 10.61 ? 4   PHE A CE2 1 
+ATOM   36  C CZ  . PHE A 1 4  ? 24.620 34.778 4.853  1.00 8.90  ? 4   PHE A CZ  1 
+ATOM   37  N N   . VAL A 1 5  ? 28.260 33.943 11.096 1.00 4.44  ? 5   VAL A N   1 
+ATOM   38  C CA  . VAL A 1 5  ? 28.605 33.965 12.503 1.00 3.87  ? 5   VAL A CA  1 
+ATOM   39  C C   . VAL A 1 5  ? 28.638 35.461 12.900 1.00 4.93  ? 5   VAL A C   1 
+ATOM   40  O O   . VAL A 1 5  ? 29.522 36.103 12.320 1.00 6.84  ? 5   VAL A O   1 
+ATOM   41  C CB  . VAL A 1 5  ? 29.963 33.317 12.814 1.00 2.99  ? 5   VAL A CB  1 
+ATOM   42  C CG1 . VAL A 1 5  ? 30.211 33.394 14.304 1.00 5.28  ? 5   VAL A CG1 1 
+ATOM   43  C CG2 . VAL A 1 5  ? 29.957 31.838 12.352 1.00 9.13  ? 5   VAL A CG2 1 
+ATOM   44  N N   . LYS A 1 6  ? 27.751 35.867 13.740 1.00 6.04  ? 6   LYS A N   1 
+ATOM   45  C CA  . LYS A 1 6  ? 27.691 37.315 14.143 1.00 6.12  ? 6   LYS A CA  1 
+ATOM   46  C C   . LYS A 1 6  ? 28.469 37.475 15.420 1.00 6.57  ? 6   LYS A C   1 
+ATOM   47  O O   . LYS A 1 6  ? 28.213 36.753 16.411 1.00 5.76  ? 6   LYS A O   1 
+ATOM   48  C CB  . LYS A 1 6  ? 26.219 37.684 14.307 1.00 7.45  ? 6   LYS A CB  1 
+ATOM   49  C CG  . LYS A 1 6  ? 25.884 39.139 14.615 1.00 11.12 ? 6   LYS A CG  1 
+ATOM   50  C CD  . LYS A 1 6  ? 24.348 39.296 14.642 1.00 14.54 ? 6   LYS A CD  1 
+ATOM   51  C CE  . LYS A 1 6  ? 23.865 40.723 14.749 1.00 18.84 ? 6   LYS A CE  1 
+ATOM   52  N NZ  . LYS A 1 6  ? 22.375 40.720 14.907 1.00 20.55 ? 6   LYS A NZ  1 
+ATOM   53  N N   . THR A 1 7  ? 29.426 38.430 15.446 1.00 7.41  ? 7   THR A N   1 
+ATOM   54  C CA  . THR A 1 7  ? 30.225 38.643 16.662 1.00 7.48  ? 7   THR A CA  1 
+ATOM   55  C C   . THR A 1 7  ? 29.664 39.839 17.434 1.00 8.75  ? 7   THR A C   1 
+ATOM   56  O O   . THR A 1 7  ? 28.850 40.565 16.859 1.00 8.58  ? 7   THR A O   1 
+ATOM   57  C CB  . THR A 1 7  ? 31.744 38.879 16.299 1.00 9.61  ? 7   THR A CB  1 
+ATOM   58  O OG1 . THR A 1 7  ? 31.737 40.257 15.824 1.00 11.78 ? 7   THR A OG1 1 
+ATOM   59  C CG2 . THR A 1 7  ? 32.260 37.969 15.171 1.00 9.17  ? 7   THR A CG2 1 
+ATOM   60  N N   . LEU A 1 8  ? 30.132 40.069 18.642 1.00 9.84  ? 8   LEU A N   1 
+ATOM   61  C CA  . LEU A 1 8  ? 29.607 41.180 19.467 1.00 14.15 ? 8   LEU A CA  1 
+ATOM   62  C C   . LEU A 1 8  ? 30.075 42.538 18.984 1.00 17.37 ? 8   LEU A C   1 
+ATOM   63  O O   . LEU A 1 8  ? 29.586 43.570 19.483 1.00 17.01 ? 8   LEU A O   1 
+ATOM   64  C CB  . LEU A 1 8  ? 29.919 40.890 20.938 1.00 16.63 ? 8   LEU A CB  1 
+ATOM   65  C CG  . LEU A 1 8  ? 29.183 39.722 21.581 1.00 18.88 ? 8   LEU A CG  1 
+ATOM   66  C CD1 . LEU A 1 8  ? 29.308 39.750 23.095 1.00 19.31 ? 8   LEU A CD1 1 
+ATOM   67  C CD2 . LEU A 1 8  ? 27.700 39.721 21.228 1.00 18.59 ? 8   LEU A CD2 1 
+ATOM   68  N N   . THR A 1 9  ? 30.991 42.571 17.998 1.00 18.33 ? 9   THR A N   1 
+ATOM   69  C CA  . THR A 1 9  ? 31.422 43.940 17.553 1.00 19.24 ? 9   THR A CA  1 
+ATOM   70  C C   . THR A 1 9  ? 30.755 44.351 16.277 1.00 19.48 ? 9   THR A C   1 
+ATOM   71  O O   . THR A 1 9  ? 31.207 45.268 15.566 1.00 23.14 ? 9   THR A O   1 
+ATOM   72  C CB  . THR A 1 9  ? 32.979 43.918 17.445 1.00 18.97 ? 9   THR A CB  1 
+ATOM   73  O OG1 . THR A 1 9  ? 33.174 43.067 16.265 1.00 20.24 ? 9   THR A OG1 1 
+ATOM   74  C CG2 . THR A 1 9  ? 33.657 43.319 18.672 1.00 19.70 ? 9   THR A CG2 1 
+ATOM   75  N N   . GLY A 1 10 ? 29.721 43.673 15.885 1.00 19.43 ? 10  GLY A N   1 
+ATOM   76  C CA  . GLY A 1 10 ? 28.978 43.960 14.678 1.00 18.74 ? 10  GLY A CA  1 
+ATOM   77  C C   . GLY A 1 10 ? 29.604 43.507 13.393 1.00 17.62 ? 10  GLY A C   1 
+ATOM   78  O O   . GLY A 1 10 ? 29.219 43.981 12.301 1.00 19.74 ? 10  GLY A O   1 
+ATOM   79  N N   . LYS A 1 11 ? 30.563 42.623 13.495 1.00 13.56 ? 11  LYS A N   1 
+ATOM   80  C CA  . LYS A 1 11 ? 31.191 42.012 12.331 1.00 11.91 ? 11  LYS A CA  1 
+ATOM   81  C C   . LYS A 1 11 ? 30.459 40.666 12.130 1.00 10.18 ? 11  LYS A C   1 
+ATOM   82  O O   . LYS A 1 11 ? 30.253 39.991 13.133 1.00 9.10  ? 11  LYS A O   1 
+ATOM   83  C CB  . LYS A 1 11 ? 32.672 41.717 12.505 1.00 13.43 ? 11  LYS A CB  1 
+ATOM   84  C CG  . LYS A 1 11 ? 33.280 41.086 11.227 1.00 16.69 ? 11  LYS A CG  1 
+ATOM   85  C CD  . LYS A 1 11 ? 34.762 40.799 11.470 1.00 17.92 ? 11  LYS A CD  1 
+ATOM   86  C CE  . LYS A 1 11 ? 35.614 40.847 10.240 1.00 20.81 ? 11  LYS A CE  1 
+ATOM   87  N NZ  . LYS A 1 11 ? 35.100 40.073 9.101  1.00 21.93 ? 11  LYS A NZ  1 
+ATOM   88  N N   . THR A 1 12 ? 30.163 40.338 10.886 1.00 9.63  ? 12  THR A N   1 
+ATOM   89  C CA  . THR A 1 12 ? 29.542 39.020 10.653 1.00 9.85  ? 12  THR A CA  1 
+ATOM   90  C C   . THR A 1 12 ? 30.494 38.261 9.729  1.00 11.66 ? 12  THR A C   1 
+ATOM   91  O O   . THR A 1 12 ? 30.849 38.850 8.706  1.00 12.33 ? 12  THR A O   1 
+ATOM   92  C CB  . THR A 1 12 ? 28.113 39.049 10.015 1.00 10.85 ? 12  THR A CB  1 
+ATOM   93  O OG1 . THR A 1 12 ? 27.280 39.722 10.996 1.00 10.91 ? 12  THR A OG1 1 
+ATOM   94  C CG2 . THR A 1 12 ? 27.588 37.635 9.715  1.00 9.63  ? 12  THR A CG2 1 
+ATOM   95  N N   . ILE A 1 13 ? 30.795 37.015 10.095 1.00 10.42 ? 13  ILE A N   1 
+ATOM   96  C CA  . ILE A 1 13 ? 31.720 36.289 9.176  1.00 11.84 ? 13  ILE A CA  1 
+ATOM   97  C C   . ILE A 1 13 ? 30.955 35.211 8.459  1.00 10.55 ? 13  ILE A C   1 
+ATOM   98  O O   . ILE A 1 13 ? 30.025 34.618 9.040  1.00 11.92 ? 13  ILE A O   1 
+ATOM   99  C CB  . ILE A 1 13 ? 32.995 35.883 9.934  1.00 14.86 ? 13  ILE A CB  1 
+ATOM   100 C CG1 . ILE A 1 13 ? 33.306 34.381 9.840  1.00 14.87 ? 13  ILE A CG1 1 
+ATOM   101 C CG2 . ILE A 1 13 ? 33.109 36.381 11.435 1.00 17.08 ? 13  ILE A CG2 1 
+ATOM   102 C CD1 . ILE A 1 13 ? 34.535 34.028 10.720 1.00 16.46 ? 13  ILE A CD1 1 
+ATOM   103 N N   . THR A 1 14 ? 31.244 34.986 7.197  1.00 9.39  ? 14  THR A N   1 
+ATOM   104 C CA  . THR A 1 14 ? 30.505 33.884 6.512  1.00 9.63  ? 14  THR A CA  1 
+ATOM   105 C C   . THR A 1 14 ? 31.409 32.680 6.446  1.00 11.20 ? 14  THR A C   1 
+ATOM   106 O O   . THR A 1 14 ? 32.619 32.812 6.125  1.00 11.63 ? 14  THR A O   1 
+ATOM   107 C CB  . THR A 1 14 ? 30.091 34.393 5.078  1.00 10.38 ? 14  THR A CB  1 
+ATOM   108 O OG1 . THR A 1 14 ? 31.440 34.513 4.487  1.00 16.30 ? 14  THR A OG1 1 
+ATOM   109 C CG2 . THR A 1 14 ? 29.420 35.756 5.119  1.00 11.66 ? 14  THR A CG2 1 
+ATOM   110 N N   . LEU A 1 15 ? 30.884 31.485 6.666  1.00 8.29  ? 15  LEU A N   1 
+ATOM   111 C CA  . LEU A 1 15 ? 31.677 30.275 6.639  1.00 9.03  ? 15  LEU A CA  1 
+ATOM   112 C C   . LEU A 1 15 ? 31.022 29.288 5.665  1.00 8.59  ? 15  LEU A C   1 
+ATOM   113 O O   . LEU A 1 15 ? 29.809 29.395 5.545  1.00 7.79  ? 15  LEU A O   1 
+ATOM   114 C CB  . LEU A 1 15 ? 31.562 29.686 8.045  1.00 11.08 ? 15  LEU A CB  1 
+ATOM   115 C CG  . LEU A 1 15 ? 32.631 29.444 9.060  1.00 15.79 ? 15  LEU A CG  1 
+ATOM   116 C CD1 . LEU A 1 15 ? 33.814 30.390 9.030  1.00 15.88 ? 15  LEU A CD1 1 
+ATOM   117 C CD2 . LEU A 1 15 ? 31.945 29.449 10.436 1.00 15.27 ? 15  LEU A CD2 1 
+ATOM   118 N N   . GLU A 1 16 ? 31.834 28.412 5.125  1.00 11.04 ? 16  GLU A N   1 
+ATOM   119 C CA  . GLU A 1 16 ? 31.220 27.341 4.275  1.00 11.50 ? 16  GLU A CA  1 
+ATOM   120 C C   . GLU A 1 16 ? 31.440 26.079 5.080  1.00 10.13 ? 16  GLU A C   1 
+ATOM   121 O O   . GLU A 1 16 ? 32.576 25.802 5.461  1.00 9.83  ? 16  GLU A O   1 
+ATOM   122 C CB  . GLU A 1 16 ? 31.827 27.262 2.894  1.00 17.22 ? 16  GLU A CB  1 
+ATOM   123 C CG  . GLU A 1 16 ? 31.363 28.410 1.962  1.00 23.33 ? 16  GLU A CG  1 
+ATOM   124 C CD  . GLU A 1 16 ? 31.671 28.291 0.498  1.00 26.99 ? 16  GLU A CD  1 
+ATOM   125 O OE1 . GLU A 1 16 ? 30.869 28.621 -0.366 1.00 28.86 ? 16  GLU A OE1 1 
+ATOM   126 O OE2 . GLU A 1 16 ? 32.835 27.861 0.278  1.00 28.90 ? 16  GLU A OE2 1 
+ATOM   127 N N   . VAL A 1 17 ? 30.310 25.458 5.384  1.00 8.99  ? 17  VAL A N   1 
+ATOM   128 C CA  . VAL A 1 17 ? 30.288 24.245 6.193  1.00 8.85  ? 17  VAL A CA  1 
+ATOM   129 C C   . VAL A 1 17 ? 29.279 23.227 5.641  1.00 8.04  ? 17  VAL A C   1 
+ATOM   130 O O   . VAL A 1 17 ? 28.478 23.522 4.725  1.00 8.99  ? 17  VAL A O   1 
+ATOM   131 C CB  . VAL A 1 17 ? 29.903 24.590 7.665  1.00 9.78  ? 17  VAL A CB  1 
+ATOM   132 C CG1 . VAL A 1 17 ? 30.862 25.496 8.389  1.00 12.05 ? 17  VAL A CG1 1 
+ATOM   133 C CG2 . VAL A 1 17 ? 28.476 25.135 7.705  1.00 10.54 ? 17  VAL A CG2 1 
+ATOM   134 N N   . GLU A 1 18 ? 29.380 22.057 6.232  1.00 7.29  ? 18  GLU A N   1 
+ATOM   135 C CA  . GLU A 1 18 ? 28.468 20.940 5.980  1.00 7.08  ? 18  GLU A CA  1 
+ATOM   136 C C   . GLU A 1 18 ? 27.819 20.609 7.316  1.00 6.45  ? 18  GLU A C   1 
+ATOM   137 O O   . GLU A 1 18 ? 28.449 20.674 8.360  1.00 5.28  ? 18  GLU A O   1 
+ATOM   138 C CB  . GLU A 1 18 ? 29.213 19.697 5.506  1.00 10.28 ? 18  GLU A CB  1 
+ATOM   139 C CG  . GLU A 1 18 ? 29.728 19.755 4.060  1.00 12.65 ? 18  GLU A CG  1 
+ATOM   140 C CD  . GLU A 1 18 ? 28.754 20.061 2.978  1.00 14.15 ? 18  GLU A CD  1 
+ATOM   141 O OE1 . GLU A 1 18 ? 27.546 19.992 2.985  1.00 14.33 ? 18  GLU A OE1 1 
+ATOM   142 O OE2 . GLU A 1 18 ? 29.336 20.423 1.904  1.00 18.17 ? 18  GLU A OE2 1 
+ATOM   143 N N   . PRO A 1 19 ? 26.559 20.220 7.288  1.00 7.24  ? 19  PRO A N   1 
+ATOM   144 C CA  . PRO A 1 19 ? 25.829 19.825 8.494  1.00 7.07  ? 19  PRO A CA  1 
+ATOM   145 C C   . PRO A 1 19 ? 26.541 18.732 9.251  1.00 6.65  ? 19  PRO A C   1 
+ATOM   146 O O   . PRO A 1 19 ? 26.333 18.536 10.457 1.00 6.37  ? 19  PRO A O   1 
+ATOM   147 C CB  . PRO A 1 19 ? 24.469 19.332 7.952  1.00 7.61  ? 19  PRO A CB  1 
+ATOM   148 C CG  . PRO A 1 19 ? 24.299 20.134 6.704  1.00 8.16  ? 19  PRO A CG  1 
+ATOM   149 C CD  . PRO A 1 19 ? 25.714 20.108 6.073  1.00 7.49  ? 19  PRO A CD  1 
+ATOM   150 N N   . SER A 1 20 ? 27.361 17.959 8.559  1.00 6.80  ? 20  SER A N   1 
+ATOM   151 C CA  . SER A 1 20 ? 28.054 16.835 9.210  1.00 6.28  ? 20  SER A CA  1 
+ATOM   152 C C   . SER A 1 20 ? 29.258 17.318 9.984  1.00 8.45  ? 20  SER A C   1 
+ATOM   153 O O   . SER A 1 20 ? 29.930 16.477 10.606 1.00 7.26  ? 20  SER A O   1 
+ATOM   154 C CB  . SER A 1 20 ? 28.523 15.820 8.182  1.00 8.57  ? 20  SER A CB  1 
+ATOM   155 O OG  . SER A 1 20 ? 28.946 16.445 6.967  1.00 11.13 ? 20  SER A OG  1 
+ATOM   156 N N   . ASP A 1 21 ? 29.599 18.599 9.828  1.00 7.50  ? 21  ASP A N   1 
+ATOM   157 C CA  . ASP A 1 21 ? 30.796 19.083 10.566 1.00 7.70  ? 21  ASP A CA  1 
+ATOM   158 C C   . ASP A 1 21 ? 30.491 19.162 12.040 1.00 7.08  ? 21  ASP A C   1 
+ATOM   159 O O   . ASP A 1 21 ? 29.367 19.523 12.441 1.00 8.11  ? 21  ASP A O   1 
+ATOM   160 C CB  . ASP A 1 21 ? 31.155 20.515 10.048 1.00 11.00 ? 21  ASP A CB  1 
+ATOM   161 C CG  . ASP A 1 21 ? 31.923 20.436 8.755  1.00 15.32 ? 21  ASP A CG  1 
+ATOM   162 O OD1 . ASP A 1 21 ? 32.493 19.374 8.456  1.00 18.03 ? 21  ASP A OD1 1 
+ATOM   163 O OD2 . ASP A 1 21 ? 31.838 21.402 7.968  1.00 14.36 ? 21  ASP A OD2 1 
+ATOM   164 N N   . THR A 1 22 ? 31.510 18.936 12.852 1.00 5.37  ? 22  THR A N   1 
+ATOM   165 C CA  . THR A 1 22 ? 31.398 19.064 14.286 1.00 6.01  ? 22  THR A CA  1 
+ATOM   166 C C   . THR A 1 22 ? 31.593 20.553 14.655 1.00 8.01  ? 22  THR A C   1 
+ATOM   167 O O   . THR A 1 22 ? 32.159 21.311 13.861 1.00 8.11  ? 22  THR A O   1 
+ATOM   168 C CB  . THR A 1 22 ? 32.492 18.193 14.995 1.00 8.92  ? 22  THR A CB  1 
+ATOM   169 O OG1 . THR A 1 22 ? 33.778 18.739 14.516 1.00 10.22 ? 22  THR A OG1 1 
+ATOM   170 C CG2 . THR A 1 22 ? 32.352 16.700 14.630 1.00 9.65  ? 22  THR A CG2 1 
+ATOM   171 N N   . ILE A 1 23 ? 31.113 20.863 15.860 1.00 8.32  ? 23  ILE A N   1 
+ATOM   172 C CA  . ILE A 1 23 ? 31.288 22.201 16.417 1.00 9.92  ? 23  ILE A CA  1 
+ATOM   173 C C   . ILE A 1 23 ? 32.776 22.519 16.577 1.00 10.01 ? 23  ILE A C   1 
+ATOM   174 O O   . ILE A 1 23 ? 33.233 23.659 16.384 1.00 8.71  ? 23  ILE A O   1 
+ATOM   175 C CB  . ILE A 1 23 ? 30.520 22.300 17.764 1.00 10.78 ? 23  ILE A CB  1 
+ATOM   176 C CG1 . ILE A 1 23 ? 29.006 22.043 17.442 1.00 11.38 ? 23  ILE A CG1 1 
+ATOM   177 C CG2 . ILE A 1 23 ? 30.832 23.699 18.358 1.00 10.90 ? 23  ILE A CG2 1 
+ATOM   178 C CD1 . ILE A 1 23 ? 28.407 22.948 16.366 1.00 12.30 ? 23  ILE A CD1 1 
+ATOM   179 N N   . GLU A 1 24 ? 33.548 21.526 16.950 1.00 9.54  ? 24  GLU A N   1 
+ATOM   180 C CA  . GLU A 1 24 ? 35.031 21.722 17.069 1.00 11.81 ? 24  GLU A CA  1 
+ATOM   181 C C   . GLU A 1 24 ? 35.615 22.190 15.759 1.00 11.14 ? 24  GLU A C   1 
+ATOM   182 O O   . GLU A 1 24 ? 36.532 23.046 15.724 1.00 10.62 ? 24  GLU A O   1 
+ATOM   183 C CB  . GLU A 1 24 ? 35.667 20.383 17.447 1.00 19.24 ? 24  GLU A CB  1 
+ATOM   184 C CG  . GLU A 1 24 ? 37.128 20.293 17.872 1.00 27.76 ? 24  GLU A CG  1 
+ATOM   185 C CD  . GLU A 1 24 ? 37.561 18.851 18.082 1.00 32.92 ? 24  GLU A CD  1 
+ATOM   186 O OE1 . GLU A 1 24 ? 37.758 18.024 17.195 1.00 34.80 ? 24  GLU A OE1 1 
+ATOM   187 O OE2 . GLU A 1 24 ? 37.628 18.599 19.313 1.00 36.51 ? 24  GLU A OE2 1 
+ATOM   188 N N   . ASN A 1 25 ? 35.139 21.624 14.662 1.00 9.43  ? 25  ASN A N   1 
+ATOM   189 C CA  . ASN A 1 25 ? 35.590 21.945 13.302 1.00 10.96 ? 25  ASN A CA  1 
+ATOM   190 C C   . ASN A 1 25 ? 35.238 23.382 12.920 1.00 9.68  ? 25  ASN A C   1 
+ATOM   191 O O   . ASN A 1 25 ? 36.066 24.109 12.333 1.00 9.33  ? 25  ASN A O   1 
+ATOM   192 C CB  . ASN A 1 25 ? 35.064 20.957 12.255 1.00 16.78 ? 25  ASN A CB  1 
+ATOM   193 C CG  . ASN A 1 25 ? 35.541 21.418 10.871 1.00 22.31 ? 25  ASN A CG  1 
+ATOM   194 O OD1 . ASN A 1 25 ? 36.772 21.623 10.676 1.00 25.66 ? 25  ASN A OD1 1 
+ATOM   195 N ND2 . ASN A 1 25 ? 34.628 21.595 9.920  1.00 24.70 ? 25  ASN A ND2 1 
+ATOM   196 N N   . VAL A 1 26 ? 34.007 23.745 13.250 1.00 6.52  ? 26  VAL A N   1 
+ATOM   197 C CA  . VAL A 1 26 ? 33.533 25.097 12.978 1.00 5.53  ? 26  VAL A CA  1 
+ATOM   198 C C   . VAL A 1 26 ? 34.441 26.099 13.684 1.00 4.42  ? 26  VAL A C   1 
+ATOM   199 O O   . VAL A 1 26 ? 34.883 27.090 13.093 1.00 3.40  ? 26  VAL A O   1 
+ATOM   200 C CB  . VAL A 1 26 ? 32.060 25.257 13.364 1.00 3.86  ? 26  VAL A CB  1 
+ATOM   201 C CG1 . VAL A 1 26 ? 31.684 26.749 13.342 1.00 7.25  ? 26  VAL A CG1 1 
+ATOM   202 C CG2 . VAL A 1 26 ? 31.152 24.421 12.477 1.00 8.12  ? 26  VAL A CG2 1 
+ATOM   203 N N   . LYS A 1 27 ? 34.734 25.822 14.949 1.00 2.64  ? 27  LYS A N   1 
+ATOM   204 C CA  . LYS A 1 27 ? 35.596 26.715 15.736 1.00 4.14  ? 27  LYS A CA  1 
+ATOM   205 C C   . LYS A 1 27 ? 36.975 26.826 15.107 1.00 5.58  ? 27  LYS A C   1 
+ATOM   206 O O   . LYS A 1 27 ? 37.579 27.926 15.159 1.00 4.11  ? 27  LYS A O   1 
+ATOM   207 C CB  . LYS A 1 27 ? 35.715 26.203 17.172 1.00 3.97  ? 27  LYS A CB  1 
+ATOM   208 C CG  . LYS A 1 27 ? 34.343 26.445 17.898 1.00 7.45  ? 27  LYS A CG  1 
+ATOM   209 C CD  . LYS A 1 27 ? 34.509 26.077 19.360 1.00 9.02  ? 27  LYS A CD  1 
+ATOM   210 C CE  . LYS A 1 27 ? 33.206 26.311 20.122 1.00 12.90 ? 27  LYS A CE  1 
+ATOM   211 N NZ  . LYS A 1 27 ? 33.455 25.910 21.546 1.00 15.47 ? 27  LYS A NZ  1 
+ATOM   212 N N   . ALA A 1 28 ? 37.499 25.743 14.571 1.00 6.61  ? 28  ALA A N   1 
+ATOM   213 C CA  . ALA A 1 28 ? 38.794 25.761 13.880 1.00 7.74  ? 28  ALA A CA  1 
+ATOM   214 C C   . ALA A 1 28 ? 38.728 26.591 12.611 1.00 9.17  ? 28  ALA A C   1 
+ATOM   215 O O   . ALA A 1 28 ? 39.704 27.346 12.277 1.00 11.45 ? 28  ALA A O   1 
+ATOM   216 C CB  . ALA A 1 28 ? 39.285 24.336 13.566 1.00 7.68  ? 28  ALA A CB  1 
+ATOM   217 N N   . LYS A 1 29 ? 37.633 26.543 11.867 1.00 8.96  ? 29  LYS A N   1 
+ATOM   218 C CA  . LYS A 1 29 ? 37.471 27.391 10.668 1.00 7.90  ? 29  LYS A CA  1 
+ATOM   219 C C   . LYS A 1 29 ? 37.441 28.882 11.052 1.00 6.92  ? 29  LYS A C   1 
+ATOM   220 O O   . LYS A 1 29 ? 38.020 29.772 10.382 1.00 6.87  ? 29  LYS A O   1 
+ATOM   221 C CB  . LYS A 1 29 ? 36.193 27.058 9.911  1.00 10.28 ? 29  LYS A CB  1 
+ATOM   222 C CG  . LYS A 1 29 ? 36.153 25.620 9.409  1.00 14.94 ? 29  LYS A CG  1 
+ATOM   223 C CD  . LYS A 1 29 ? 34.758 25.280 8.900  1.00 19.69 ? 29  LYS A CD  1 
+ATOM   224 C CE  . LYS A 1 29 ? 34.793 24.264 7.767  1.00 22.63 ? 29  LYS A CE  1 
+ATOM   225 N NZ  . LYS A 1 29 ? 34.914 24.944 6.441  1.00 24.98 ? 29  LYS A NZ  1 
+ATOM   226 N N   . ILE A 1 30 ? 36.811 29.170 12.192 1.00 4.57  ? 30  ILE A N   1 
+ATOM   227 C CA  . ILE A 1 30 ? 36.731 30.570 12.645 1.00 5.58  ? 30  ILE A CA  1 
+ATOM   228 C C   . ILE A 1 30 ? 38.148 30.981 13.069 1.00 7.26  ? 30  ILE A C   1 
+ATOM   229 O O   . ILE A 1 30 ? 38.544 32.150 12.856 1.00 9.46  ? 30  ILE A O   1 
+ATOM   230 C CB  . ILE A 1 30 ? 35.708 30.776 13.806 1.00 5.36  ? 30  ILE A CB  1 
+ATOM   231 C CG1 . ILE A 1 30 ? 34.228 30.630 13.319 1.00 2.94  ? 30  ILE A CG1 1 
+ATOM   232 C CG2 . ILE A 1 30 ? 35.874 32.138 14.512 1.00 2.78  ? 30  ILE A CG2 1 
+ATOM   233 C CD1 . ILE A 1 30 ? 33.284 30.504 14.552 1.00 2.00  ? 30  ILE A CD1 1 
+ATOM   234 N N   . GLN A 1 31 ? 38.883 30.110 13.713 1.00 7.06  ? 31  GLN A N   1 
+ATOM   235 C CA  . GLN A 1 31 ? 40.269 30.508 14.115 1.00 8.67  ? 31  GLN A CA  1 
+ATOM   236 C C   . GLN A 1 31 ? 41.092 30.808 12.851 1.00 10.90 ? 31  GLN A C   1 
+ATOM   237 O O   . GLN A 1 31 ? 41.828 31.808 12.681 1.00 9.63  ? 31  GLN A O   1 
+ATOM   238 C CB  . GLN A 1 31 ? 40.996 29.399 14.865 1.00 9.12  ? 31  GLN A CB  1 
+ATOM   239 C CG  . GLN A 1 31 ? 42.445 29.848 15.182 1.00 10.76 ? 31  GLN A CG  1 
+ATOM   240 C CD  . GLN A 1 31 ? 43.090 28.828 16.095 1.00 13.78 ? 31  GLN A CD  1 
+ATOM   241 O OE1 . GLN A 1 31 ? 42.770 27.655 15.906 1.00 14.48 ? 31  GLN A OE1 1 
+ATOM   242 N NE2 . GLN A 1 31 ? 43.898 29.252 17.050 1.00 14.76 ? 31  GLN A NE2 1 
+ATOM   243 N N   . ASP A 1 32 ? 41.001 29.878 11.931 1.00 10.93 ? 32  ASP A N   1 
+ATOM   244 C CA  . ASP A 1 32 ? 41.718 30.022 10.643 1.00 14.01 ? 32  ASP A CA  1 
+ATOM   245 C C   . ASP A 1 32 ? 41.399 31.338 9.967  1.00 14.04 ? 32  ASP A C   1 
+ATOM   246 O O   . ASP A 1 32 ? 42.260 32.036 9.381  1.00 13.39 ? 32  ASP A O   1 
+ATOM   247 C CB  . ASP A 1 32 ? 41.398 28.780 9.810  1.00 18.01 ? 32  ASP A CB  1 
+ATOM   248 C CG  . ASP A 1 32 ? 42.626 28.557 8.928  1.00 24.33 ? 32  ASP A CG  1 
+ATOM   249 O OD1 . ASP A 1 32 ? 43.666 28.262 9.539  1.00 26.29 ? 32  ASP A OD1 1 
+ATOM   250 O OD2 . ASP A 1 32 ? 42.430 28.812 7.728  1.00 25.17 ? 32  ASP A OD2 1 
+ATOM   251 N N   . LYS A 1 33 ? 40.117 31.750 9.988  1.00 14.22 ? 33  LYS A N   1 
+ATOM   252 C CA  . LYS A 1 33 ? 39.808 32.994 9.233  1.00 14.00 ? 33  LYS A CA  1 
+ATOM   253 C C   . LYS A 1 33 ? 39.837 34.271 9.995  1.00 12.37 ? 33  LYS A C   1 
+ATOM   254 O O   . LYS A 1 33 ? 40.164 35.323 9.345  1.00 12.17 ? 33  LYS A O   1 
+ATOM   255 C CB  . LYS A 1 33 ? 38.615 32.801 8.320  1.00 18.62 ? 33  LYS A CB  1 
+ATOM   256 C CG  . LYS A 1 33 ? 37.220 32.822 8.827  1.00 24.00 ? 33  LYS A CG  1 
+ATOM   257 C CD  . LYS A 1 33 ? 36.351 33.613 7.838  1.00 27.61 ? 33  LYS A CD  1 
+ATOM   258 C CE  . LYS A 1 33 ? 36.322 32.944 6.477  1.00 27.64 ? 33  LYS A CE  1 
+ATOM   259 N NZ  . LYS A 1 33 ? 35.768 33.945 5.489  1.00 30.06 ? 33  LYS A NZ  1 
+ATOM   260 N N   . GLU A 1 34 ? 39.655 34.335 11.285 1.00 10.11 ? 34  GLU A N   1 
+ATOM   261 C CA  . GLU A 1 34 ? 39.676 35.547 12.072 1.00 10.07 ? 34  GLU A CA  1 
+ATOM   262 C C   . GLU A 1 34 ? 40.675 35.527 13.200 1.00 9.32  ? 34  GLU A C   1 
+ATOM   263 O O   . GLU A 1 34 ? 40.814 36.528 13.911 1.00 11.61 ? 34  GLU A O   1 
+ATOM   264 C CB  . GLU A 1 34 ? 38.290 35.814 12.698 1.00 14.77 ? 34  GLU A CB  1 
+ATOM   265 C CG  . GLU A 1 34 ? 37.156 35.985 11.688 1.00 18.75 ? 34  GLU A CG  1 
+ATOM   266 C CD  . GLU A 1 34 ? 37.192 37.361 11.033 1.00 22.28 ? 34  GLU A CD  1 
+ATOM   267 O OE1 . GLU A 1 34 ? 37.519 38.360 11.645 1.00 21.95 ? 34  GLU A OE1 1 
+ATOM   268 O OE2 . GLU A 1 34 ? 36.861 37.320 9.822  1.00 25.19 ? 34  GLU A OE2 1 
+ATOM   269 N N   . GLY A 1 35 ? 41.317 34.393 13.432 1.00 7.22  ? 35  GLY A N   1 
+ATOM   270 C CA  . GLY A 1 35 ? 42.345 34.269 14.431 1.00 6.29  ? 35  GLY A CA  1 
+ATOM   271 C C   . GLY A 1 35 ? 41.949 34.076 15.842 1.00 6.93  ? 35  GLY A C   1 
+ATOM   272 O O   . GLY A 1 35 ? 42.829 34.000 16.739 1.00 7.41  ? 35  GLY A O   1 
+ATOM   273 N N   . ILE A 1 36 ? 40.642 33.916 16.112 1.00 5.86  ? 36  ILE A N   1 
+ATOM   274 C CA  . ILE A 1 36 ? 40.226 33.716 17.509 1.00 6.07  ? 36  ILE A CA  1 
+ATOM   275 C C   . ILE A 1 36 ? 40.449 32.278 17.945 1.00 6.36  ? 36  ILE A C   1 
+ATOM   276 O O   . ILE A 1 36 ? 39.936 31.336 17.315 1.00 6.18  ? 36  ILE A O   1 
+ATOM   277 C CB  . ILE A 1 36 ? 38.693 34.106 17.595 1.00 7.47  ? 36  ILE A CB  1 
+ATOM   278 C CG1 . ILE A 1 36 ? 38.471 35.546 17.045 1.00 8.52  ? 36  ILE A CG1 1 
+ATOM   279 C CG2 . ILE A 1 36 ? 38.146 33.932 19.027 1.00 7.36  ? 36  ILE A CG2 1 
+ATOM   280 C CD1 . ILE A 1 36 ? 36.958 35.746 16.680 1.00 9.49  ? 36  ILE A CD1 1 
+ATOM   281 N N   . PRO A 1 37 ? 41.189 32.085 19.031 1.00 8.65  ? 37  PRO A N   1 
+ATOM   282 C CA  . PRO A 1 37 ? 41.461 30.751 19.594 1.00 9.18  ? 37  PRO A CA  1 
+ATOM   283 C C   . PRO A 1 37 ? 40.168 30.026 19.918 1.00 9.85  ? 37  PRO A C   1 
+ATOM   284 O O   . PRO A 1 37 ? 39.264 30.662 20.521 1.00 8.51  ? 37  PRO A O   1 
+ATOM   285 C CB  . PRO A 1 37 ? 42.195 31.142 20.913 1.00 11.42 ? 37  PRO A CB  1 
+ATOM   286 C CG  . PRO A 1 37 ? 42.904 32.414 20.553 1.00 9.27  ? 37  PRO A CG  1 
+ATOM   287 C CD  . PRO A 1 37 ? 41.822 33.188 19.813 1.00 8.33  ? 37  PRO A CD  1 
+ATOM   288 N N   . PRO A 1 38 ? 40.059 28.758 19.607 1.00 8.71  ? 38  PRO A N   1 
+ATOM   289 C CA  . PRO A 1 38 ? 38.817 28.020 19.889 1.00 9.08  ? 38  PRO A CA  1 
+ATOM   290 C C   . PRO A 1 38 ? 38.421 28.048 21.341 1.00 9.28  ? 38  PRO A C   1 
+ATOM   291 O O   . PRO A 1 38 ? 37.213 28.036 21.704 1.00 6.50  ? 38  PRO A O   1 
+ATOM   292 C CB  . PRO A 1 38 ? 39.090 26.629 19.325 1.00 10.31 ? 38  PRO A CB  1 
+ATOM   293 C CG  . PRO A 1 38 ? 40.082 26.904 18.198 1.00 10.81 ? 38  PRO A CG  1 
+ATOM   294 C CD  . PRO A 1 38 ? 41.035 27.909 18.879 1.00 12.00 ? 38  PRO A CD  1 
+ATOM   295 N N   . ASP A 1 39 ? 39.374 28.090 22.240 1.00 11.20 ? 39  ASP A N   1 
+ATOM   296 C CA  . ASP A 1 39 ? 39.063 28.063 23.695 1.00 14.96 ? 39  ASP A CA  1 
+ATOM   297 C C   . ASP A 1 39 ? 38.365 29.335 24.159 1.00 13.99 ? 39  ASP A C   1 
+ATOM   298 O O   . ASP A 1 39 ? 37.684 29.390 25.221 1.00 13.75 ? 39  ASP A O   1 
+ATOM   299 C CB  . ASP A 1 39 ? 40.340 27.692 24.468 1.00 24.16 ? 39  ASP A CB  1 
+ATOM   300 C CG  . ASP A 1 39 ? 40.559 28.585 25.675 1.00 31.06 ? 39  ASP A CG  1 
+ATOM   301 O OD1 . ASP A 1 39 ? 40.716 29.809 25.456 1.00 35.55 ? 39  ASP A OD1 1 
+ATOM   302 O OD2 . ASP A 1 39 ? 40.549 28.090 26.840 1.00 34.22 ? 39  ASP A OD2 1 
+ATOM   303 N N   . GLN A 1 40 ? 38.419 30.373 23.341 1.00 11.60 ? 40  GLN A N   1 
+ATOM   304 C CA  . GLN A 1 40 ? 37.738 31.637 23.712 1.00 10.76 ? 40  GLN A CA  1 
+ATOM   305 C C   . GLN A 1 40 ? 36.334 31.742 23.087 1.00 8.01  ? 40  GLN A C   1 
+ATOM   306 O O   . GLN A 1 40 ? 35.574 32.618 23.483 1.00 8.96  ? 40  GLN A O   1 
+ATOM   307 C CB  . GLN A 1 40 ? 38.528 32.854 23.182 1.00 11.14 ? 40  GLN A CB  1 
+ATOM   308 C CG  . GLN A 1 40 ? 39.919 32.854 23.840 1.00 14.85 ? 40  GLN A CG  1 
+ATOM   309 C CD  . GLN A 1 40 ? 40.760 34.036 23.394 1.00 16.11 ? 40  GLN A CD  1 
+ATOM   310 O OE1 . GLN A 1 40 ? 41.975 34.008 23.624 1.00 20.52 ? 40  GLN A OE1 1 
+ATOM   311 N NE2 . GLN A 1 40 ? 40.140 35.007 22.775 1.00 18.16 ? 40  GLN A NE2 1 
+ATOM   312 N N   . GLN A 1 41 ? 36.000 30.860 22.172 1.00 6.52  ? 41  GLN A N   1 
+ATOM   313 C CA  . GLN A 1 41 ? 34.738 30.875 21.473 1.00 3.87  ? 41  GLN A CA  1 
+ATOM   314 C C   . GLN A 1 41 ? 33.589 30.189 22.181 1.00 4.79  ? 41  GLN A C   1 
+ATOM   315 O O   . GLN A 1 41 ? 33.580 29.009 22.499 1.00 6.34  ? 41  GLN A O   1 
+ATOM   316 C CB  . GLN A 1 41 ? 34.876 30.237 20.066 1.00 4.20  ? 41  GLN A CB  1 
+ATOM   317 C CG  . GLN A 1 41 ? 36.012 30.860 19.221 1.00 3.20  ? 41  GLN A CG  1 
+ATOM   318 C CD  . GLN A 1 41 ? 36.083 30.194 17.875 1.00 4.89  ? 41  GLN A CD  1 
+ATOM   319 O OE1 . GLN A 1 41 ? 35.048 29.702 17.393 1.00 5.21  ? 41  GLN A OE1 1 
+ATOM   320 N NE2 . GLN A 1 41 ? 37.228 30.126 17.233 1.00 7.13  ? 41  GLN A NE2 1 
+ATOM   321 N N   . ARG A 1 42 ? 32.478 30.917 22.269 1.00 5.73  ? 42  ARG A N   1 
+ATOM   322 C CA  . ARG A 1 42 ? 31.200 30.329 22.780 1.00 6.97  ? 42  ARG A CA  1 
+ATOM   323 C C   . ARG A 1 42 ? 30.210 30.509 21.650 1.00 7.15  ? 42  ARG A C   1 
+ATOM   324 O O   . ARG A 1 42 ? 29.978 31.726 21.269 1.00 7.33  ? 42  ARG A O   1 
+ATOM   325 C CB  . ARG A 1 42 ? 30.847 30.931 24.118 1.00 13.23 ? 42  ARG A CB  1 
+ATOM   326 C CG  . ARG A 1 42 ? 29.412 30.796 24.598 1.00 21.27 ? 42  ARG A CG  1 
+ATOM   327 C CD  . ARG A 1 42 ? 29.271 31.314 26.016 1.00 26.14 ? 42  ARG A CD  1 
+ATOM   328 N NE  . ARG A 1 42 ? 27.875 31.317 26.443 1.00 32.26 ? 42  ARG A NE  1 
+ATOM   329 C CZ  . ARG A 1 42 ? 27.132 32.423 26.574 1.00 34.32 ? 42  ARG A CZ  1 
+ATOM   330 N NH1 . ARG A 1 42 ? 27.630 33.656 26.461 1.00 35.30 ? 42  ARG A NH1 1 
+ATOM   331 N NH2 . ARG A 1 42 ? 25.810 32.299 26.732 1.00 36.39 ? 42  ARG A NH2 1 
+ATOM   332 N N   . LEU A 1 43 ? 29.694 29.436 21.054 1.00 4.65  ? 43  LEU A N   1 
+ATOM   333 C CA  . LEU A 1 43 ? 28.762 29.573 19.906 1.00 3.51  ? 43  LEU A CA  1 
+ATOM   334 C C   . LEU A 1 43 ? 27.331 29.317 20.364 1.00 5.56  ? 43  LEU A C   1 
+ATOM   335 O O   . LEU A 1 43 ? 27.101 28.346 21.097 1.00 4.19  ? 43  LEU A O   1 
+ATOM   336 C CB  . LEU A 1 43 ? 29.151 28.655 18.755 1.00 3.74  ? 43  LEU A CB  1 
+ATOM   337 C CG  . LEU A 1 43 ? 30.416 28.912 17.980 1.00 6.32  ? 43  LEU A CG  1 
+ATOM   338 C CD1 . LEU A 1 43 ? 30.738 27.693 17.122 1.00 9.55  ? 43  LEU A CD1 1 
+ATOM   339 C CD2 . LEU A 1 43 ? 30.205 30.168 17.129 1.00 6.41  ? 43  LEU A CD2 1 
+ATOM   340 N N   . ILE A 1 44 ? 26.436 30.232 20.004 1.00 4.58  ? 44  ILE A N   1 
+ATOM   341 C CA  . ILE A 1 44 ? 25.034 30.170 20.401 1.00 5.55  ? 44  ILE A CA  1 
+ATOM   342 C C   . ILE A 1 44 ? 24.101 30.149 19.196 1.00 5.46  ? 44  ILE A C   1 
+ATOM   343 O O   . ILE A 1 44 ? 24.196 30.948 18.287 1.00 6.04  ? 44  ILE A O   1 
+ATOM   344 C CB  . ILE A 1 44 ? 24.639 31.426 21.286 1.00 6.80  ? 44  ILE A CB  1 
+ATOM   345 C CG1 . ILE A 1 44 ? 25.646 31.670 22.421 1.00 10.31 ? 44  ILE A CG1 1 
+ATOM   346 C CG2 . ILE A 1 44 ? 23.181 31.309 21.824 1.00 7.39  ? 44  ILE A CG2 1 
+ATOM   347 C CD1 . ILE A 1 44 ? 25.778 30.436 23.356 1.00 13.90 ? 44  ILE A CD1 1 
+ATOM   348 N N   . PHE A 1 45 ? 23.141 29.187 19.241 1.00 6.75  ? 45  PHE A N   1 
+ATOM   349 C CA  . PHE A 1 45 ? 22.126 29.062 18.183 1.00 4.70  ? 45  PHE A CA  1 
+ATOM   350 C C   . PHE A 1 45 ? 20.835 28.629 18.904 1.00 6.34  ? 45  PHE A C   1 
+ATOM   351 O O   . PHE A 1 45 ? 20.821 27.734 19.749 1.00 5.45  ? 45  PHE A O   1 
+ATOM   352 C CB  . PHE A 1 45 ? 22.494 28.057 17.109 1.00 5.51  ? 45  PHE A CB  1 
+ATOM   353 C CG  . PHE A 1 45 ? 21.447 27.869 16.026 1.00 5.98  ? 45  PHE A CG  1 
+ATOM   354 C CD1 . PHE A 1 45 ? 21.325 28.813 15.005 1.00 6.86  ? 45  PHE A CD1 1 
+ATOM   355 C CD2 . PHE A 1 45 ? 20.638 26.735 16.053 1.00 5.87  ? 45  PHE A CD2 1 
+ATOM   356 C CE1 . PHE A 1 45 ? 20.369 28.648 14.001 1.00 6.68  ? 45  PHE A CE1 1 
+ATOM   357 C CE2 . PHE A 1 45 ? 19.677 26.539 15.051 1.00 6.64  ? 45  PHE A CE2 1 
+ATOM   358 C CZ  . PHE A 1 45 ? 19.593 27.465 14.021 1.00 6.84  ? 45  PHE A CZ  1 
+ATOM   359 N N   . ALA A 1 46 ? 19.810 29.378 18.578 1.00 6.53  ? 46  ALA A N   1 
+ATOM   360 C CA  . ALA A 1 46 ? 18.443 29.143 19.083 1.00 7.15  ? 46  ALA A CA  1 
+ATOM   361 C C   . ALA A 1 46 ? 18.453 28.941 20.591 1.00 9.00  ? 46  ALA A C   1 
+ATOM   362 O O   . ALA A 1 46 ? 17.860 27.994 21.128 1.00 11.15 ? 46  ALA A O   1 
+ATOM   363 C CB  . ALA A 1 46 ? 17.864 27.977 18.346 1.00 8.99  ? 46  ALA A CB  1 
+ATOM   364 N N   . GLY A 1 47 ? 19.172 29.808 21.243 1.00 9.35  ? 47  GLY A N   1 
+ATOM   365 C CA  . GLY A 1 47 ? 19.399 29.894 22.655 1.00 11.68 ? 47  GLY A CA  1 
+ATOM   366 C C   . GLY A 1 47 ? 20.083 28.729 23.321 1.00 11.14 ? 47  GLY A C   1 
+ATOM   367 O O   . GLY A 1 47 ? 19.991 28.584 24.561 1.00 13.93 ? 47  GLY A O   1 
+ATOM   368 N N   . LYS A 1 48 ? 20.801 27.931 22.578 1.00 10.47 ? 48  LYS A N   1 
+ATOM   369 C CA  . LYS A 1 48 ? 21.550 26.796 23.133 1.00 8.82  ? 48  LYS A CA  1 
+ATOM   370 C C   . LYS A 1 48 ? 23.046 27.087 22.913 1.00 7.68  ? 48  LYS A C   1 
+ATOM   371 O O   . LYS A 1 48 ? 23.383 27.627 21.870 1.00 6.47  ? 48  LYS A O   1 
+ATOM   372 C CB  . LYS A 1 48 ? 21.242 25.519 22.391 1.00 9.74  ? 48  LYS A CB  1 
+ATOM   373 C CG  . LYS A 1 48 ? 19.762 25.077 22.455 1.00 14.14 ? 48  LYS A CG  1 
+ATOM   374 C CD  . LYS A 1 48 ? 19.634 23.885 21.531 1.00 16.32 ? 48  LYS A CD  1 
+ATOM   375 C CE  . LYS A 1 48 ? 18.791 24.221 20.313 1.00 20.04 ? 48  LYS A CE  1 
+ATOM   376 N NZ  . LYS A 1 48 ? 17.440 24.655 20.827 1.00 23.92 ? 48  LYS A NZ  1 
+ATOM   377 N N   . GLN A 1 49 ? 23.880 26.727 23.851 1.00 8.89  ? 49  GLN A N   1 
+ATOM   378 C CA  . GLN A 1 49 ? 25.349 26.872 23.643 1.00 7.18  ? 49  GLN A CA  1 
+ATOM   379 C C   . GLN A 1 49 ? 25.743 25.586 22.922 1.00 8.23  ? 49  GLN A C   1 
+ATOM   380 O O   . GLN A 1 49 ? 25.325 24.489 23.378 1.00 9.70  ? 49  GLN A O   1 
+ATOM   381 C CB  . GLN A 1 49 ? 26.070 27.025 24.960 1.00 11.67 ? 49  GLN A CB  1 
+ATOM   382 C CG  . GLN A 1 49 ? 27.553 27.356 24.695 1.00 15.82 ? 49  GLN A CG  1 
+ATOM   383 C CD  . GLN A 1 49 ? 28.262 27.576 26.020 1.00 20.21 ? 49  GLN A CD  1 
+ATOM   384 O OE1 . GLN A 1 49 ? 29.189 26.840 26.335 1.00 23.23 ? 49  GLN A OE1 1 
+ATOM   385 N NE2 . GLN A 1 49 ? 27.777 28.585 26.739 1.00 20.67 ? 49  GLN A NE2 1 
+ATOM   386 N N   . LEU A 1 50 ? 26.465 25.689 21.833 1.00 6.51  ? 50  LEU A N   1 
+ATOM   387 C CA  . LEU A 1 50 ? 26.826 24.521 21.012 1.00 7.41  ? 50  LEU A CA  1 
+ATOM   388 C C   . LEU A 1 50 ? 27.994 23.781 21.643 1.00 8.27  ? 50  LEU A C   1 
+ATOM   389 O O   . LEU A 1 50 ? 28.904 24.444 22.098 1.00 8.34  ? 50  LEU A O   1 
+ATOM   390 C CB  . LEU A 1 50 ? 27.043 24.992 19.571 1.00 7.13  ? 50  LEU A CB  1 
+ATOM   391 C CG  . LEU A 1 50 ? 25.931 25.844 18.959 1.00 7.53  ? 50  LEU A CG  1 
+ATOM   392 C CD1 . LEU A 1 50 ? 26.203 26.083 17.471 1.00 8.14  ? 50  LEU A CD1 1 
+ATOM   393 C CD2 . LEU A 1 50 ? 24.577 25.190 19.079 1.00 9.11  ? 50  LEU A CD2 1 
+ATOM   394 N N   . GLU A 1 51 ? 27.942 22.448 21.648 1.00 9.43  ? 51  GLU A N   1 
+ATOM   395 C CA  . GLU A 1 51 ? 29.015 21.657 22.288 1.00 11.90 ? 51  GLU A CA  1 
+ATOM   396 C C   . GLU A 1 51 ? 29.942 21.106 21.240 1.00 11.49 ? 51  GLU A C   1 
+ATOM   397 O O   . GLU A 1 51 ? 29.470 20.677 20.190 1.00 9.88  ? 51  GLU A O   1 
+ATOM   398 C CB  . GLU A 1 51 ? 28.348 20.540 23.066 1.00 16.56 ? 51  GLU A CB  1 
+ATOM   399 C CG  . GLU A 1 51 ? 29.247 19.456 23.705 1.00 26.06 ? 51  GLU A CG  1 
+ATOM   400 C CD  . GLU A 1 51 ? 28.722 19.047 25.066 1.00 29.86 ? 51  GLU A CD  1 
+ATOM   401 O OE1 . GLU A 1 51 ? 29.139 18.132 25.746 1.00 32.13 ? 51  GLU A OE1 1 
+ATOM   402 O OE2 . GLU A 1 51 ? 27.777 19.842 25.367 1.00 33.44 ? 51  GLU A OE2 1 
+ATOM   403 N N   . ASP A 1 52 ? 31.233 21.090 21.459 1.00 12.71 ? 52  ASP A N   1 
+ATOM   404 C CA  . ASP A 1 52 ? 32.262 20.670 20.514 1.00 16.56 ? 52  ASP A CA  1 
+ATOM   405 C C   . ASP A 1 52 ? 32.128 19.364 19.750 1.00 15.83 ? 52  ASP A C   1 
+ATOM   406 O O   . ASP A 1 52 ? 32.546 19.317 18.558 1.00 17.21 ? 52  ASP A O   1 
+ATOM   407 C CB  . ASP A 1 52 ? 33.638 20.716 21.242 1.00 21.05 ? 52  ASP A CB  1 
+ATOM   408 C CG  . ASP A 1 52 ? 34.174 22.129 21.354 1.00 25.12 ? 52  ASP A CG  1 
+ATOM   409 O OD1 . ASP A 1 52 ? 35.252 22.322 21.958 1.00 28.37 ? 52  ASP A OD1 1 
+ATOM   410 O OD2 . ASP A 1 52 ? 33.544 23.086 20.883 1.00 25.82 ? 52  ASP A OD2 1 
+ATOM   411 N N   . GLY A 1 53 ? 31.697 18.311 20.406 1.00 15.00 ? 53  GLY A N   1 
+ATOM   412 C CA  . GLY A 1 53 ? 31.568 16.962 19.825 1.00 11.77 ? 53  GLY A CA  1 
+ATOM   413 C C   . GLY A 1 53 ? 30.320 16.698 19.051 1.00 11.10 ? 53  GLY A C   1 
+ATOM   414 O O   . GLY A 1 53 ? 30.198 15.657 18.366 1.00 11.25 ? 53  GLY A O   1 
+ATOM   415 N N   . ARG A 1 54 ? 29.340 17.594 19.076 1.00 8.53  ? 54  ARG A N   1 
+ATOM   416 C CA  . ARG A 1 54 ? 28.108 17.439 18.276 1.00 9.05  ? 54  ARG A CA  1 
+ATOM   417 C C   . ARG A 1 54 ? 28.375 17.999 16.887 1.00 8.96  ? 54  ARG A C   1 
+ATOM   418 O O   . ARG A 1 54 ? 29.326 18.786 16.690 1.00 11.60 ? 54  ARG A O   1 
+ATOM   419 C CB  . ARG A 1 54 ? 26.926 18.191 18.892 1.00 7.97  ? 54  ARG A CB  1 
+ATOM   420 C CG  . ARG A 1 54 ? 26.621 17.799 20.352 1.00 9.62  ? 54  ARG A CG  1 
+ATOM   421 C CD  . ARG A 1 54 ? 26.010 16.370 20.280 1.00 12.20 ? 54  ARG A CD  1 
+ATOM   422 N NE  . ARG A 1 54 ? 26.975 15.521 20.942 1.00 18.23 ? 54  ARG A NE  1 
+ATOM   423 C CZ  . ARG A 1 54 ? 27.603 14.423 20.655 1.00 22.08 ? 54  ARG A CZ  1 
+ATOM   424 N NH1 . ARG A 1 54 ? 27.479 13.733 19.537 1.00 23.38 ? 54  ARG A NH1 1 
+ATOM   425 N NH2 . ARG A 1 54 ? 28.519 13.967 21.550 1.00 25.50 ? 54  ARG A NH2 1 
+ATOM   426 N N   . THR A 1 55 ? 27.510 17.689 15.954 1.00 9.05  ? 55  THR A N   1 
+ATOM   427 C CA  . THR A 1 55 ? 27.574 18.192 14.563 1.00 9.03  ? 55  THR A CA  1 
+ATOM   428 C C   . THR A 1 55 ? 26.482 19.280 14.432 1.00 8.15  ? 55  THR A C   1 
+ATOM   429 O O   . THR A 1 55 ? 25.609 19.388 15.287 1.00 5.91  ? 55  THR A O   1 
+ATOM   430 C CB  . THR A 1 55 ? 27.299 17.055 13.533 1.00 11.15 ? 55  THR A CB  1 
+ATOM   431 O OG1 . THR A 1 55 ? 25.925 16.611 13.913 1.00 11.95 ? 55  THR A OG1 1 
+ATOM   432 C CG2 . THR A 1 55 ? 28.236 15.864 13.558 1.00 11.71 ? 55  THR A CG2 1 
+ATOM   433 N N   . LEU A 1 56 ? 26.585 20.063 13.378 1.00 6.91  ? 56  LEU A N   1 
+ATOM   434 C CA  . LEU A 1 56 ? 25.594 21.109 13.072 1.00 8.29  ? 56  LEU A CA  1 
+ATOM   435 C C   . LEU A 1 56 ? 24.241 20.436 12.857 1.00 8.05  ? 56  LEU A C   1 
+ATOM   436 O O   . LEU A 1 56 ? 23.264 20.951 13.329 1.00 10.17 ? 56  LEU A O   1 
+ATOM   437 C CB  . LEU A 1 56 ? 26.084 21.888 11.833 1.00 6.60  ? 56  LEU A CB  1 
+ATOM   438 C CG  . LEU A 1 56 ? 27.426 22.616 11.902 1.00 7.73  ? 56  LEU A CG  1 
+ATOM   439 C CD1 . LEU A 1 56 ? 27.718 23.341 10.578 1.00 9.85  ? 56  LEU A CD1 1 
+ATOM   440 C CD2 . LEU A 1 56 ? 27.380 23.721 12.955 1.00 8.64  ? 56  LEU A CD2 1 
+ATOM   441 N N   . SER A 1 57 ? 24.240 19.233 12.246 1.00 8.92  ? 57  SER A N   1 
+ATOM   442 C CA  . SER A 1 57 ? 22.924 18.583 12.025 1.00 9.00  ? 57  SER A CA  1 
+ATOM   443 C C   . SER A 1 57 ? 22.229 18.244 13.325 1.00 9.44  ? 57  SER A C   1 
+ATOM   444 O O   . SER A 1 57 ? 20.963 18.253 13.395 1.00 10.91 ? 57  SER A O   1 
+ATOM   445 C CB  . SER A 1 57 ? 23.059 17.326 11.154 1.00 10.32 ? 57  SER A CB  1 
+ATOM   446 O OG  . SER A 1 57 ? 23.914 16.395 11.755 1.00 13.59 ? 57  SER A OG  1 
+ATOM   447 N N   . ASP A 1 58 ? 22.997 17.978 14.366 1.00 9.11  ? 58  ASP A N   1 
+ATOM   448 C CA  . ASP A 1 58 ? 22.418 17.638 15.693 1.00 7.91  ? 58  ASP A CA  1 
+ATOM   449 C C   . ASP A 1 58 ? 21.460 18.737 16.163 1.00 9.12  ? 58  ASP A C   1 
+ATOM   450 O O   . ASP A 1 58 ? 20.497 18.506 16.900 1.00 8.61  ? 58  ASP A O   1 
+ATOM   451 C CB  . ASP A 1 58 ? 23.461 17.331 16.741 1.00 8.41  ? 58  ASP A CB  1 
+ATOM   452 C CG  . ASP A 1 58 ? 24.184 16.016 16.619 1.00 11.50 ? 58  ASP A CG  1 
+ATOM   453 O OD1 . ASP A 1 58 ? 25.303 15.894 17.152 1.00 10.05 ? 58  ASP A OD1 1 
+ATOM   454 O OD2 . ASP A 1 58 ? 23.572 15.107 15.975 1.00 11.70 ? 58  ASP A OD2 1 
+ATOM   455 N N   . TYR A 1 59 ? 21.846 19.954 15.905 1.00 7.97  ? 59  TYR A N   1 
+ATOM   456 C CA  . TYR A 1 59 ? 21.079 21.149 16.251 1.00 8.45  ? 59  TYR A CA  1 
+ATOM   457 C C   . TYR A 1 59 ? 20.142 21.590 15.149 1.00 10.98 ? 59  TYR A C   1 
+ATOM   458 O O   . TYR A 1 59 ? 19.499 22.645 15.321 1.00 12.95 ? 59  TYR A O   1 
+ATOM   459 C CB  . TYR A 1 59 ? 22.085 22.254 16.581 1.00 7.94  ? 59  TYR A CB  1 
+ATOM   460 C CG  . TYR A 1 59 ? 22.945 21.951 17.785 1.00 6.91  ? 59  TYR A CG  1 
+ATOM   461 C CD1 . TYR A 1 59 ? 24.272 21.544 17.644 1.00 4.59  ? 59  TYR A CD1 1 
+ATOM   462 C CD2 . TYR A 1 59 ? 22.437 22.157 19.065 1.00 6.98  ? 59  TYR A CD2 1 
+ATOM   463 C CE1 . TYR A 1 59 ? 25.052 21.285 18.776 1.00 5.39  ? 59  TYR A CE1 1 
+ATOM   464 C CE2 . TYR A 1 59 ? 23.204 21.907 20.192 1.00 6.52  ? 59  TYR A CE2 1 
+ATOM   465 C CZ  . TYR A 1 59 ? 24.517 21.470 20.030 1.00 6.76  ? 59  TYR A CZ  1 
+ATOM   466 O OH  . TYR A 1 59 ? 25.248 21.302 21.191 1.00 7.63  ? 59  TYR A OH  1 
+ATOM   467 N N   . ASN A 1 60 ? 19.993 20.884 14.049 1.00 12.38 ? 60  ASN A N   1 
+ATOM   468 C CA  . ASN A 1 60 ? 19.065 21.352 12.999 1.00 13.94 ? 60  ASN A CA  1 
+ATOM   469 C C   . ASN A 1 60 ? 19.442 22.745 12.510 1.00 14.16 ? 60  ASN A C   1 
+ATOM   470 O O   . ASN A 1 60 ? 18.571 23.610 12.289 1.00 14.26 ? 60  ASN A O   1 
+ATOM   471 C CB  . ASN A 1 60 ? 17.586 21.282 13.461 1.00 19.23 ? 60  ASN A CB  1 
+ATOM   472 C CG  . ASN A 1 60 ? 16.576 21.258 12.315 1.00 22.65 ? 60  ASN A CG  1 
+ATOM   473 O OD1 . ASN A 1 60 ? 15.440 21.819 12.378 1.00 25.45 ? 60  ASN A OD1 1 
+ATOM   474 N ND2 . ASN A 1 60 ? 16.924 20.586 11.216 1.00 24.09 ? 60  ASN A ND2 1 
+ATOM   475 N N   . ILE A 1 61 ? 20.717 22.964 12.260 1.00 11.08 ? 61  ILE A N   1 
+ATOM   476 C CA  . ILE A 1 61 ? 21.184 24.263 11.690 1.00 11.78 ? 61  ILE A CA  1 
+ATOM   477 C C   . ILE A 1 61 ? 21.110 24.111 10.173 1.00 13.74 ? 61  ILE A C   1 
+ATOM   478 O O   . ILE A 1 61 ? 21.841 23.198 9.686  1.00 14.60 ? 61  ILE A O   1 
+ATOM   479 C CB  . ILE A 1 61 ? 22.650 24.516 12.172 1.00 11.80 ? 61  ILE A CB  1 
+ATOM   480 C CG1 . ILE A 1 61 ? 22.662 24.819 13.699 1.00 11.56 ? 61  ILE A CG1 1 
+ATOM   481 C CG2 . ILE A 1 61 ? 23.376 25.645 11.409 1.00 13.29 ? 61  ILE A CG2 1 
+ATOM   482 C CD1 . ILE A 1 61 ? 24.123 24.981 14.195 1.00 11.42 ? 61  ILE A CD1 1 
+ATOM   483 N N   . GLN A 1 62 ? 20.291 24.875 9.507  1.00 13.97 ? 62  GLN A N   1 
+ATOM   484 C CA  . GLN A 1 62 ? 20.081 24.773 8.033  1.00 15.52 ? 62  GLN A CA  1 
+ATOM   485 C C   . GLN A 1 62 ? 20.822 25.914 7.332  1.00 13.94 ? 62  GLN A C   1 
+ATOM   486 O O   . GLN A 1 62 ? 21.323 26.830 8.008  1.00 12.15 ? 62  GLN A O   1 
+ATOM   487 C CB  . GLN A 1 62 ? 18.599 24.736 7.727  1.00 19.53 ? 62  GLN A CB  1 
+ATOM   488 C CG  . GLN A 1 62 ? 17.819 23.434 7.900  1.00 26.38 ? 62  GLN A CG  1 
+ATOM   489 C CD  . GLN A 1 62 ? 16.509 23.529 7.116  1.00 30.61 ? 62  GLN A CD  1 
+ATOM   490 O OE1 . GLN A 1 62 ? 15.446 22.980 7.433  1.00 33.23 ? 62  GLN A OE1 1 
+ATOM   491 N NE2 . GLN A 1 62 ? 16.539 24.293 6.009  1.00 32.71 ? 62  GLN A NE2 1 
+ATOM   492 N N   . LYS A 1 63 ? 20.924 25.862 6.006  1.00 11.73 ? 63  LYS A N   1 
+ATOM   493 C CA  . LYS A 1 63 ? 21.656 26.847 5.240  1.00 11.97 ? 63  LYS A CA  1 
+ATOM   494 C C   . LYS A 1 63 ? 21.127 28.240 5.574  1.00 10.41 ? 63  LYS A C   1 
+ATOM   495 O O   . LYS A 1 63 ? 19.958 28.465 5.842  1.00 9.59  ? 63  LYS A O   1 
+ATOM   496 C CB  . LYS A 1 63 ? 21.631 26.642 3.731  1.00 13.73 ? 63  LYS A CB  1 
+ATOM   497 C CG  . LYS A 1 63 ? 20.210 26.423 3.175  1.00 16.98 ? 63  LYS A CG  1 
+ATOM   498 C CD  . LYS A 1 63 ? 20.268 26.589 1.656  1.00 20.19 ? 63  LYS A CD  1 
+ATOM   499 C CE  . LYS A 1 63 ? 19.202 25.857 0.891  1.00 23.42 ? 63  LYS A CE  1 
+ATOM   500 N NZ  . LYS A 1 63 ? 17.884 26.544 1.075  1.00 25.97 ? 63  LYS A NZ  1 
+ATOM   501 N N   . GLU A 1 64 ? 22.099 29.163 5.605  1.00 10.04 ? 64  GLU A N   1 
+ATOM   502 C CA  . GLU A 1 64 ? 21.907 30.563 5.881  1.00 10.94 ? 64  GLU A CA  1 
+ATOM   503 C C   . GLU A 1 64 ? 21.466 30.953 7.261  1.00 9.74  ? 64  GLU A C   1 
+ATOM   504 O O   . GLU A 1 64 ? 21.066 32.112 7.533  1.00 9.42  ? 64  GLU A O   1 
+ATOM   505 C CB  . GLU A 1 64 ? 21.023 31.223 4.784  1.00 18.31 ? 64  GLU A CB  1 
+ATOM   506 C CG  . GLU A 1 64 ? 21.861 31.342 3.474  1.00 24.16 ? 64  GLU A CG  1 
+ATOM   507 C CD  . GLU A 1 64 ? 21.156 30.726 2.311  1.00 29.00 ? 64  GLU A CD  1 
+ATOM   508 O OE1 . GLU A 1 64 ? 19.942 30.793 2.170  1.00 31.72 ? 64  GLU A OE1 1 
+ATOM   509 O OE2 . GLU A 1 64 ? 21.954 30.152 1.535  1.00 32.61 ? 64  GLU A OE2 1 
+ATOM   510 N N   . SER A 1 65 ? 21.674 30.034 8.191  1.00 6.85  ? 65  SER A N   1 
+ATOM   511 C CA  . SER A 1 65 ? 21.419 30.253 9.620  1.00 6.90  ? 65  SER A CA  1 
+ATOM   512 C C   . SER A 1 65 ? 22.504 31.228 10.136 1.00 4.72  ? 65  SER A C   1 
+ATOM   513 O O   . SER A 1 65 ? 23.579 31.321 9.554  1.00 3.91  ? 65  SER A O   1 
+ATOM   514 C CB  . SER A 1 65 ? 21.637 28.923 10.353 1.00 7.28  ? 65  SER A CB  1 
+ATOM   515 O OG  . SER A 1 65 ? 20.544 28.047 10.059 1.00 10.56 ? 65  SER A OG  1 
+ATOM   516 N N   . THR A 1 66 ? 22.241 31.873 11.241 1.00 4.48  ? 66  THR A N   1 
+ATOM   517 C CA  . THR A 1 66 ? 23.212 32.762 11.891 1.00 3.80  ? 66  THR A CA  1 
+ATOM   518 C C   . THR A 1 66 ? 23.509 32.224 13.290 1.00 4.60  ? 66  THR A C   1 
+ATOM   519 O O   . THR A 1 66 ? 22.544 31.942 14.034 1.00 5.33  ? 66  THR A O   1 
+ATOM   520 C CB  . THR A 1 66 ? 22.699 34.267 11.985 1.00 2.85  ? 66  THR A CB  1 
+ATOM   521 O OG1 . THR A 1 66 ? 22.495 34.690 10.589 1.00 2.15  ? 66  THR A OG1 1 
+ATOM   522 C CG2 . THR A 1 66 ? 23.727 35.131 12.722 1.00 3.40  ? 66  THR A CG2 1 
+ATOM   523 N N   . LEU A 1 67 ? 24.790 32.021 13.618 1.00 4.17  ? 67  LEU A N   1 
+ATOM   524 C CA  . LEU A 1 67 ? 25.149 31.609 14.980 1.00 3.85  ? 67  LEU A CA  1 
+ATOM   525 C C   . LEU A 1 67 ? 25.698 32.876 15.669 1.00 3.80  ? 67  LEU A C   1 
+ATOM   526 O O   . LEU A 1 67 ? 26.158 33.730 14.894 1.00 5.54  ? 67  LEU A O   1 
+ATOM   527 C CB  . LEU A 1 67 ? 26.310 30.594 14.967 1.00 7.18  ? 67  LEU A CB  1 
+ATOM   528 C CG  . LEU A 1 67 ? 26.290 29.480 13.960 1.00 9.67  ? 67  LEU A CG  1 
+ATOM   529 C CD1 . LEU A 1 67 ? 27.393 28.442 14.229 1.00 8.12  ? 67  LEU A CD1 1 
+ATOM   530 C CD2 . LEU A 1 67 ? 24.942 28.807 13.952 1.00 11.66 ? 67  LEU A CD2 1 
+ATOM   531 N N   . HIS A 1 68 ? 25.621 32.945 16.950 1.00 2.94  ? 68  HIS A N   1 
+ATOM   532 C CA  . HIS A 1 68 ? 26.179 34.127 17.650 1.00 4.17  ? 68  HIS A CA  1 
+ATOM   533 C C   . HIS A 1 68 ? 27.475 33.651 18.304 1.00 5.32  ? 68  HIS A C   1 
+ATOM   534 O O   . HIS A 1 68 ? 27.507 32.587 18.958 1.00 7.70  ? 68  HIS A O   1 
+ATOM   535 C CB  . HIS A 1 68 ? 25.214 34.565 18.780 1.00 5.57  ? 68  HIS A CB  1 
+ATOM   536 C CG  . HIS A 1 68 ? 23.978 35.121 18.126 1.00 9.95  ? 68  HIS A CG  1 
+ATOM   537 N ND1 . HIS A 1 68 ? 23.853 36.432 17.781 1.00 13.74 ? 68  HIS A ND1 1 
+ATOM   538 C CD2 . HIS A 1 68 ? 22.824 34.514 17.782 1.00 12.79 ? 68  HIS A CD2 1 
+ATOM   539 C CE1 . HIS A 1 68 ? 22.674 36.627 17.200 1.00 14.75 ? 68  HIS A CE1 1 
+ATOM   540 N NE2 . HIS A 1 68 ? 22.045 35.455 17.173 1.00 16.30 ? 68  HIS A NE2 1 
+ATOM   541 N N   . LEU A 1 69 ? 28.525 34.447 18.189 1.00 5.29  ? 69  LEU A N   1 
+ATOM   542 C CA  . LEU A 1 69 ? 29.801 34.145 18.829 1.00 3.97  ? 69  LEU A CA  1 
+ATOM   543 C C   . LEU A 1 69 ? 30.052 35.042 20.004 1.00 5.07  ? 69  LEU A C   1 
+ATOM   544 O O   . LEU A 1 69 ? 30.105 36.305 19.788 1.00 4.34  ? 69  LEU A O   1 
+ATOM   545 C CB  . LEU A 1 69 ? 30.925 34.304 17.753 1.00 6.08  ? 69  LEU A CB  1 
+ATOM   546 C CG  . LEU A 1 69 ? 32.345 34.183 18.358 1.00 7.37  ? 69  LEU A CG  1 
+ATOM   547 C CD1 . LEU A 1 69 ? 32.555 32.783 18.870 1.00 6.87  ? 69  LEU A CD1 1 
+ATOM   548 C CD2 . LEU A 1 69 ? 33.361 34.491 17.245 1.00 9.96  ? 69  LEU A CD2 1 
+ATOM   549 N N   . VAL A 1 70 ? 30.124 34.533 21.191 1.00 4.29  ? 70  VAL A N   1 
+ATOM   550 C CA  . VAL A 1 70 ? 30.479 35.369 22.374 1.00 6.26  ? 70  VAL A CA  1 
+ATOM   551 C C   . VAL A 1 70 ? 31.901 34.910 22.728 1.00 9.22  ? 70  VAL A C   1 
+ATOM   552 O O   . VAL A 1 70 ? 32.190 33.696 22.635 1.00 9.36  ? 70  VAL A O   1 
+ATOM   553 C CB  . VAL A 1 70 ? 29.472 35.181 23.498 1.00 8.69  ? 70  VAL A CB  1 
+ATOM   554 C CG1 . VAL A 1 70 ? 29.821 35.957 24.765 1.00 9.76  ? 70  VAL A CG1 1 
+ATOM   555 C CG2 . VAL A 1 70 ? 28.049 35.454 23.071 1.00 8.54  ? 70  VAL A CG2 1 
+ATOM   556 N N   . LEU A 1 71 ? 32.763 35.831 23.090 1.00 12.71 ? 71  LEU A N   1 
+ATOM   557 C CA  . LEU A 1 71 ? 34.145 35.472 23.481 1.00 16.06 ? 71  LEU A CA  1 
+ATOM   558 C C   . LEU A 1 71 ? 34.239 35.353 24.979 1.00 18.09 ? 71  LEU A C   1 
+ATOM   559 O O   . LEU A 1 71 ? 33.707 36.197 25.728 1.00 19.26 ? 71  LEU A O   1 
+ATOM   560 C CB  . LEU A 1 71 ? 35.114 36.564 22.907 1.00 17.10 ? 71  LEU A CB  1 
+ATOM   561 C CG  . LEU A 1 71 ? 35.926 35.979 21.737 1.00 19.37 ? 71  LEU A CG  1 
+ATOM   562 C CD1 . LEU A 1 71 ? 35.003 35.084 20.920 1.00 17.51 ? 71  LEU A CD1 1 
+ATOM   563 C CD2 . LEU A 1 71 ? 36.533 37.087 20.917 1.00 19.57 ? 71  LEU A CD2 1 
+ATOM   564 N N   . ARG A 1 72 ? 34.930 34.384 25.451 1.00 21.47 ? 72  ARG A N   1 
+ATOM   565 C CA  . ARG A 1 72 ? 35.161 34.174 26.896 1.00 25.83 ? 72  ARG A CA  1 
+ATOM   566 C C   . ARG A 1 72 ? 36.671 34.296 27.089 1.00 27.74 ? 72  ARG A C   1 
+ATOM   567 O O   . ARG A 1 72 ? 37.305 33.233 26.795 1.00 30.65 ? 72  ARG A O   1 
+ATOM   568 C CB  . ARG A 1 72 ? 34.717 32.760 27.286 1.00 28.49 ? 72  ARG A CB  1 
+ATOM   569 C CG  . ARG A 1 72 ? 35.752 32.054 28.160 1.00 31.79 ? 72  ARG A CG  1 
+ATOM   570 C CD  . ARG A 1 72 ? 35.612 30.577 28.044 1.00 34.05 ? 72  ARG A CD  1 
+ATOM   571 N NE  . ARG A 1 72 ? 35.040 30.252 26.730 1.00 35.08 ? 72  ARG A NE  1 
+ATOM   572 C CZ  . ARG A 1 72 ? 34.338 29.103 26.650 1.00 34.67 ? 72  ARG A CZ  1 
+ATOM   573 N NH1 . ARG A 1 72 ? 34.110 28.437 27.768 1.00 35.02 ? 72  ARG A NH1 1 
+ATOM   574 N NH2 . ARG A 1 72 ? 34.014 28.657 25.457 1.00 34.97 ? 72  ARG A NH2 1 
+ATOM   575 N N   . LEU A 1 73 ? 37.197 35.397 27.513 0.45 28.93 ? 73  LEU A N   1 
+ATOM   576 C CA  . LEU A 1 73 ? 38.668 35.502 27.680 0.45 30.76 ? 73  LEU A CA  1 
+ATOM   577 C C   . LEU A 1 73 ? 39.076 34.931 29.031 0.45 32.18 ? 73  LEU A C   1 
+ATOM   578 O O   . LEU A 1 73 ? 38.297 34.946 29.996 0.45 32.31 ? 73  LEU A O   1 
+ATOM   579 C CB  . LEU A 1 73 ? 39.080 36.941 27.406 0.45 30.53 ? 73  LEU A CB  1 
+ATOM   580 C CG  . LEU A 1 73 ? 39.502 37.340 26.002 0.45 30.16 ? 73  LEU A CG  1 
+ATOM   581 C CD1 . LEU A 1 73 ? 38.684 36.647 24.923 0.45 29.57 ? 73  LEU A CD1 1 
+ATOM   582 C CD2 . LEU A 1 73 ? 39.337 38.854 25.862 0.45 29.11 ? 73  LEU A CD2 1 
+ATOM   583 N N   . ARG A 1 74 ? 40.294 34.412 29.045 0.45 33.82 ? 74  ARG A N   1 
+ATOM   584 C CA  . ARG A 1 74 ? 40.873 33.802 30.253 0.45 35.33 ? 74  ARG A CA  1 
+ATOM   585 C C   . ARG A 1 74 ? 41.765 34.829 30.944 0.45 36.22 ? 74  ARG A C   1 
+ATOM   586 O O   . ARG A 1 74 ? 42.945 34.994 30.583 0.45 36.70 ? 74  ARG A O   1 
+ATOM   587 C CB  . ARG A 1 74 ? 41.651 32.529 29.923 0.45 36.91 ? 74  ARG A CB  1 
+ATOM   588 C CG  . ARG A 1 74 ? 41.608 31.444 30.989 0.45 38.62 ? 74  ARG A CG  1 
+ATOM   589 C CD  . ARG A 1 74 ? 41.896 30.080 30.456 0.45 39.75 ? 74  ARG A CD  1 
+ATOM   590 N NE  . ARG A 1 74 ? 43.311 29.735 30.563 0.45 41.13 ? 74  ARG A NE  1 
+ATOM   591 C CZ  . ARG A 1 74 ? 44.174 29.905 29.554 0.45 41.91 ? 74  ARG A CZ  1 
+ATOM   592 N NH1 . ARG A 1 74 ? 43.754 30.312 28.356 0.45 42.75 ? 74  ARG A NH1 1 
+ATOM   593 N NH2 . ARG A 1 74 ? 45.477 29.726 29.763 0.45 41.93 ? 74  ARG A NH2 1 
+ATOM   594 N N   . GLY A 1 75 ? 41.165 35.531 31.898 0.25 36.31 ? 75  GLY A N   1 
+ATOM   595 C CA  . GLY A 1 75 ? 41.845 36.550 32.686 0.25 36.07 ? 75  GLY A CA  1 
+ATOM   596 C C   . GLY A 1 75 ? 41.251 37.941 32.588 0.25 36.16 ? 75  GLY A C   1 
+ATOM   597 O O   . GLY A 1 75 ? 41.102 38.523 31.500 0.25 36.26 ? 75  GLY A O   1 
+ATOM   598 N N   . GLY A 1 76 ? 40.946 38.472 33.757 0.25 36.05 ? 76  GLY A N   1 
+ATOM   599 C CA  . GLY A 1 76 ? 40.373 39.813 33.944 0.25 36.19 ? 76  GLY A CA  1 
+ATOM   600 C C   . GLY A 1 76 ? 40.031 39.992 35.432 0.25 36.20 ? 76  GLY A C   1 
+ATOM   601 O O   . GLY A 1 76 ? 38.933 40.525 35.687 0.25 36.13 ? 76  GLY A O   1 
+ATOM   602 O OXT . GLY A 1 76 ? 40.862 39.575 36.251 0.25 36.27 ? 76  GLY A OXT 1 
+HETATM 603 O O   . HOH B 2 .  ? 45.747 30.081 19.708 1.00 12.43 ? 77  HOH A O   1 
+HETATM 604 O O   . HOH B 2 .  ? 19.168 31.868 17.050 1.00 12.65 ? 78  HOH A O   1 
+HETATM 605 O O   . HOH B 2 .  ? 32.010 38.387 19.636 1.00 12.83 ? 79  HOH A O   1 
+HETATM 606 O O   . HOH B 2 .  ? 42.084 27.361 21.953 1.00 22.27 ? 80  HOH A O   1 
+HETATM 607 O O   . HOH B 2 .  ? 21.314 20.644 8.719  1.00 18.33 ? 81  HOH A O   1 
+HETATM 608 O O   . HOH B 2 .  ? 31.965 38.637 3.699  1.00 31.69 ? 82  HOH A O   1 
+HETATM 609 O O   . HOH B 2 .  ? 27.707 15.908 4.653  1.00 20.30 ? 83  HOH A O   1 
+HETATM 610 O O   . HOH B 2 .  ? 19.969 32.720 14.769 1.00 10.14 ? 84  HOH A O   1 
+HETATM 611 O O   . HOH B 2 .  ? 29.847 13.577 10.864 1.00 29.65 ? 85  HOH A O   1 
+HETATM 612 O O   . HOH B 2 .  ? 23.893 27.864 1.501  1.00 23.48 ? 86  HOH A O   1 
+HETATM 613 O O   . HOH B 2 .  ? 19.638 23.312 4.775  1.00 18.40 ? 87  HOH A O   1 
+HETATM 614 O O   . HOH B 2 .  ? 34.628 29.369 4.779  1.00 26.17 ? 88  HOH A O   1 
+HETATM 615 O O   . HOH B 2 .  ? 42.240 24.744 25.707 1.00 31.34 ? 89  HOH A O   1 
+HETATM 616 O O   . HOH B 2 .  ? 30.290 42.500 8.820  1.00 16.49 ? 90  HOH A O   1 
+HETATM 617 O O   . HOH B 2 .  ? 24.512 39.162 10.841 1.00 13.14 ? 91  HOH A O   1 
+HETATM 618 O O   . HOH B 2 .  ? 26.557 43.450 19.940 1.00 19.38 ? 92  HOH A O   1 
+HETATM 619 O O   . HOH B 2 .  ? 42.535 22.385 13.872 1.00 29.35 ? 93  HOH A O   1 
+HETATM 620 O O   . HOH B 2 .  ? 42.440 26.381 12.686 1.00 29.46 ? 94  HOH A O   1 
+HETATM 621 O O   . HOH B 2 .  ? 22.651 14.457 13.085 1.00 22.07 ? 95  HOH A O   1 
+HETATM 622 O O   . HOH B 2 .  ? 35.325 26.551 23.202 1.00 15.20 ? 96  HOH A O   1 
+HETATM 623 O O   . HOH B 2 .  ? 23.629 20.940 3.146  1.00 15.45 ? 97  HOH A O   1 
+HETATM 624 O O   . HOH B 2 .  ? 25.928 21.774 2.325  1.00 13.70 ? 98  HOH A O   1 
+HETATM 625 O O   . HOH B 2 .  ? 33.388 21.973 5.659  1.00 24.89 ? 99  HOH A O   1 
+HETATM 626 O O   . HOH B 2 .  ? 18.326 23.911 17.697 1.00 24.10 ? 100 HOH A O   1 
+HETATM 627 O O   . HOH B 2 .  ? 18.160 27.072 10.662 1.00 20.76 ? 101 HOH A O   1 
+HETATM 628 O O   . HOH B 2 .  ? 34.746 17.167 18.219 1.00 32.86 ? 102 HOH A O   1 
+HETATM 629 O O   . HOH B 2 .  ? 19.801 32.364 20.210 1.00 21.09 ? 103 HOH A O   1 
+HETATM 630 O O   . HOH B 2 .  ? 30.285 26.829 22.191 1.00 8.56  ? 104 HOH A O   1 
+HETATM 631 O O   . HOH B 2 .  ? 44.612 32.306 16.961 1.00 7.69  ? 105 HOH A O   1 
+HETATM 632 O O   . HOH B 2 .  ? 16.287 25.999 13.142 0.78 28.90 ? 106 HOH A O   1 
+HETATM 633 O O   . HOH B 2 .  ? 27.101 42.135 15.494 0.51 23.36 ? 107 HOH A O   1 
+HETATM 634 O O   . HOH B 2 .  ? 37.209 23.795 21.367 0.74 27.88 ? 108 HOH A O   1 
+HETATM 635 O O   . HOH B 2 .  ? 19.582 32.034 -0.685 0.49 22.24 ? 109 HOH A O   1 
+HETATM 636 O O   . HOH B 2 .  ? 28.824 25.094 0.886  0.77 36.99 ? 110 HOH A O   1 
+HETATM 637 O O   . HOH B 2 .  ? 25.146 19.162 25.323 0.87 36.70 ? 111 HOH A O   1 
+HETATM 638 O O   . HOH B 2 .  ? 20.747 37.769 14.674 0.85 29.64 ? 112 HOH A O   1 
+HETATM 639 O O   . HOH B 2 .  ? 16.035 17.841 8.765  0.61 23.89 ? 113 HOH A O   1 
+HETATM 640 O O   . HOH B 2 .  ? 35.712 46.814 12.926 0.48 27.11 ? 114 HOH A O   1 
+HETATM 641 O O   . HOH B 2 .  ? 15.570 27.475 7.482  0.51 24.18 ? 115 HOH A O   1 
+HETATM 642 O O   . HOH B 2 .  ? 33.447 21.075 2.918  0.59 26.03 ? 116 HOH A O   1 
+HETATM 643 O O   . HOH B 2 .  ? 41.116 39.021 13.061 0.63 22.39 ? 117 HOH A O   1 
+HETATM 644 O O   . HOH B 2 .  ? 32.346 13.689 18.912 0.48 24.09 ? 118 HOH A O   1 
+HETATM 645 O O   . HOH B 2 .  ? 31.197 13.048 7.920  0.71 29.54 ? 119 HOH A O   1 
+HETATM 646 O O   . HOH B 2 .  ? 42.853 39.375 29.308 0.64 46.90 ? 120 HOH A O   1 
+HETATM 647 O O   . HOH B 2 .  ? 39.646 23.959 9.699  0.41 18.25 ? 121 HOH A O   1 
+HETATM 648 O O   . HOH B 2 .  ? 34.405 45.181 13.420 0.87 26.13 ? 122 HOH A O   1 
+HETATM 649 O O   . HOH B 2 .  ? 26.517 24.300 27.592 0.41 21.02 ? 123 HOH A O   1 
+HETATM 650 O O   . HOH B 2 .  ? 40.740 38.734 9.602  0.45 16.60 ? 124 HOH A O   1 
+HETATM 651 O O   . HOH B 2 .  ? 31.494 18.276 23.170 0.67 26.53 ? 125 HOH A O   1 
+HETATM 652 O O   . HOH B 2 .  ? 37.752 30.947 1.059  0.87 32.52 ? 126 HOH A O   1 
+HETATM 653 O O   . HOH B 2 .  ? 31.771 16.941 7.511  0.64 15.94 ? 127 HOH A O   1 
+HETATM 654 O O   . HOH B 2 .  ? 41.628 24.537 10.145 0.57 22.53 ? 128 HOH A O   1 
+HETATM 655 O O   . HOH B 2 .  ? 28.988 22.175 -1.744 0.56 29.32 ? 129 HOH A O   1 
+HETATM 656 O O   . HOH B 2 .  ? 14.882 16.539 10.692 0.53 24.82 ? 130 HOH A O   1 
+HETATM 657 O O   . HOH B 2 .  ? 32.589 40.385 7.523  0.36 26.01 ? 131 HOH A O   1 
+HETATM 658 O O   . HOH B 2 .  ? 38.363 30.369 5.579  0.49 35.45 ? 132 HOH A O   1 
+HETATM 659 O O   . HOH B 2 .  ? 27.841 46.062 17.589 0.81 32.15 ? 133 HOH A O   1 
+HETATM 660 O O   . HOH B 2 .  ? 37.667 43.421 17.000 0.50 33.32 ? 134 HOH A O   1 
+# 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,49 @@
+import hashlib
+from pathlib import Path
+
+from mosaic.cache import cache_dir
+
+
+def test_default_cache_dir(monkeypatch):
+    monkeypatch.delenv("MOSAIC_CACHE_DIR", raising=False)
+
+    assert cache_dir() == Path("~/.cache/mosaic").expanduser()
+
+
+def test_cache_dir_can_be_overridden(monkeypatch, tmp_path):
+    root = tmp_path / "models"
+    monkeypatch.setenv("MOSAIC_CACHE_DIR", str(root))
+
+    assert cache_dir() == root
+
+def test_opendde_msa_cache_follows_runtime_override(monkeypatch, tmp_path):
+    from mosaic.models.opendde import _target_a3m
+
+    sequence = "ACDE"
+    digest = hashlib.sha256(sequence.encode("utf-8")).hexdigest()[:16]
+
+    for name in ("first", "second"):
+        root = tmp_path / name
+        monkeypatch.setenv("MOSAIC_CACHE_DIR", str(root))
+        cached = root / "msa" / f"{digest}.a3m"
+        cached.parent.mkdir(parents=True)
+        cached.write_text(f">query\n{sequence}\n")
+
+        assert _target_a3m(sequence) == str(cached)
+
+
+def test_esmfold_msa_cache_follows_runtime_override(monkeypatch, tmp_path):
+    from mosaic.models.esmfold2 import _fetch_msa
+
+    sequence = "ACDE"
+    digest = hashlib.sha256(sequence.encode("utf-8")).hexdigest()[:16]
+
+    for name in ("first", "second"):
+        root = tmp_path / name
+        monkeypatch.setenv("MOSAIC_CACHE_DIR", str(root))
+        cached = root / "msa" / f"{digest}.a3m"
+        cached.parent.mkdir(parents=True)
+        cached.write_text(f">query\n{sequence}\n")
+
+        _fetch_msa(sequence)
+        assert cached.exists()

--- a/tests/test_esmfold2_multisample.py
+++ b/tests/test_esmfold2_multisample.py
@@ -1,0 +1,86 @@
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from mosaic.common import LossTerm
+import mosaic.losses.esmfold2 as esmfold2_loss
+
+
+class _OutputLoss(LossTerm):
+    def __call__(self, sequence, output, *, key):
+        del sequence, key
+        return output, {"sample": output}
+
+
+@pytest.mark.parametrize("num_samples", [1, 3])
+def test_esmfold2_loss_runs_trunk_once(monkeypatch, num_samples):
+    calls = {"prepare": 0, "trunk": 0}
+
+    def fake_prepare(*args, **kwargs):
+        del args, kwargs
+        calls["prepare"] += 1
+        return (
+            object(),
+            None,
+            jnp.zeros(1, dtype=jnp.int32),
+            jnp.zeros((4, 1), dtype=jnp.int32),
+            jnp.zeros((1, 20)),
+        )
+
+    def fake_trunk(*args, **kwargs):
+        del args, kwargs
+        calls["trunk"] += 1
+        return jnp.array(0.0), jnp.array(0.0)
+
+    def fake_forward(*args, **kwargs):
+        key = args[3]
+        del kwargs
+        sample = jax.random.uniform(key)
+        return sample, jnp.zeros((1, 1, 1)), {}
+
+    def fake_to_output(**kwargs):
+        return kwargs["sample_atom_coords"]
+
+    monkeypatch.setattr(
+        esmfold2_loss,
+        "_prepare_esmfold2_inputs",
+        fake_prepare,
+    )
+    monkeypatch.setattr(esmfold2_loss, "esmfold2_trunk", fake_trunk)
+    monkeypatch.setattr(
+        esmfold2_loss,
+        "esmfold2_forward_from_trunk",
+        fake_forward,
+    )
+    monkeypatch.setattr(
+        esmfold2_loss,
+        "_to_structure_model_output",
+        fake_to_output,
+    )
+
+    loss = esmfold2_loss.ESMFold2Loss(
+        esmf=None,
+        pack=None,
+        loss=_OutputLoss(),
+        res_type_perm=jnp.zeros((20, 33)),
+        distogram_bins=jnp.zeros(1),
+        num_loops=1,
+        num_sampling_steps=2,
+        msa_max_depth=None,
+        num_samples=num_samples,
+    )
+    key = jax.random.key(7)
+
+    value, auxiliary = eqx.filter_jit(loss)(jnp.zeros((1, 20)), key=key)
+
+    _, samples_key = jax.random.split(key)
+    expected = jax.vmap(jax.random.uniform)(
+        jax.random.split(samples_key, num_samples)
+    )
+    assert calls == {"prepare": 1, "trunk": 1}
+    assert np.isclose(value, expected.mean())
+    # Scalar aux is always returned as a loss-sorted list (no single-sample
+    # squeeze), uniformly across sample counts -- a 1-element list when num_samples == 1.
+    assert np.allclose(np.asarray(auxiliary["sample"]), np.sort(expected))

--- a/tests/test_model_smoke.py
+++ b/tests/test_model_smoke.py
@@ -1,0 +1,500 @@
+"""Integration smoke tests for model paths used by the example notebooks.
+
+These tests load real checkpoints and may download weights on first use. Run
+them explicitly with ``uv run pytest -m model_smoke``.
+"""
+
+from __future__ import annotations
+
+import gc
+from importlib import import_module
+from types import SimpleNamespace
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import gemmi
+import optax
+import pytest
+
+from mosaic.common import LossTerm
+from mosaic.losses.structure_prediction import StructureModelOutput
+from mosaic.structure_prediction import (
+    StructurePrediction,
+    StructurePredictionModel,
+    TargetChain,
+)
+
+
+# Imports stay lazy so normal test collection does not initialize every model
+# stack. The matrix covers every common-interface factory used in examples.
+MODEL_FACTORIES = [
+    pytest.param(("mosaic.models.af2", "AlphaFold2"), id="alphafold2"),
+    pytest.param(("mosaic.models.boltz1", "Boltz1"), id="boltz1"),
+    pytest.param(("mosaic.models.boltz2", "Boltz2"), id="boltz2"),
+    pytest.param(("mosaic.models.protenix", "ProtenixMini"), id="protenix-mini"),
+    pytest.param(("mosaic.models.protenix", "ProtenixBase"), id="protenix-base"),
+    pytest.param(("mosaic.models.protenix", "Protenix2025"), id="protenix-2025"),
+    pytest.param(("mosaic.models.protenix", "ProtenixV2"), id="protenix-v2"),
+    pytest.param(("mosaic.models.of3", "OF3"), id="openfold3"),
+    pytest.param(("mosaic.models.esmfold2", "ESMFold2Fast"), id="esmfold2-fast"),
+    pytest.param(
+        ("mosaic.models.esmfold2", "ESMFold2ExperimentalFast"),
+        id="esmfold2-experimental-fast",
+    ),
+    pytest.param(
+        ("mosaic.models.esmfold2", "ESMFold2ExperimentalFast2025"),
+        id="esmfold2-experimental-fast-2025",
+    ),
+    pytest.param(("mosaic.models.promera", "JPromeraModel"), id="promera"),
+    pytest.param(("mosaic.models.opendde", "OpenDDEModelV1"), id="opendde-v1"),
+    pytest.param(("mosaic.models.opendde", "OpenDDEModelAbag"), id="opendde-abag"),
+]
+
+
+@pytest.fixture(params=MODEL_FACTORIES, scope="module")
+def structure_model(request):
+    module_name, factory_name = request.param
+    factory = getattr(import_module(module_name), factory_name)
+    cpu = jax.devices("cpu")[0]
+    with jax.default_device(cpu):
+        model = factory()
+        yield model
+
+        # Avoid retaining several large checkpoints in one pytest process.
+        del model
+    jax.clear_caches()
+    gc.collect()
+
+
+@pytest.fixture(scope="module")
+def boltzgen_assets():
+    module = import_module("mosaic.models.boltzgen")
+    cpu = jax.devices("cpu")[0]
+    with jax.default_device(cpu):
+        model = module.load_boltzgen()
+        yaml = """
+entities:
+  - protein:
+      id: B
+      sequence: 8
+      secondary_structure: HHHHHHHH
+"""
+        features, writer = module.load_features_and_structure_writer(yaml)
+        yield model, features, writer
+
+        del model, features, writer
+    jax.clear_caches()
+    gc.collect()
+
+
+@pytest.mark.slow
+@pytest.mark.model_smoke
+def test_boltzgen_loads_and_featurizes(boltzgen_assets):
+    model, features, writer = boltzgen_assets
+
+    assert jax.tree.leaves(model)
+    assert jax.tree.leaves(features)
+    assert callable(writer)
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+@pytest.mark.xfail(
+    jax.default_backend() == "cpu",
+    reason="BoltzGen diffusion currently produces non-finite coordinates on CPU",
+    strict=True,
+)
+def test_boltzgen_samples_and_writes_structure(boltzgen_assets):
+    module = import_module("mosaic.models.boltzgen")
+    model, features, writer = boltzgen_assets
+    sampler = module.Sampler.from_features(
+        model=model,
+        features=features,
+        recycling_steps=1,
+        deterministic=True,
+        key=jax.random.key(10),
+    )
+    coordinates = sampler(
+        structure_module=model.structure_module,
+        num_sampling_steps=10,
+        step_scale=jnp.asarray(2.0),
+        noise_scale=jnp.asarray(0.88),
+        key=jax.random.key(11),
+    )
+    structure = writer(coordinates)
+    assert np.asarray(coordinates).shape[-1] == 3
+    assert np.isfinite(np.asarray(coordinates)).all()
+    assert len(structure) == 1
+    assert sum(len(chain) for chain in structure[0]) == 8
+
+
+@pytest.mark.slow
+@pytest.mark.model_smoke
+def test_model_loads(structure_model):
+    assert isinstance(structure_model, StructurePredictionModel)
+
+
+@pytest.mark.slow
+@pytest.mark.model_smoke
+def test_model_featurizes_single_sequence(structure_model):
+    chain = TargetChain(sequence="ACDEFGHIKLMNPQRSTVWY", use_msa=False)
+    features, _writer = structure_model.target_only_features([chain])
+
+    assert features is not None
+    assert jax.tree.leaves(features), "featurization returned an empty pytree"
+
+
+@pytest.mark.slow
+@pytest.mark.model_smoke
+def test_model_featurizes_binder_and_target(structure_model):
+    target = TargetChain(sequence="ACDEFGHIKLMNPQRSTVWY", use_msa=False)
+    features, _writer = structure_model.binder_features(
+        binder_length=8,
+        chains=[target],
+    )
+
+    assert features is not None
+    assert jax.tree.leaves(features), "featurization returned an empty pytree"
+
+
+def _template_chain() -> gemmi.Chain:
+    structure = gemmi.Structure()
+    model = gemmi.Model("1")
+    chain = gemmi.Chain("A")
+    for index, residue_name in enumerate(("ALA", "CYS", "ASP"), start=1):
+        residue = gemmi.Residue()
+        residue.name = residue_name
+        residue.seqid = gemmi.SeqId(index, " ")
+        for atom_index, atom_name in enumerate(("N", "CA", "C", "O")):
+            atom = gemmi.Atom()
+            atom.name = atom_name
+            atom.element = gemmi.Element(atom_name[0])
+            atom.pos = gemmi.Position(float(index), float(atom_index), 0.0)
+            residue.add_atom(atom)
+        chain.add_residue(residue)
+    model.add_chain(chain)
+    structure.add_model(model)
+    return structure[0][0]
+
+
+@pytest.mark.slow
+@pytest.mark.model_smoke
+def test_notebook_models_featurize_template_chain(structure_model):
+    supported = {"AlphaFold2", "Boltz2", "OF3", "Protenix"}
+    if type(structure_model).__name__ not in supported:
+        pytest.skip("this notebook model does not use template-chain features")
+    target = TargetChain(
+        sequence="ACD", use_msa=False, template_chain=_template_chain()
+    )
+    features, _writer = structure_model.binder_features(2, [target])
+    assert jax.tree.leaves(features)
+
+
+class MeanConfidenceLoss(LossTerm):
+    def __call__(self, sequence, output, key):
+        del sequence, key
+        value = -jnp.mean(output.plddt)
+        return value, {"mean_plddt": -value}
+
+
+@pytest.fixture(scope="module")
+def forward_inputs(structure_model):
+    features, writer = structure_model.binder_features(
+        binder_length=2,
+        chains=[TargetChain(sequence="ACD", use_msa=False)],
+    )
+    pssm = jax.nn.one_hot(jnp.asarray([0, 7]), 20)
+    sampling_steps = None if type(structure_model).__name__ == "AlphaFold2" else 2
+    return SimpleNamespace(
+        features=features,
+        writer=writer,
+        pssm=pssm,
+        sampling_steps=sampling_steps,
+    )
+
+
+@pytest.fixture(scope="module")
+def built_loss(structure_model, forward_inputs):
+    return structure_model.build_loss(
+        loss=MeanConfidenceLoss(),
+        features=forward_inputs.features,
+        recycling_steps=1,
+        sampling_steps=forward_inputs.sampling_steps,
+    )
+
+
+@pytest.fixture(scope="module")
+def model_output_result(structure_model, forward_inputs):
+    return structure_model.model_output(
+        PSSM=forward_inputs.pssm,
+        features=forward_inputs.features,
+        recycling_steps=1,
+        sampling_steps=forward_inputs.sampling_steps,
+        key=jax.random.key(1),
+    )
+
+
+@pytest.fixture(scope="module")
+def prediction_result(structure_model, forward_inputs):
+    return structure_model.predict(
+        PSSM=forward_inputs.pssm,
+        features=forward_inputs.features,
+        writer=forward_inputs.writer,
+        recycling_steps=1,
+        sampling_steps=forward_inputs.sampling_steps,
+        key=jax.random.key(2),
+    )
+
+
+@pytest.fixture(scope="module")
+def evaluated_loss(built_loss, forward_inputs):
+    return eqx.filter_jit(built_loss)(forward_inputs.pssm, key=jax.random.key(3))
+
+
+@pytest.fixture(scope="module")
+def loss_and_gradient(built_loss, forward_inputs):
+    value_and_grad = eqx.filter_jit(eqx.filter_value_and_grad(built_loss, has_aux=True))
+    return value_and_grad(forward_inputs.pssm, key=jax.random.key(4))
+
+
+@pytest.fixture(params=["binder", "target_only"], scope="module")
+def multichain_prediction(structure_model, request):
+    target_sequences = ("AC", "DEF")
+    targets = [
+        TargetChain(sequence=sequence, use_msa=False) for sequence in target_sequences
+    ]
+    if request.param == "binder":
+        features, writer = structure_model.binder_features(
+            binder_length=2,
+            chains=targets,
+        )
+        pssm = jax.nn.one_hot(jnp.asarray([0, 7]), 20)
+        expected_names = (
+            ("ALA", "GLY"),
+            ("ALA", "CYS"),
+            ("ASP", "GLU", "PHE"),
+        )
+    else:
+        features, writer = structure_model.target_only_features(targets)
+        pssm = None
+        expected_names = (
+            ("ALA", "CYS"),
+            ("ASP", "GLU", "PHE"),
+        )
+    sampling_steps = None if type(structure_model).__name__ == "AlphaFold2" else 2
+    prediction = structure_model.predict(
+        PSSM=pssm,
+        features=features,
+        writer=writer,
+        recycling_steps=1,
+        sampling_steps=sampling_steps,
+        key=jax.random.key(5),
+    )
+    return SimpleNamespace(
+        prediction=prediction,
+        mode=request.param,
+        expected_names=expected_names,
+    )
+
+
+def _protein_chains(structure):
+    return [list(chain) for chain in structure[0]]
+
+
+def _atom_coordinates(chains):
+    return {
+        (chain_index, residue_index, atom.name): np.asarray(
+            [atom.pos.x, atom.pos.y, atom.pos.z]
+        )
+        for chain_index, chain in enumerate(chains)
+        for residue_index, residue in enumerate(chain)
+        for atom in residue
+    }
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_model_builds_loss(built_loss):
+    assert isinstance(built_loss, LossTerm)
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_model_output_runs(model_output_result):
+    assert isinstance(model_output_result, StructureModelOutput)
+    assert model_output_result.plddt.shape == (5,)
+    assert model_output_result.pae.shape == (5, 5)
+    assert model_output_result.atom37_coords.shape == (5, 37, 3)
+    assert np.isfinite(np.asarray(model_output_result.plddt)).all()
+    assert np.isfinite(np.asarray(model_output_result.pae)).all()
+    assert np.isfinite(np.asarray(model_output_result.atom37_coords)).all()
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_model_predict_runs(prediction_result):
+    assert isinstance(prediction_result, StructurePrediction)
+    assert prediction_result.st is not None
+    assert len(prediction_result.st) > 0
+    assert prediction_result.plddt.shape == (5,)
+    assert prediction_result.pae.shape == (5, 5)
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_model_loss_runs(evaluated_loss):
+    value, auxiliary = evaluated_loss
+    assert np.isfinite(np.asarray(value)).all()
+    assert auxiliary is not None
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_model_loss_gradient_runs(loss_and_gradient, forward_inputs):
+    (value, auxiliary), gradient = loss_and_gradient
+
+    assert np.isfinite(np.asarray(value)).all()
+    assert auxiliary is not None
+    assert gradient.shape == forward_inputs.pssm.shape
+    assert np.isfinite(np.asarray(gradient)).all()
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_model_optimizer_step_runs(loss_and_gradient, forward_inputs):
+    (_value, _auxiliary), gradient = loss_and_gradient
+    optimizer = optax.adam(learning_rate=0.01)
+    state = optimizer.init(forward_inputs.pssm)
+    updates, state = optimizer.update(
+        gradient,
+        state,
+        params=forward_inputs.pssm,
+    )
+    updated_pssm = optax.apply_updates(forward_inputs.pssm, updates)
+
+    assert state is not None
+    assert updated_pssm.shape == forward_inputs.pssm.shape
+    assert np.isfinite(np.asarray(updated_pssm)).all()
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_notebook_models_run_multisample_loss(structure_model, forward_inputs):
+    if type(structure_model).__name__ not in {"ESMFold2", "OF3", "OpenDDEModel", "Protenix"}:
+        pytest.skip("representative notebooks only")
+    loss = structure_model.build_multisample_loss(
+        loss=MeanConfidenceLoss(),
+        features=forward_inputs.features,
+        recycling_steps=1,
+        sampling_steps=2,
+        num_samples=2,
+    )
+    value, auxiliary = eqx.filter_jit(loss)(forward_inputs.pssm, key=jax.random.key(12))
+    assert np.isfinite(np.asarray(value)).all()
+    assert auxiliary is not None
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_promera_backbone_design_and_refold_flow(structure_model):
+    if type(structure_model).__name__ != "JPromeraModel":
+        pytest.skip("Promera-specific notebook workflow")
+    from mosaic.losses.protein_mpnn import inverse_fold
+    from mosaic.proteinmpnn.mpnn import load_mpnn_sol
+
+    binder_length = 2
+    target = TargetChain("ACD", use_msa=False)
+    design_features, _ = structure_model.target_only_features(
+        [TargetChain("X" * binder_length, use_msa=False), target]
+    )
+    backbone = structure_model.model_output(
+        features=design_features,
+        recycling_steps=1,
+        sampling_steps=2,
+        key=jax.random.key(13),
+    )
+    sequence = inverse_fold(
+        load_mpnn_sol(),
+        binder_length,
+        backbone,
+        temp=0.1,
+        jacobi_iterations=1,
+        key=jax.random.key(14),
+    )
+    refold_features, writer = structure_model.binder_features(binder_length, [target])
+    prediction = structure_model.predict(
+        PSSM=jax.nn.one_hot(sequence, 20),
+        features=refold_features,
+        writer=writer,
+        recycling_steps=1,
+        sampling_steps=2,
+        key=jax.random.key(15),
+    )
+    assert sequence.shape == (binder_length,)
+    assert np.isfinite(np.asarray(backbone.atom37_coords)).all()
+    assert tuple(map(len, _protein_chains(prediction.st))) == (binder_length, 3)
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_model_predict_preserves_multichain_boundaries(multichain_prediction):
+    prediction = multichain_prediction.prediction
+    expected_lengths = tuple(map(len, multichain_prediction.expected_names))
+    chains = _protein_chains(prediction.st)
+    asym_id = np.asarray(prediction.model_output.asym_id)
+    observed_asym_ids = dict.fromkeys(asym_id.tolist())
+
+    assert tuple(map(len, chains)) == expected_lengths
+    assert tuple(
+        np.count_nonzero(asym_id == chain_id) for chain_id in observed_asym_ids
+    ) == (expected_lengths)
+    assert prediction.plddt.shape == (sum(expected_lengths),)
+    assert prediction.pae.shape == (sum(expected_lengths),) * 2
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_model_output_structure_matches_prediction(multichain_prediction):
+    prediction = multichain_prediction.prediction
+    expected_names = multichain_prediction.expected_names
+    expected_lengths = tuple(map(len, expected_names))
+    converted_chains = _protein_chains(prediction.model_output.to_structure())
+    predicted_chains = _protein_chains(prediction.st)
+
+    assert tuple(map(len, converted_chains)) == expected_lengths
+    assert (
+        tuple(tuple(residue.name for residue in chain) for chain in converted_chains)
+        == expected_names
+    )
+    for chain_index, (converted, predicted) in enumerate(
+        zip(converted_chains, predicted_chains)
+    ):
+        for converted_residue, predicted_residue in zip(converted, predicted):
+            allowed_names = {converted_residue.name}
+            if multichain_prediction.mode == "binder" and chain_index == 0:
+                allowed_names.add("UNK")
+            assert predicted_residue.name in allowed_names
+
+    converted_atoms = _atom_coordinates(converted_chains)
+    predicted_atoms = _atom_coordinates(predicted_chains)
+    shared_atoms = converted_atoms.keys() & predicted_atoms.keys()
+    for chain_index, chain in enumerate(converted_chains):
+        for residue_index, _residue in enumerate(chain):
+            assert {
+                (chain_index, residue_index, name) for name in ("N", "CA", "C", "O")
+            } <= shared_atoms
+    comparable_atoms = {
+        key
+        for key in shared_atoms
+        if not (
+            multichain_prediction.mode == "binder"
+            and key[0] == 0
+            and predicted_chains[key[0]][key[1]].name == "UNK"
+            and key[2] not in {"N", "CA", "C", "O"}
+        )
+    }
+    converted_coords = np.asarray([converted_atoms[key] for key in comparable_atoms])
+    predicted_coords = np.asarray([predicted_atoms[key] for key in comparable_atoms])
+    assert np.sqrt(np.mean(np.square(converted_coords - predicted_coords))) < 0.1

--- a/tests/test_opendde.py
+++ b/tests/test_opendde.py
@@ -1,0 +1,157 @@
+"""Focused contract tests for the OpenDDE adapter."""
+
+from pathlib import Path
+
+import gemmi
+import numpy as np
+import pytest
+
+from mosaic.models.opendde import (
+    _binder_extents,
+    _build_spec,
+    _featurize,
+    _target_template_features,
+)
+from mosaic.structure_prediction import PolymerType, TargetChain
+
+
+def test_build_spec_for_msa_free_protein():
+    spec = _build_spec([TargetChain("ACDE", use_msa=False)])
+
+    assert spec == [
+        {
+            "name": "design",
+            "modelSeeds": [0],
+            "sequences": [{"proteinChain": {"sequence": "ACDE", "count": 1}}],
+        }
+    ]
+
+
+@pytest.mark.parametrize("polymer_type", [PolymerType.RNA, PolymerType.DNA])
+def test_build_spec_rejects_nonprotein_chains(polymer_type):
+    chain = TargetChain("ACGU", polymer_type=polymer_type, use_msa=False)
+
+    with pytest.raises(NotImplementedError, match="protein chains only"):
+        _build_spec([chain])
+
+
+def test_build_spec_accepts_target_templates():
+    chain = TargetChain("ACDE", use_msa=False, template_chain=gemmi.Chain("A"))
+
+    assert _build_spec([chain])[0]["sequences"] == [
+        {"proteinChain": {"sequence": "ACDE", "count": 1}}
+    ]
+
+
+@pytest.mark.slow
+@pytest.mark.opendde_smoke
+def test_featurizes_1ubq_as_structural_template():
+    structure = gemmi.read_structure(str(Path(__file__).parent / "data" / "1ubq.cif"))
+    template = structure[0]["A"]
+    sequence = gemmi.one_letter_code([res.name for res in template.get_polymer()])
+
+    features, _writer = _featurize(
+        [TargetChain(sequence, use_msa=False, template_chain=template)]
+    )
+
+    assert features.template is not None
+    assert features.template.aatype.shape == (4, len(sequence))
+    assert np.count_nonzero(np.asarray(features.template.pseudo_beta_mask[0])) > 0
+    assert np.count_nonzero(np.asarray(features.template.backbone_frame_mask[0])) > 0
+
+
+def test_target_template_ignores_waters_after_binder_offset():
+    structure = gemmi.read_structure(str(Path(__file__).parent / "data" / "1ubq.cif"))
+    template = structure[0]["A"]
+    sequence = gemmi.one_letter_code([res.name for res in template.get_polymer()])
+
+    features = _target_template_features(
+        [
+            TargetChain("WWWW", use_msa=False),
+            TargetChain(sequence, use_msa=False, template_chain=template),
+        ]
+    )
+
+    assert features is not None
+    assert features["template_aatype"].shape == (4, 4 + len(sequence))
+    assert np.all(features["template_aatype"][1:] == 0)
+    assert not np.any(features["template_pseudo_beta_mask"][0, :4])
+    assert np.any(features["template_pseudo_beta_mask"][0, 4:, 4:])
+
+
+@pytest.mark.slow
+@pytest.mark.opendde_smoke
+def test_featurizes_single_protein_without_model_weights():
+    sequence = "ACDEFGHIK"
+
+    features, writer = _featurize([TargetChain(sequence, use_msa=False)])
+
+    assert features.restype.shape[0] == len(sequence)
+    assert features.asym_id.shape == (len(sequence),)
+    assert np.all(np.asarray(features.asym_id) == 0)
+    assert features.ref_pos.shape[-1] == 3
+    assert writer is not None
+
+
+@pytest.mark.slow
+@pytest.mark.opendde_smoke
+def test_binder_extent_matches_first_chain():
+    binder_length = 5
+    features, _writer = _featurize(
+        [
+            TargetChain("W" * binder_length, use_msa=False),
+            TargetChain("ACDE", use_msa=False),
+        ]
+    )
+
+    observed_length, atom_allocation = _binder_extents(features)
+
+    assert observed_length == binder_length
+    assert atom_allocation > binder_length
+
+
+def test_model_build_loads_predictor_without_process_cache(monkeypatch, tmp_path):
+    import jopendde.inference as inference
+    import mosaic.models.opendde as adapter
+
+    calls = []
+    model = object()
+
+    class SummaryParams:
+        pae_bins = (0.0, 32.0, 64)
+        plddt_bins = (0.0, 1.0, 50)
+
+    class LoadedPredictor:
+        summary_params = SummaryParams()
+
+    class FakePredictor:
+        @classmethod
+        def from_checkpoint(cls, *args, **kwargs):
+            calls.append((args, kwargs))
+            predictor = LoadedPredictor()
+            predictor.model = model
+            return predictor
+
+    monkeypatch.setenv("MOSAIC_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(inference, "Predictor", FakePredictor)
+    monkeypatch.setattr(
+        adapter,
+        "_build_dense_atom_to_atom37",
+        lambda: np.zeros((1, 1)),
+    )
+    monkeypatch.setattr(adapter, "_get_atom_templates", lambda: None)
+    monkeypatch.setattr(adapter, "OpenDDEModel", lambda **kwargs: kwargs)
+
+    first = adapter._build_model("opendde_v1", "opendde.pt")
+    second = adapter._build_model("opendde_v1", "opendde.pt")
+
+    expected_call = (
+        ("opendde_v1",),
+        {
+            "checkpoint_file": "opendde.pt",
+            "asset_cache_dir": tmp_path / "opendde",
+        },
+    )
+    assert calls == [expected_call, expected_call]
+    assert first["model"] is model
+    assert second["model"] is model

--- a/tests/test_opendde_contracts.py
+++ b/tests/test_opendde_contracts.py
@@ -1,0 +1,268 @@
+from types import SimpleNamespace
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from mosaic.common import LossTerm, TOKENS
+from mosaic.losses.opendde import (
+    MultiSampleOpenDDELoss,
+    OpenDDEAtomTemplates,
+    OpenDDEDesignFeatures,
+    set_binder_sequence,
+)
+from mosaic.models.opendde import OpenDDEModel
+from mosaic.structure_prediction import TargetChain
+
+
+class _ZeroLoss(LossTerm):
+    def __call__(self, sequence, output, *, key):
+        del sequence, output, key
+        return jnp.array(0.0), {}
+
+
+def _empty_atom_templates():
+    import mosaic.models.opendde as adapter
+
+    floats = {"ref_pos", "ref_element", "ref_charge", "ref_atom_name_chars"}
+    arrays = {
+        name: jnp.zeros(shape, dtype=jnp.float32 if name in floats else jnp.int32)
+        for name, shape in adapter._atom_template_shapes().items()
+    }
+    return OpenDDEAtomTemplates(**arrays)
+
+
+def _adapter_model():
+    return OpenDDEModel(
+        model=None,
+        dense_atom_to_atom37=jnp.zeros((32, 15), dtype=jnp.int32),
+        atom_templates=_empty_atom_templates(),
+    )
+
+
+def test_design_loss_rejects_target_only_features():
+    model = _adapter_model()
+
+    with pytest.raises(TypeError, match="binder_features"):
+        model.build_loss(loss=_ZeroLoss(), features=object())
+
+
+def test_binder_features_constructs_design_bundle_once(monkeypatch):
+    raw = SimpleNamespace(
+        asym_id=np.asarray([0, 0, 1, 1, 1]),
+        atom_to_token_idx=np.asarray([0, 0, 1, 1, 2, 3, 4]),
+    )
+    monkeypatch.setattr(
+        OpenDDEModel,
+        "target_only_features",
+        lambda self, chains: (raw, "writer"),
+    )
+    model = _adapter_model()
+
+    features, writer = model.binder_features(2, [TargetChain("ACD")])
+
+    assert isinstance(features, OpenDDEDesignFeatures)
+    assert features.features is raw
+    assert features.atom_templates is model.atom_templates
+    assert features.binder_length == 2
+    assert features.binder_atom_alloc == 4
+    assert writer == "writer"
+
+
+@pytest.mark.parametrize(
+    ("shape", "message"),
+    [((3, 20), "length"), ((2, 19), "20 columns")],
+)
+def test_set_binder_sequence_validates_pssm_shape(shape, message):
+    features = OpenDDEDesignFeatures(
+        features=None,
+        atom_templates=_empty_atom_templates(),
+        binder_length=2,
+        binder_atom_alloc=1,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        set_binder_sequence(jnp.zeros(shape), features, jax.random.key(0))
+
+
+def test_featurize_configs_are_isolated_and_follow_cache_root(monkeypatch, tmp_path):
+    import mosaic.models.opendde as adapter
+
+    base = SimpleNamespace(use_msa=False, seeds=[])
+    roots = []
+
+    def cached(root):
+        roots.append(root)
+        return base
+
+    monkeypatch.setattr(adapter, "_cached_featurize_config", cached)
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+
+    monkeypatch.setenv("MOSAIC_CACHE_DIR", str(first_root))
+    first = adapter._featurize_configs()
+    first.use_msa = True
+    first.seeds.append(1)
+
+    monkeypatch.setenv("MOSAIC_CACHE_DIR", str(second_root))
+    second = adapter._featurize_configs()
+
+    assert roots == [str(first_root), str(second_root)]
+    assert base.use_msa is False
+    assert base.seeds == []
+    assert second.use_msa is False
+    assert second.seeds == []
+
+
+def test_atom_template_cache_is_versioned_and_recovers_from_corruption(
+    monkeypatch, tmp_path
+):
+    import mosaic.models.opendde as adapter
+
+    built = []
+    templates = _empty_atom_templates()
+    monkeypatch.setenv("MOSAIC_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(adapter, "_jopendde_build_id", lambda: "revision123456")
+
+    def build(_featurize_one):
+        built.append(None)
+        return templates
+
+    monkeypatch.setattr(adapter, "build_opendde_atom_templates", build)
+    adapter._ATOM_TEMPLATE_CACHE.clear()
+
+    first = adapter._get_atom_templates()
+    files = list((tmp_path / "opendde" / "atom_templates").glob("*.npz"))
+
+    assert first is templates
+    assert len(files) == 1
+    assert "v1-revision123" in files[0].name
+    assert built == [None]
+
+    adapter._ATOM_TEMPLATE_CACHE.clear()
+    loaded = adapter._get_atom_templates()
+    assert built == [None]
+    assert np.asarray(loaded.ref_pos).shape == np.asarray(templates.ref_pos).shape
+
+    files[0].write_bytes(b"not an npz")
+    adapter._ATOM_TEMPLATE_CACHE.clear()
+    rebuilt = adapter._get_atom_templates()
+
+    assert rebuilt is templates
+    assert built == [None, None]
+    with np.load(files[0], allow_pickle=False) as data:
+        adapter._validate_atom_template_cache(data, "revision123456")
+    assert not list(files[0].parent.glob("*.tmp"))
+
+
+class _FakeModel(eqx.Module):
+    def get_pairformer_output(self, features, num_cycles):
+        del features, num_cycles
+        return jnp.array(0.0), jnp.array(0.0), jnp.array(0.0)
+
+
+class _RandomLoss(LossTerm):
+    def __call__(self, sequence, output, *, key):
+        del sequence
+        loss_random = jax.random.uniform(key)
+        return output + loss_random, {
+            "model_random": output,
+            "loss_random": loss_random,
+        }
+
+
+def test_multisample_uses_distinct_model_and_loss_keys(monkeypatch):
+    import mosaic.losses.opendde as opendde_loss
+
+    monkeypatch.setattr(
+        opendde_loss,
+        "set_binder_sequence",
+        lambda sequence, features, key: None,
+    )
+
+    def fake_forward(model, feat, s_inputs, s, z, key, **kwargs):
+        del model, feat, s_inputs, s, z, kwargs
+        return jax.random.uniform(key)
+
+    monkeypatch.setattr(opendde_loss, "opendde_forward_from_trunk", fake_forward)
+    num_samples = 3
+    loss = MultiSampleOpenDDELoss(
+        model=_FakeModel(),
+        features=None,
+        loss=_RandomLoss(),
+        dense_atom_to_atom37=jnp.zeros((32, 15), dtype=jnp.int32),
+        num_samples=num_samples,
+    )
+    key = jax.random.key(5)
+
+    value, auxiliary = eqx.filter_jit(loss)(jnp.zeros((2, 20)), key=key)
+
+    samples_key, _ = jax.random.split(key)
+    sample_keys = jax.random.split(samples_key, num_samples)
+    split_keys = jax.vmap(jax.random.split)(sample_keys)
+    model_values = jax.vmap(jax.random.uniform)(split_keys[:, 0])
+    loss_values = jax.vmap(jax.random.uniform)(split_keys[:, 1])
+    totals = model_values + loss_values
+    order = np.argsort(np.asarray(totals))
+
+    assert np.isclose(value, totals.mean())
+    assert np.allclose(np.asarray(auxiliary["model_random"]), model_values[order])
+    assert np.allclose(np.asarray(auxiliary["loss_random"]), loss_values[order])
+    assert not np.allclose(model_values, loss_values)
+
+
+@pytest.mark.slow
+@pytest.mark.opendde_smoke
+def test_refreshed_atom_metadata_matches_native_featurization():
+    import mosaic.models.opendde as adapter
+
+    target = TargetChain("ACD", use_msa=False)
+    placeholder, _ = adapter._featurize(
+        [TargetChain("W" * len(TOKENS), use_msa=False), target]
+    )
+    native, _ = adapter._featurize([TargetChain(TOKENS, use_msa=False), target])
+    binder_length, binder_atom_alloc = adapter._binder_extents(placeholder)
+    design = OpenDDEDesignFeatures(
+        features=placeholder,
+        atom_templates=adapter._get_atom_templates(),
+        binder_length=binder_length,
+        binder_atom_alloc=binder_atom_alloc,
+    )
+    pssm = jax.nn.one_hot(jnp.arange(20), 20)
+
+    refreshed = eqx.filter_jit(set_binder_sequence)(pssm, design, jax.random.key(11))
+
+    refreshed_mask = np.asarray(refreshed.ref_mask) > 0.5
+    native_mask = np.asarray(native.ref_mask) > 0.5
+    assert refreshed_mask.sum() == native_mask.sum()
+    for field in (
+        "ref_element",
+        "ref_charge",
+        "ref_atom_name_chars",
+        "atom_to_token_idx",
+        "atom_to_tokatom_idx",
+        "distogram_rep_atom_mask",
+        "pae_rep_atom_mask",
+    ):
+        refreshed_value = np.asarray(getattr(refreshed, field))[refreshed_mask]
+        native_value = np.asarray(getattr(native, field))[native_mask]
+        assert np.array_equal(refreshed_value, native_value), field
+
+    assert np.array_equal(
+        np.asarray(refreshed.frame_atom_index),
+        np.asarray(native.frame_atom_index),
+    )
+    for token in range(len(TOKENS)):
+        refreshed_pos = np.asarray(refreshed.ref_pos)[
+            refreshed_mask & (np.asarray(refreshed.atom_to_token_idx) == token)
+        ]
+        native_pos = np.asarray(native.ref_pos)[
+            native_mask & (np.asarray(native.atom_to_token_idx) == token)
+        ]
+        refreshed_dist = np.linalg.norm(
+            refreshed_pos[:, None] - refreshed_pos[None, :], axis=-1
+        )
+        native_dist = np.linalg.norm(native_pos[:, None] - native_pos[None, :], axis=-1)
+        assert np.allclose(refreshed_dist, native_dist, atol=1e-4), TOKENS[token]

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,0 +1,36 @@
+import jax.numpy as jnp
+
+from mosaic.losses.structure_prediction import reduce_samples
+from mosaic.optimizers import _ranking_leaf
+
+
+def test_ranking_leaf_found_as_bare_scalar():
+    aux = {"structure": {"ranking_loss": jnp.array(0.5), "iptm": jnp.array(-0.5)}}
+    assert _ranking_leaf(aux, "ranking_loss") == 0.5
+
+
+def test_ranking_leaf_found_through_list_wrapping():
+    # reduce_samples wraps per-sample scalar metrics in a loss-sorted list, which
+    # a terminal-key match would miss. Matching anywhere in the path still finds it.
+    aux = {"structure": {"ranking_loss": [jnp.array(0.5)]}}
+    assert _ranking_leaf(aux, "ranking_loss") == 0.5
+
+
+def test_ranking_leaf_multisample_returns_best_sample():
+    # Sorted ascending by loss, so index 0 is the best sample.
+    aux = {"ranking_loss": [jnp.array(0.1), jnp.array(0.7), jnp.array(0.9)]}
+    assert _ranking_leaf(aux, "ranking_loss") == 0.1
+
+
+def test_ranking_leaf_absent_returns_none():
+    aux = {"structure": {"iptm": jnp.array(-0.5)}}
+    assert _ranking_leaf(aux, "ranking_loss") is None
+
+
+def test_ranking_leaf_resolves_through_reduce_samples_output():
+    # End-to-end with the real reduce_samples: a per-sample ranking_loss metric
+    # survives the list wrapping and resolves to the best (lowest-loss) sample.
+    values = jnp.array([0.7, 0.1, 0.9])  # sample 1 is best
+    auxiliary = {"ranking_loss": jnp.array([0.7, 0.1, 0.9])}
+    _, aux = reduce_samples(values, auxiliary, jnp.min, num_samples=3)
+    assert _ranking_leaf(aux, "ranking_loss") == 0.1

--- a/tests/test_promera.py
+++ b/tests/test_promera.py
@@ -1,0 +1,36 @@
+import jax
+import numpy as np
+
+from mosaic.structure_prediction import PolymerType, TargetChain
+
+
+def test_structure_writer_repacks_binder_and_preserves_rna():
+    from jpromera.features import featurize
+
+    from mosaic.models.promera import _schema, _StructureWriter
+
+    chains = [
+        TargetChain("XX", use_msa=False),
+        TargetChain("ACG", polymer_type=PolymerType.RNA, use_msa=False),
+    ]
+    schema = _schema(chains)
+    _features, placeholder_structure = featurize(schema, build_msa=False)
+    writer = _StructureWriter(placeholder_structure, schema)
+
+    designed_schema = {chain_id: dict(chain) for chain_id, chain in schema.items()}
+    designed_schema["A"]["sequence"] = "AG"
+    designed_features, _designed_structure = featurize(
+        designed_schema,
+        build_msa=False,
+    )
+    pssm = jax.nn.one_hot(np.asarray([0, 7]), 20)
+    structure = writer(
+        np.asarray(designed_features.ref_pos[0]),
+        binder_pssm=pssm,
+    )
+
+    assert [chain.name for chain in structure[0]] == ["A", "B"]
+    assert [[residue.name for residue in chain] for chain in structure[0]] == [
+        ["ALA", "GLY"],
+        ["A", "C", "G"],
+    ]

--- a/tests/test_structure_prediction.py
+++ b/tests/test_structure_prediction.py
@@ -1,0 +1,28 @@
+import jax
+import jax.numpy as jnp
+
+from mosaic.losses.structure_prediction import StructureModelOutput
+
+
+def test_to_structure_preserves_discontiguous_residue_indices():
+    n_residues = 4
+    atom37_mask = jnp.zeros((n_residues, 37)).at[:, 1].set(1)
+    output = StructureModelOutput(
+        distogram_logits=jnp.zeros((n_residues, n_residues, 1)),
+        distogram_bins=jnp.zeros(1),
+        plddt=jnp.ones(n_residues),
+        pae=jnp.zeros((n_residues, n_residues)),
+        pae_logits=jnp.zeros((n_residues, n_residues, 1)),
+        pae_bins=jnp.zeros(1),
+        structure_coordinates=jnp.zeros((n_residues, 37, 3)),
+        backbone_coordinates=jnp.zeros((n_residues, 4, 3)),
+        full_sequence=jax.nn.one_hot(jnp.zeros(n_residues, dtype=jnp.int32), 20),
+        asym_id=jnp.zeros(n_residues, dtype=jnp.int32),
+        residue_idx=jnp.array([4, 5, 10, 11]),
+        atom37_coords=jnp.zeros((n_residues, 37, 3)),
+        atom37_mask=atom37_mask,
+    )
+
+    structure = output.to_structure()
+
+    assert [residue.seqid.num for residue in structure[0][0]] == [4, 5, 10, 11]


### PR DESCRIPTION
Adds test coverage for the model wrappers, centralizes cache-path resolution in `cache.py`, and factors the shared multi-sample sort/reduce into `reduce_samples`. Unpins jopendde/opendde.