### PR TITLE
Add precomputed MSA feature extraction for AlphaFold2

### DIFF
--- a/src/mosaic/models/af2.py
+++ b/src/mosaic/models/af2.py
@@ -9,6 +9,12 @@ from mosaic.common import tokenize
 from mosaic.alphafold.common import residue_constants, protein
 from mosaic.alphafold.model import config, data, modules_multimer, modules, state
 from mosaic.losses.confidence_metrics import confidence_metrics, _calculate_bin_centers
+from mosaic.models.af2_msa import (
+    create_features_from_raw_msa,
+    load_a3m_file,
+    merge_unpaired_msas,
+    raw_msa_from_sequence,
+)
 
 
 from jaxtyping import Array, Float, PyTree, Bool
@@ -18,7 +24,6 @@ import jax.numpy as jnp
 import gemmi
 import numpy as np
 
-from dataclasses import dataclass
 from jax import tree
 from tempfile import NamedTemporaryFile
 from pathlib import Path
@@ -64,7 +69,11 @@ class AFOutput(eqx.Module):
     recycling_state: state.AlphaFoldState
 
 
-def load_af2(data_dir: str | Path | None = None, multimer=True):
+def load_af2(
+    data_dir: str | Path | None = None,
+    multimer=True,
+    max_extra_msa: int = 2048,
+):
     data_dir = resolve_cache(data_dir, "alphafold2")
 
     if not (data_dir / "params").exists():
@@ -102,17 +111,14 @@ def load_af2(data_dir: str | Path | None = None, multimer=True):
     stacked_model_params = tree.map(lambda *v: np.stack(v), *model_params)
 
     cfg = config.model_config("model_1_multimer_v3" if multimer else "model_1_ptm")
-    cfg.max_msa_clusters = 1
-    cfg.max_extra_msa = 1
-    cfg.masked_msa_replace_fraction = 0
-    cfg.subbatch_size = None
     cfg.model.num_ensemble_eval = 1
     cfg.model.global_config.subbatch_size = None
     cfg.model.global_config.eval_dropout = False
     cfg.model.global_config.deterministic = True
     cfg.model.global_config.use_remat = True
-    cfg.model.num_extra_msa = 1
     cfg.model.resample_msa_in_recycling = False
+    if multimer:
+        cfg.model.embeddings_and_evoformer.num_extra_msa = max_extra_msa
 
     #haiku transform forward function
     init_model = modules_multimer.AlphaFold if multimer else modules.AlphaFold
@@ -218,8 +224,6 @@ def set_binder_sequence(PSSM, features: dict, multimer: bool=True):
         )
     )
 
-    L = features["aatype"].shape[0]
-
     # Do not touch this. One-hot seems necessary for multimer models to work properly.
     hard_pssm = (
         jax.lax.stop_gradient(
@@ -227,13 +231,15 @@ def set_binder_sequence(PSSM, features: dict, multimer: bool=True):
         )
         + soft_sequence
     )
-    msa_feat = (
-        jnp.zeros((1, L, 49))
-        .at[..., 0:21]
-        .set(soft_sequence)
-        .at[..., 25:46]
-        .set(hard_pssm)
-    )
+    # Preserve the fixed target MSA. Only the query row's binder columns are
+    # differentiable; homolog rows already contain gaps in those columns.
+    msa_feat = jnp.asarray(features["msa_feat"])
+    binder_soft_msa = jnp.pad(PSSM, [[0, 0], [0, 3]])
+    binder_hard_msa = jnp.pad(hard_pssm[:binder_length], [[0, 0], [0, 2]])
+    msa_feat = msa_feat.at[0, :binder_length, 0:23].set(binder_soft_msa)
+    msa_feat = msa_feat.at[0, :binder_length, 23:25].set(0)
+    msa_feat = msa_feat.at[0, :binder_length, 25:48].set(binder_hard_msa)
+    msa_feat = msa_feat.at[0, :binder_length, 48].set(0)
 
     out = features | {
         "msa_feat": msa_feat,
@@ -306,8 +312,14 @@ def af2_atom_positions(chain: gemmi.Chain) -> tuple[np.ndarray, np.ndarray]:
     return all_positions[None], all_positions_mask[None]
 
 
-def make_af_features(chains: list[TargetChain]) -> dict[str, jax.Array]:
-    assert all(not c.use_msa for c in chains), "AF2 interface does not support MSAs"
+def make_af_features(
+    chains: list[TargetChain],
+    *,
+    multimer: bool = True,
+    max_msa_clusters: int = 512,
+    max_extra_msa: int = 2048,
+    msa_seed: int = 0,
+) -> dict[str, jax.Array]:
 
     # check for missing residues in template chains
     for c in chains:
@@ -328,19 +340,33 @@ def make_af_features(chains: list[TargetChain]) -> dict[str, jax.Array]:
         ]
     )
 
