### PR TITLE
Add cyclic (head-to-tail) binder design support for AF2

### DIFF
--- a/src/mosaic/alphafold/model/modules_multimer.py
+++ b/src/mosaic/alphafold/model/modules_multimer.py
@@ -249,7 +249,10 @@ class EmbeddingsAndEvoformer(hk.Module):
         pos = batch["residue_index"]
         asym_id = batch["asym_id"]
         asym_id_same = jnp.equal(asym_id[:, None], asym_id[None, :])
-        offset = pos[:, None] - pos[None, :]
+        if "offset" in batch:
+            offset = batch["offset"]
+        else:
+            offset = pos[:, None] - pos[None, :]
         dtype = jnp.bfloat16 if gc.bfloat16 else jnp.float32
 
         clipped_offset = jnp.clip(

--- a/src/mosaic/geometry.py
+++ b/src/mosaic/geometry.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def cyclic_offset_matrix(length: int, offset_type: int = 2) -> np.ndarray:
+    """Wraparound sequence-separation matrix for a head-to-tail cyclic chain.
+
+    Port of ColabDesign's ``cyclic_offset`` (af_cyc_design.ipynb), as productionized
+    in grasp's ``utils/cyclic_offset.py``. For each residue pair (i, j), computes the
+    shortest signed separation around the ring instead of the linear ``i - j``.
+
+    offset_type:
+      1: unsigned cyclic distance (min(|i-j|, length-|i-j|)).
+      2: cyclic distance, re-signed to match the linear offset's sign, but only
+         overriding the linear distance where the cyclic path is shorter.
+      3: like 2, but pairs with cyclic distance > 2 are saturated to a large
+         constant (biases losses away from long-range pairs).
+    """
+    if offset_type not in (1, 2, 3):
+        raise ValueError(f"Invalid offset_type: {offset_type}. Must be 1, 2, or 3.")
+
+    i = np.arange(length)
+    ij = np.stack([i, i + length], -1)
+    offset = i[:, None] - i[None, :]
+    c_offset = np.abs(ij[:, None, :, None] - ij[None, :, None, :]).min((2, 3))
+
+    if offset_type >= 2:
+        a = c_offset < np.abs(offset)
+        c_offset[a] = -c_offset[a]
+    if offset_type == 3:
+        idx = np.abs(c_offset) > 2
+        c_offset[idx] = (32 * c_offset[idx]) / np.abs(c_offset[idx])
+
+    return c_offset * np.sign(offset)

--- a/src/mosaic/losses/structure_prediction.py
+++ b/src/mosaic/losses/structure_prediction.py
@@ -10,6 +10,7 @@ import numpy as np
 import gemmi
 
 from ..common import LossTerm
+from ..geometry import cyclic_offset_matrix
 
 # 64 bins, 0.0–32.0 Å, shared across all model backends
 PAE_BINS = np.arange(start=0.25, stop=32.0, step=0.5)
@@ -241,6 +242,7 @@ class WithinBinderContact(LossTerm):
     max_contact_distance: float = 14.0
     min_sequence_separation: int = 8
     num_contacts_per_residue: int = 25
+    cyclic: bool = False
 
     def __call__(
         self,
@@ -255,10 +257,13 @@ class WithinBinderContact(LossTerm):
             bins=output.distogram_bins,
         )
         # only count binder-binder contacts with sequence sep > min_sequence_separation
-        within_binder_mask = (
-            jnp.abs(jnp.arange(binder_len)[:, None] - jnp.arange(binder_len)[None, :])
-            > self.min_sequence_separation
-        )
+        if self.cyclic:
+            seqsep = jnp.abs(jnp.array(cyclic_offset_matrix(binder_len, offset_type=1)))
+        else:
+            seqsep = jnp.abs(
+                jnp.arange(binder_len)[:, None] - jnp.arange(binder_len)[None, :]
+            )
+        within_binder_mask = seqsep > self.min_sequence_separation
         # for each position in binder find positions most likely to make contact
 
         # JAX/XLO has a bizarre issue with top_k when used inside vmap _only_ when used on multiple GPUs.
@@ -343,6 +348,7 @@ class BinderTargetContact(LossTerm):
 class HelixLoss(LossTerm):
     max_distance: float = 6.0
     target_value: float = -2.0
+    cyclic: bool = False
 
     def __call__(
         self,
@@ -356,7 +362,15 @@ class HelixLoss(LossTerm):
             self.max_distance,
             bins=output.distogram_bins,
         )
-        value = jnp.diagonal(log_contact, 3).mean()
+        if self.cyclic:
+            # i, i+3 pairs, but wrapped around the N/C junction instead of a
+            # fixed linear diagonal (which would miss/misrepresent pairs near
+            # the termini for a head-to-tail cyclic binder).
+            offset = jnp.abs(jnp.array(cyclic_offset_matrix(binder_len, offset_type=1)))
+            mask = offset == 3
+            value = (jnp.where(mask, log_contact, 0.0).sum()) / (mask.sum() + 1e-8)
+        else:
+            value = jnp.diagonal(log_contact, 3).mean()
 
         loss = jax.nn.elu(self.target_value - value)
 

--- a/src/mosaic/models/af2.py
+++ b/src/mosaic/models/af2.py
@@ -1,4 +1,5 @@
 from mosaic.cache import resolve_cache
+from mosaic.geometry import cyclic_offset_matrix
 from mosaic.structure_prediction import (
     StructurePredictionModel,
     TargetChain,
@@ -306,7 +307,9 @@ def af2_atom_positions(chain: gemmi.Chain) -> tuple[np.ndarray, np.ndarray]:
     return all_positions[None], all_positions_mask[None]
 
 
-def make_af_features(chains: list[TargetChain]) -> dict[str, jax.Array]:
+def make_af_features(
+    chains: list[TargetChain], cyclic_binder_length: int | None = None
+) -> dict[str, jax.Array]:
     assert all(not c.use_msa for c in chains), "AF2 interface does not support MSAs"
 
     # check for missing residues in template chains
@@ -345,6 +348,12 @@ def make_af_features(chains: list[TargetChain]) -> dict[str, jax.Array]:
         "sym_id": chain_index,
         "entity_id": chain_index,
     }
+
+    if cyclic_binder_length is not None:
+        offset = index_within_chain[:, None] - index_within_chain[None, :]
+        binder_offset = cyclic_offset_matrix(cyclic_binder_length)
+        offset[:cyclic_binder_length, :cyclic_binder_length] = binder_offset
+        raw_features["offset"] = offset
 
     template_features = [
         af2_atom_positions(tc.template_chain)
@@ -386,16 +395,17 @@ class AlphaFold2(StructurePredictionModel):
         self.stacked_parameters = stacked_params
         self.multimer = multimer
 
-    def target_only_features(self, chains: list[TargetChain]):
+    def target_only_features(self, chains: list[TargetChain], cyclic_binder_length: int | None = None):
         for c in chains:
             assert c.polymer_type == "PROTEIN", "AF2 only supports protein chains"
             assert not c.use_msa, "AF2 interface does not support MSA yet"
 
-        return make_af_features(chains=chains), None
+        return make_af_features(chains=chains, cyclic_binder_length=cyclic_binder_length), None
 
-    def binder_features(self, binder_length, chains: list[TargetChain]):
+    def binder_features(self, binder_length, chains: list[TargetChain], cyclic: bool = False):
         features, _ = self.target_only_features(
-            [TargetChain(sequence="G" * binder_length, use_msa=False)] + chains
+            [TargetChain(sequence="G" * binder_length, use_msa=False)] + chains,
+            cyclic_binder_length=binder_length if cyclic else None,
         )
         return features, None
 

--- a/tests/test_cyclic_loss.py
+++ b/tests/test_cyclic_loss.py
@@ -1,0 +1,106 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from mosaic.geometry import cyclic_offset_matrix
+from mosaic.losses.structure_prediction import (
+    HelixLoss,
+    WithinBinderContact,
+    StructureModelOutput,
+)
+
+
+def _random_output(binder_len: int, key) -> StructureModelOutput:
+    n = binder_len
+    bins = jnp.linspace(2.0, 20.0, 8)
+    distogram_logits = jax.random.normal(key, (n, n, len(bins)))
+    return StructureModelOutput(
+        distogram_logits=distogram_logits,
+        distogram_bins=bins,
+        plddt=jnp.ones(n),
+        pae=jnp.zeros((n, n)),
+        pae_logits=jnp.zeros((n, n, 1)),
+        pae_bins=jnp.zeros(1),
+        structure_coordinates=jnp.zeros((n, 37, 3)),
+        backbone_coordinates=jnp.zeros((n, 4, 3)),
+        full_sequence=jax.nn.one_hot(jnp.zeros(n, dtype=jnp.int32), 20),
+        asym_id=jnp.zeros(n, dtype=jnp.int32),
+        residue_idx=jnp.arange(n),
+        atom37_coords=jnp.zeros((n, 37, 3)),
+        atom37_mask=jnp.zeros((n, 37)),
+    )
+
+
+def test_within_binder_contact_cyclic_false_is_regression_safe():
+    binder_len = 10
+    key = jax.random.PRNGKey(0)
+    output = _random_output(binder_len, key)
+    sequence = jnp.zeros((binder_len, 20))
+
+    loss_default = WithinBinderContact(min_sequence_separation=5)
+    loss_explicit_linear = WithinBinderContact(min_sequence_separation=5, cyclic=False)
+
+    value_default, aux_default = loss_default(sequence, output, key=None)
+    value_explicit, aux_explicit = loss_explicit_linear(sequence, output, key=None)
+
+    assert value_default == value_explicit
+    assert aux_default == aux_explicit
+
+
+def test_within_binder_contact_cyclic_true_differs_from_linear():
+    binder_len = 10
+    key = jax.random.PRNGKey(1)
+    output = _random_output(binder_len, key)
+    sequence = jnp.zeros((binder_len, 20))
+
+    linear_loss = WithinBinderContact(min_sequence_separation=5, cyclic=False)
+    cyclic_loss = WithinBinderContact(min_sequence_separation=5, cyclic=True)
+
+    linear_value, _ = linear_loss(sequence, output, key=None)
+    cyclic_value, _ = cyclic_loss(sequence, output, key=None)
+
+    # with min_sequence_separation=5 and binder_len=10, the wraparound pair
+    # (0, 9) has cyclic distance 1 (excluded) but linear distance 9 (included),
+    # so the two masks genuinely differ and should produce different losses.
+    assert linear_value != cyclic_value
+
+
+def test_helix_loss_cyclic_false_is_regression_safe():
+    binder_len = 12
+    key = jax.random.PRNGKey(2)
+    output = _random_output(binder_len, key)
+    sequence = jnp.zeros((binder_len, 20))
+
+    loss_default = HelixLoss()
+    loss_explicit_linear = HelixLoss(cyclic=False)
+
+    value_default, aux_default = loss_default(sequence, output, key=None)
+    value_explicit, aux_explicit = loss_explicit_linear(sequence, output, key=None)
+
+    assert value_default == value_explicit
+    assert aux_default == aux_explicit
+
+
+def test_helix_loss_cyclic_true_includes_wraparound_i_plus_3_pairs():
+    binder_len = 12
+    key = jax.random.PRNGKey(3)
+    output = _random_output(binder_len, key)
+    sequence = jnp.zeros((binder_len, 20))
+
+    linear_loss = HelixLoss(cyclic=False)
+    cyclic_loss = HelixLoss(cyclic=True)
+
+    linear_value, _ = linear_loss(sequence, output, key=None)
+    cyclic_value, _ = cyclic_loss(sequence, output, key=None)
+
+    # jnp.diagonal(log_contact, 3) only ever sees binder_len - 3 pairs and never
+    # the wraparound i,i+3 pairs near the C-terminus, so cyclic mode (which
+    # includes those wraparound pairs) should generally produce a different
+    # value for a random (non-degenerate) contact map.
+    assert linear_value != cyclic_value
+
+    # sanity: the cyclic mask should select exactly 2*binder_len pairs (each
+    # residue has both a forward and backward "distance-3" neighbor around
+    # the ring, i.e. (i, i+3) and (i, i-3)).
+    offset = np.abs(cyclic_offset_matrix(binder_len, offset_type=1))
+    assert (offset == 3).sum() == 2 * binder_len

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+
+from mosaic.geometry import cyclic_offset_matrix
+
+
+def test_invalid_offset_type_raises():
+    with pytest.raises(ValueError):
+        cyclic_offset_matrix(4, offset_type=0)
+
+
+def test_offset_type_1_wraparound_distance_is_antisymmetric_in_magnitude():
+    m = cyclic_offset_matrix(4, offset_type=1)
+    # signed like the linear offset, but magnitude is the wraparound distance:
+    # |m| is symmetric (a proper distance), even though m itself is antisymmetric.
+    assert np.array_equal(np.abs(m), np.abs(m).T)
+    # residue 0 and residue 3 are adjacent on the ring (distance 1), not 3.
+    assert abs(m[0, 3]) == 1
+    assert abs(m[0, 2]) == 2
+    # interior pairs match the ordinary linear distance.
+    assert abs(m[1, 2]) == 1
+
+
+def test_offset_type_2_matches_linear_offset_away_from_wraparound():
+    length = 6
+    m = cyclic_offset_matrix(length, offset_type=2)
+    i = np.arange(length)
+    linear_offset = i[:, None] - i[None, :]
+    # for interior pairs the cyclic path isn't shorter, so type 2 == linear offset.
+    assert m[1, 2] == linear_offset[1, 2]
+    assert m[2, 3] == linear_offset[2, 3]
+
+
+def test_offset_type_2_wraparound_pair_is_close():
+    length = 6
+    m = cyclic_offset_matrix(length, offset_type=2)
+    # residue 0 and residue length-1 are wraparound-adjacent: cyclic distance 1,
+    # far shorter than the linear distance (length-1), so it should be re-signed
+    # to a small magnitude rather than the large linear offset.
+    assert abs(m[0, length - 1]) == 1
+
+
+def test_offset_type_3_saturates_long_range_pairs():
+    length = 8
+    m = cyclic_offset_matrix(length, offset_type=3)
+    # a pair whose cyclic distance exceeds 2 should be saturated to +/-32.
+    far_pairs_mask = np.abs(cyclic_offset_matrix(length, offset_type=1)) > 2
+    assert np.all(np.abs(m[far_pairs_mask]) == 32)
+
+
+def test_offset_type_1_reduces_to_linear_for_small_length_boundary():
+    # for length=4, the maximum possible unsigned cyclic distance is 2 (L/2).
+    m = cyclic_offset_matrix(4, offset_type=1)
+    assert m.max() == 2


### PR DESCRIPTION
Ports ColabDesign's cyclic-offset mechanism: a wraparound sequence-separation matrix is injected as an optional "offset" feature, consumed by AF2's relpos encoding (mirroring ColabDesign's own vendored override) and by the two loss terms that bake in a linear-separation assumption (WithinBinderContact, HelixLoss).

Default behavior (cyclic=False) is unchanged; cyclic=True opts a binder chain into circular seqsep/adjacency instead of linear.