+    chain_msas = []
+    for chain in chains:
+        if chain.use_msa:
+            if chain.msa_path is None:
+                raise ValueError(
+                    "AF2 MSA requested but TargetChain.msa_path is not set for "
+                    f"sequence {chain.sequence!r}"
+                )
+            chain_msas.append(
+                load_a3m_file(chain.msa_path, sequence=chain.sequence)
+            )
+        else:
+            chain_msas.append(raw_msa_from_sequence(chain.sequence))
+
+    msa_features = create_features_from_raw_msa(
+        merge_unpaired_msas(chain_msas),
+        max_msa_clusters=max_msa_clusters,
+        max_extra_msa=max_extra_msa,
+        seed=msa_seed,
+    ).as_dict(multimer=multimer)
+
     raw_features = {
         "target_feat": np.zeros((L, 20)),
-        "msa_feat": np.zeros((1, L, 49)),
         "aatype": np.concatenate([tokenize(c.sequence) for c in chains]),
         "all_atom_positions": np.zeros((L, 37, 3)),
         "seq_mask": np.ones(L),
-        "msa_mask": np.ones((1, L)),
         "residue_index": index_within_chain,
-        "extra_deletion_value": np.zeros((1, L)),
-        "extra_has_deletion": np.zeros((1, L)),
-        "extra_msa": np.zeros((1, L), int),
-        "extra_msa_mask": np.zeros((1, L)),
-        "extra_msa_row_mask": np.zeros(1),
         "asym_id": chain_index,
         "sym_id": chain_index,
         "entity_id": chain_index,
@@ -368,7 +394,7 @@ def make_af_features(chains: list[TargetChain]) -> dict[str, jax.Array]:
         ]
     )
 
-    return raw_features | {
+    return raw_features | msa_features | {
         "template_aatype": template_aatype[None],
         "template_all_atom_mask": template_mask,
         "template_all_atom_positions": template_positions,
@@ -379,19 +405,41 @@ class AlphaFold2(StructurePredictionModel):
     af2_forward: callable
     stacked_parameters: PyTree
     multimer: bool
+    max_msa_clusters: int
+    max_extra_msa: int
+    msa_seed: int
 
-    def __init__(self, data_dir: str | Path | None = None, multimer=True):
-        (forward_function, stacked_params) = load_af2(data_dir=data_dir, multimer=multimer)
+    def __init__(
+        self,
+        data_dir: str | Path | None = None,
+        multimer=True,
+        max_msa_clusters: int = 512,
+        max_extra_msa: int = 2048,
+        msa_seed: int = 0,
+    ):
+        (forward_function, stacked_params) = load_af2(
+            data_dir=data_dir,
+            multimer=multimer,
+            max_extra_msa=max_extra_msa,
+        )
         self.af2_forward = forward_function
         self.stacked_parameters = stacked_params
         self.multimer = multimer
+        self.max_msa_clusters = max_msa_clusters
+        self.max_extra_msa = max_extra_msa
+        self.msa_seed = msa_seed
 
     def target_only_features(self, chains: list[TargetChain]):
         for c in chains:
             assert c.polymer_type == "PROTEIN", "AF2 only supports protein chains"
-            assert not c.use_msa, "AF2 interface does not support MSA yet"
 
-        return make_af_features(chains=chains), None
+        return make_af_features(
+            chains=chains,
+            multimer=self.multimer,
+            max_msa_clusters=self.max_msa_clusters,
+            max_extra_msa=self.max_extra_msa,
+            msa_seed=self.msa_seed,
+        ), None
 
     def binder_features(self, binder_length, chains: list[TargetChain]):
         features, _ = self.target_only_features(

--- a/src/mosaic/models/af2_msa.py
+++ b/src/mosaic/models/af2_msa.py
@@ -1,0 +1,315 @@
+"""Inference-only AlphaFold 2 MSA feature construction.
+
+This module deliberately stops at the tensors consumed by the vendored AF2
+model.  MSA search, target/template features, and differentiable binder
+sequence updates belong elsewhere in the Mosaic wrapper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from mosaic.alphafold.common import residue_constants
+from mosaic.alphafold.data import parsers
+
+
+_GAP_TOKEN = residue_constants.restype_num + 1
+_NUM_MSA_TOKENS = residue_constants.restype_num + 3
+
+
+@dataclass(frozen=True)
+class RawMSA:
+    """An aligned MSA before clustering.
+
+    Row zero is always the query. Tokens use AF2's internal residue ordering,
+    with X=20 and gap=21.
+    """
+
+    tokens: np.ndarray  # int32 [N, L]
+    deletion_matrix: np.ndarray  # float32 [N, L], raw insertion counts
+
+    def __post_init__(self) -> None:
+        if self.tokens.ndim != 2:
+            raise ValueError(f"MSA tokens must have rank 2, got {self.tokens.shape}")
+        if self.deletion_matrix.shape != self.tokens.shape:
+            raise ValueError(
+                "MSA tokens and deletion matrix must have the same shape, got "
+                f"{self.tokens.shape} and {self.deletion_matrix.shape}"
+            )
+        if self.tokens.shape[0] == 0:
+            raise ValueError("MSA must contain at least the query row")
+
+
+@dataclass(frozen=True)
+class AF2MSAFeatures:
+    """Post-clustering AF2 MSA features.
+
+    Raw extra-MSA deletion counts are retained here because this vendored
+    multimer implementation transforms them inside the model, whereas the
+    monomer implementation expects the transformed values as input.
+    """
+
+    msa_feat: np.ndarray  # float32 [N_cluster, L, 49]
+    msa_mask: np.ndarray  # float32 [N_cluster, L]
+    extra_msa: np.ndarray  # int32 [N_extra, L]
+    extra_deletion_matrix: np.ndarray  # float32 [N_extra, L]
+    extra_msa_mask: np.ndarray  # float32 [N_extra, L]
+
+    def as_dict(self, *, multimer: bool) -> dict[str, np.ndarray]:
+        deletion_matrix = self.extra_deletion_matrix.astype(np.float32)
+        deletion_value = (
+            deletion_matrix
+            if multimer
+            else _deletion_value(deletion_matrix)
+        )
+        return {
+            "msa_feat": self.msa_feat.astype(np.float32),
+            "msa_mask": self.msa_mask.astype(np.float32),
+            "msa_row_mask": np.any(self.msa_mask != 0, axis=-1).astype(np.float32),
+            "extra_msa": self.extra_msa.astype(np.int32),
+            "extra_deletion_value": deletion_value.astype(np.float32),
+            "extra_has_deletion": np.clip(
+                deletion_matrix, 0.0, 1.0
+            ).astype(np.float32),
+            "extra_msa_mask": self.extra_msa_mask.astype(np.float32),
+            "extra_msa_row_mask": np.any(
+                self.extra_msa_mask != 0, axis=-1
+            ).astype(np.float32),
+        }
+
+
+def _deletion_value(deletion_matrix: np.ndarray) -> np.ndarray:
+    return np.arctan(deletion_matrix / 3.0) * (2.0 / np.pi)
+
+
+def _encode_aligned_sequence(sequence: str) -> np.ndarray:
+    """Encode an aligned sequence using AF2's internal residue ordering."""
+
+    try:
+        hhblits_tokens = np.asarray(
+            [residue_constants.HHBLITS_AA_TO_ID[residue] for residue in sequence],
+            dtype=np.int32,
+        )
+    except KeyError as error:
+        raise ValueError(
+            f"Unsupported residue {error.args[0]!r} in aligned MSA sequence"
+        ) from error
+
+    return np.take(
+        np.asarray(
+            residue_constants.MAP_HHBLITS_AATYPE_TO_OUR_AATYPE,
+            dtype=np.int32,
+        ),
+        hhblits_tokens,
+    )
+
+
+def raw_msa_from_sequence(sequence: str) -> RawMSA:
+    """Construct a query-only MSA for a chain with ``use_msa=False``."""
+
+    if not sequence:
+        raise ValueError("Protein sequence must not be empty")
+    tokens = _encode_aligned_sequence(sequence)[None]
+    return RawMSA(
+        tokens=tokens,
+        deletion_matrix=np.zeros(tokens.shape, dtype=np.float32),
+    )
+
+
+def load_a3m_file(file_name: str | Path, *, sequence: str) -> RawMSA:
+    """Parse and validate an A3M whose first row is ``sequence``."""
+
+    path = Path(file_name).expanduser()
+    if not path.is_file():
+        raise FileNotFoundError(f"MSA not found: {path}")
+
+    parsed = parsers.parse_a3m(path.read_text())
+    if not parsed.sequences:
+        raise ValueError(f"MSA is empty: {path}")
+    if parsed.sequences[0] != sequence:
+        raise ValueError(
+            f"A3M query in {path} does not match the target sequence: "
+            f"{parsed.sequences[0]!r} != {sequence!r}"
+        )
+
+    unique_sequences: list[str] = []
+    unique_deletions: list[Sequence[int]] = []
+    seen_sequences: set[str] = set()
+    for aligned_sequence, deletion_row in zip(
+        parsed.sequences, parsed.deletion_matrix
+    ):
+        if len(aligned_sequence) != len(sequence):
+            raise ValueError(
+                f"Aligned row in {path} has length {len(aligned_sequence)}; "
+                f"expected {len(sequence)}"
+            )
+        if len(deletion_row) != len(sequence):
+            raise ValueError(
+                f"Deletion row in {path} has length {len(deletion_row)}; "
+                f"expected {len(sequence)}"
+            )
+        if aligned_sequence in seen_sequences:
+            continue
+        seen_sequences.add(aligned_sequence)
+        unique_sequences.append(aligned_sequence)
+        unique_deletions.append(deletion_row)
+
+    return RawMSA(
+        tokens=np.stack(
+            [_encode_aligned_sequence(row) for row in unique_sequences]
+        ).astype(np.int32),
+        deletion_matrix=np.asarray(unique_deletions, dtype=np.float32),
+    )
+
+
+def merge_unpaired_msas(msas: Sequence[RawMSA]) -> RawMSA:
+    """Merge per-chain MSAs into a full-complex, unpaired alignment.
+
+    Row zero is the concatenated query. Each non-query homolog occupies only
+    its chain's residue columns and is gap-padded across all other chains.
+    """
+
+    if not msas:
+        raise ValueError("At least one chain MSA is required")
+
+    lengths = [msa.tokens.shape[1] for msa in msas]
+    total_length = sum(lengths)
+    query = np.concatenate([msa.tokens[0] for msa in msas], axis=0)
+    token_rows = [query]
+    deletion_rows = [
+        np.concatenate([msa.deletion_matrix[0] for msa in msas], axis=0).astype(
+            np.float32
+        )
+    ]
+
+    offset = 0
+    for msa, length in zip(msas, lengths):
+        for tokens, deletion_matrix in zip(
+            msa.tokens[1:], msa.deletion_matrix[1:]
+        ):
+            merged_tokens = np.full(total_length, _GAP_TOKEN, dtype=np.int32)
+            merged_deletions = np.zeros(total_length, dtype=np.float32)
+            merged_tokens[offset : offset + length] = tokens
+            merged_deletions[offset : offset + length] = deletion_matrix
+            token_rows.append(merged_tokens)
+            deletion_rows.append(merged_deletions)
+        offset += length
+
+    return RawMSA(
+        tokens=np.stack(token_rows).astype(np.int32),
+        deletion_matrix=np.stack(deletion_rows).astype(np.float32),
+    )
+
+
+def create_features_from_raw_msa(
+    msa: RawMSA,
+    *,
+    max_msa_clusters: int = 512,
+    max_extra_msa: int = 2048,
+    seed: int = 0,
+) -> AF2MSAFeatures:
+    """Cluster a raw MSA and construct the tensors consumed by AF2."""
+
+    if max_msa_clusters < 1:
+        raise ValueError("max_msa_clusters must be at least 1")
+    if max_extra_msa < 1:
+        raise ValueError("max_extra_msa must be at least 1")
+
+    num_sequences, num_residues = msa.tokens.shape
+    rng = np.random.default_rng(seed)
+
+    non_query_indices = rng.permutation(np.arange(1, num_sequences))
+    index_order = np.concatenate(
+        [np.asarray([0], dtype=np.int64), non_query_indices]
+    )
+    num_clusters = min(max_msa_clusters, num_sequences)
+    cluster_indices = index_order[:num_clusters]
+    extra_indices = index_order[num_clusters:]
+
+    cluster_tokens = msa.tokens[cluster_indices]
+    cluster_deletions = msa.deletion_matrix[cluster_indices]
+    extra_tokens_all = msa.tokens[extra_indices]
+    extra_deletions_all = msa.deletion_matrix[extra_indices]
+
+    token_eye = np.eye(_NUM_MSA_TOKENS, dtype=np.float32)
+    cluster_one_hot = token_eye[cluster_tokens]
+    extra_one_hot_all = token_eye[extra_tokens_all]
+
+    cluster_profile_sum = cluster_one_hot.copy()
+    cluster_deletion_sum = cluster_deletions.copy()
+    cluster_counts = np.ones(num_clusters, dtype=np.float32)
+
+    if extra_tokens_all.shape[0]:
+        agreement_weights = np.concatenate(
+            [
+                np.ones(residue_constants.restype_num + 1, dtype=np.float32),
+                np.zeros(2, dtype=np.float32),
+            ]
+        )
+        agreement = np.einsum(
+            "xra,kra,a->xk",
+            extra_one_hot_all,
+            cluster_one_hot,
+            agreement_weights,
+            optimize=True,
+        )
+        assignment = np.argmax(agreement, axis=-1)
+        np.add.at(cluster_profile_sum, assignment, extra_one_hot_all)
+        np.add.at(cluster_deletion_sum, assignment, extra_deletions_all)
+        np.add.at(cluster_counts, assignment, 1.0)
+
+    cluster_profile = cluster_profile_sum / cluster_counts[:, None, None]
+    cluster_deletion_mean = cluster_deletion_sum / cluster_counts[:, None]
+
+    msa_feat = np.concatenate(
+        [
+            cluster_one_hot,
+            np.clip(cluster_deletions, 0.0, 1.0)[..., None],
+            _deletion_value(cluster_deletions)[..., None],
+            cluster_profile,
+            _deletion_value(cluster_deletion_mean)[..., None],
+        ],
+        axis=-1,
+    ).astype(np.float32)
+    msa_mask = np.ones((num_clusters, num_residues), dtype=np.float32)
+
+    if extra_tokens_all.shape[0]:
+        crop_order = rng.permutation(extra_tokens_all.shape[0])[:max_extra_msa]
+        extra_msa = extra_tokens_all[crop_order].astype(np.int32)
+        extra_deletion_matrix = extra_deletions_all[crop_order].astype(np.float32)
+        extra_msa_mask = np.ones(extra_msa.shape, dtype=np.float32)
+    else:
+        # The extra-MSA stack is not robust to a zero-sized sequence dimension.
+        extra_msa = np.zeros((1, num_residues), dtype=np.int32)
+        extra_deletion_matrix = np.zeros((1, num_residues), dtype=np.float32)
+        extra_msa_mask = np.zeros((1, num_residues), dtype=np.float32)
+
+    return AF2MSAFeatures(
+        msa_feat=msa_feat,
+        msa_mask=msa_mask,
+        extra_msa=extra_msa,
+        extra_deletion_matrix=extra_deletion_matrix,
+        extra_msa_mask=extra_msa_mask,
+    )
+
+
+def create_features_from_a3m(
+    file_name: str | Path,
+    *,
+    sequence: str,
+    max_msa_clusters: int = 512,
+    max_extra_msa: int = 2048,
+    seed: int = 0,
+) -> AF2MSAFeatures:
+    """Convenience wrapper for the common single-chain A3M case."""
+
+    return create_features_from_raw_msa(
+        load_a3m_file(file_name, sequence=sequence),
+        max_msa_clusters=max_msa_clusters,
+        max_extra_msa=max_extra_msa,
+        seed=seed,
+    )

--- a/src/mosaic/models/af2_msa.py
+++ b/src/mosaic/models/af2_msa.py
@@ -3,6 +3,10 @@
 This module deliberately stops at the tensors consumed by the vendored AF2
 model.  MSA search, target/template features, and differentiable binder
 sequence updates belong elsewhere in the Mosaic wrapper.
+
+The algorithm for the feature extraction has been implemented following the original paper (https://www.nature.com/articles/s41586-021-03819-2). 
+
+Importantly, this does not compute the raw MSA but it expects one to compute the features from.
 """
 
 from __future__ import annotations

--- a/src/mosaic/structure_prediction.py
+++ b/src/mosaic/structure_prediction.py
@@ -26,6 +26,9 @@ class TargetChain:
     polymer_type: str = PolymerType.PROTEIN
     use_msa: bool = True
     template_chain: gemmi.Chain | None = None
+    # Optional precomputed A3M. MSA-capable backends may require this when
+    # ``use_msa`` is true rather than performing a network search implicitly.
+    msa_path: str | None = None
 
 
 class StructurePrediction(eqx.Module):
@@ -92,5 +95,4 @@ class StructurePredictionModel(eqx.Module):
     @abstractmethod
     def build_loss(self, *, loss: LossTerm | LinearCombination, features: PyTree,  recycling_steps: int = 1, sampling_steps: int | None = None,) -> LossTerm:
         pass
-
 

--- a/tests/test_af2_msa.py
+++ b/tests/test_af2_msa.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+import numpy as np
+
+from mosaic.models.af2 import make_af_features
+from mosaic.models.af2_msa import (
+    create_features_from_a3m,
+    create_features_from_raw_msa,
+    load_a3m_file,
+    merge_unpaired_msas,
+    raw_msa_from_sequence,
+)
+from mosaic.structure_prediction import TargetChain
+
+
+def test_query_only_fasta_is_valid_a3m(tmp_path: Path):
+    path = tmp_path / "query.fasta"
+    path.write_text(">query\nACD\n")
+
+    features = create_features_from_a3m(path, sequence="ACD")
+    feature_dict = features.as_dict(multimer=True)
+
+    assert feature_dict["msa_feat"].shape == (1, 3, 49)
+    assert feature_dict["msa_mask"].shape == (1, 3)
+    assert feature_dict["extra_msa"].shape == (1, 3)
+    assert feature_dict["extra_msa"].dtype == np.int32
+    assert not feature_dict["extra_msa_mask"].any()
+    # Query-only msa_feat contains one residue and one profile one-hot per site.
+    assert feature_dict["msa_feat"].sum() == 6
+
+
+def test_a3m_insertions_deduplication_and_clustering(tmp_path: Path):
+    path = tmp_path / "alignment.a3m"
+    path.write_text(
+        ">query\nACD\n"
+        ">insertion\nAcCE\n"
+        ">gap\nA-D\n"
+        ">duplicate\nA-D\n"
+    )
+
+    raw_msa = load_a3m_file(path, sequence="ACD")
+    assert raw_msa.tokens.shape == (3, 3)
+    assert raw_msa.deletion_matrix.max() == 1
+
+    features = create_features_from_raw_msa(
+        raw_msa, max_msa_clusters=2, max_extra_msa=8, seed=0
+    )
+    assert features.msa_feat.shape == (2, 3, 49)
+    assert features.extra_msa.shape == (1, 3)
+    assert features.msa_feat.dtype == np.float32
+
+
+def test_unpaired_chain_merge_gap_pads_homolog_rows(tmp_path: Path):
+    path = tmp_path / "target.a3m"
+    path.write_text(">query\nACD\n>homolog\nA-D\n")
+
+    binder = raw_msa_from_sequence("GG")
+    target = load_a3m_file(path, sequence="ACD")
+    merged = merge_unpaired_msas([binder, target])
+
+    assert merged.tokens.shape == (2, 5)
+    np.testing.assert_array_equal(
+        merged.tokens[0],
+        np.concatenate([binder.tokens[0], target.tokens[0]]),
+    )
+    np.testing.assert_array_equal(merged.tokens[1, :2], np.asarray([21, 21]))
+
+
+def test_make_af_features_integrates_target_msa_with_binder(tmp_path: Path):
+    path = tmp_path / "target.a3m"
+    path.write_text(
+        ">query\nACD\n"
+        ">homolog_one\nA-D\n"
+        ">homolog_two\nAC-\n"
+    )
+
+    features = make_af_features(
+        [
+            TargetChain(sequence="GG", use_msa=False),
+            TargetChain(sequence="ACD", use_msa=True, msa_path=str(path)),
+        ],
+        max_msa_clusters=1,
+        max_extra_msa=8,
+        msa_seed=0,
+    )
+
+    assert features["msa_feat"].shape == (1, 5, 49)
+    assert features["msa_mask"].shape == (1, 5)
+    assert features["extra_msa"].shape == (2, 5)
+    assert features["extra_msa_mask"].shape == (2, 5)
+    np.testing.assert_array_equal(features["asym_id"], [1, 1, 2, 2, 2])
+    np.testing.assert_array_equal(
+        np.argmax(features["msa_feat"][0, :, :23], axis=-1),
+        features["aatype"],
+    )
+    np.testing.assert_array_equal(
+        features["extra_msa"][:, :2],
+        np.full((2, 2), 21),
+    )


### PR DESCRIPTION
## Summary

  This PR adds MSA feature extraction for the AlphaFold2 model.

  Previously, Mosaic's AlphaFold2 interface could only be used without an MSA. This change allows a precomputed A3M alignment to be supplied through
  `TargetChain.msa_path`.

  ## Usage

`  from mosaic.models.af2 import AlphaFold2
  from mosaic.structure_prediction import TargetChain

  af2 = AlphaFold2()

  features, writer = af2.target_only_features([
      TargetChain(
          sequence=TARGET_SEQUENCE,
          use_msa=True,
          msa_path="target.a3m",
      )
  ])`

  The implementation follows AlphaFold2's original MSA feature-construction pipeline. It does not perform an MSA search; it parses a supplied A3M file and constructs
  the features consumed by the model.

  MSA features are computed before optimization. During binder optimization, the target MSA remains fixed while the binder sequence in the query row remains
  differentiable.

  ## Testing

  Added tests covering:

  - A3M parsing and validation
  - Insertions and duplicate sequences
  - MSA clustering and extra-MSA features
  - Unpaired multi-chain MSA construction
  - Integration with TargetChain.msa_path and AF2 feature generation