### PR TITLE
Add swappable binder design and evaluation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,43 @@ To run the example notebook try `uv run marimo edit examples/example_notebook.py
 
 > You'll need a GPU or TPU-compatible version of JAX for structure prediction. You might need to install this manually, i.e. `uv add jax[cuda12]`.
 
+### Binder evaluation pipeline
+
+`mosaic.binder_design` can fold and evaluate existing binder-target complex PDBs
+without running hallucination or ProteinMPNN. The folding backend is selected by
+the advanced JSON and can be AlphaFold2, Boltz-2, Protenix-v2, or ESMFold2:
+
+```bash
+python -m mosaic.binder_design \
+  --settings examples/binder_design_evaluation/settings.json \
+  --advanced examples/binder_design_evaluation/advanced/boltz2.json \
+  --filters examples/binder_design_evaluation/filters.json \
+  --mode evaluate \
+  --input-dir path/to/complex_pdbs \
+  --output-dir results/boltz2
+```
+
+Filters decide acceptance. Metric groups only request additional measurements,
+so `--evaluation-metric-group pyrosetta` enables PyRosetta metrics without
+making them filters. PyRosetta is loaded lazily and is not required for model-only,
+confidence, geometry, DSSP, or monomer evaluation.
+
+Use the matrix runner to evaluate the same input set with several backends in
+isolated output directories and combine their CSVs:
+
+```bash
+python -m mosaic.binder_design.matrix \
+  --settings examples/binder_design_evaluation/settings.json \
+  --filters examples/binder_design_evaluation/filters.json \
+  --advanced-dir examples/binder_design_evaluation/advanced \
+  --input-dir path/to/complex_pdbs \
+  --output-root results/evaluation_matrix \
+  --device af2=0 \
+  --device boltz2=2 \
+  --device protenix-v2=0 \
+  --device esmfold2=cpu
+```
+
 
 ### Introduction
 
@@ -484,5 +521,4 @@ Typically $\ell$ is formed by a single neural network (or an ensemble of the sam
 This kind of modular implementation of loss terms is also useful with modern RL-based alignment of generative models approaches: these forms of alignment can often be seen as _amortized optimization_. Typically, they train a generative model to minimize some combination of KL divergence minus a loss function, which can be a combination of in-silico predictors. We demonstrate exactly this — finetuning and RL-aligning a generative model (BoltzGen) against a `mosaic` loss functional — in [Teaching generative models to hallucinate](https://blog.escalante.bio/teaching-generative-models-to-hallucinate/). Another use case is to provide guidance to discrete diffusion or flow models. 
 
 [^1]: This requires us to treat neural networks as _simple parametric functions_ that can be combined programmatically; **not** as complicated software packages that require large libraries (e.g. PyTorch lightning), bash scripts, or containers as is common practice in BioML. 
-
 

--- a/examples/binder_design_evaluation/advanced/af2.json
+++ b/examples/binder_design_evaluation/advanced/af2.json
@@ -1,0 +1,13 @@
+{
+    "folding_model": "af2",
+    "folding_model_options": {
+        "model_numbers": [4],
+        "members": [3]
+    },
+    "evaluation_metric_groups": ["confidence"],
+    "num_recycles_validation": 0,
+    "af_params_dir": "",
+    "ipsae": {
+        "enabled": false
+    }
+}

--- a/examples/binder_design_evaluation/advanced/boltz2.json
+++ b/examples/binder_design_evaluation/advanced/boltz2.json
@@ -1,0 +1,12 @@
+{
+    "folding_model": "boltz2",
+    "folding_model_options": {
+        "members": [0],
+        "sampling_steps": 5
+    },
+    "evaluation_metric_groups": ["confidence"],
+    "num_recycles_validation": 0,
+    "ipsae": {
+        "enabled": false
+    }
+}

--- a/examples/binder_design_evaluation/advanced/esmfold2_fast.json
+++ b/examples/binder_design_evaluation/advanced/esmfold2_fast.json
@@ -1,0 +1,13 @@
+{
+    "folding_model": "esmfold2",
+    "folding_model_options": {
+        "variant": "fast",
+        "members": [0],
+        "sampling_steps": 5
+    },
+    "evaluation_metric_groups": ["confidence"],
+    "num_recycles_validation": 0,
+    "ipsae": {
+        "enabled": false
+    }
+}

--- a/examples/binder_design_evaluation/advanced/protenix_v2.json
+++ b/examples/binder_design_evaluation/advanced/protenix_v2.json
@@ -1,0 +1,12 @@
+{
+    "folding_model": "protenix-v2",
+    "folding_model_options": {
+        "members": [0],
+        "sampling_steps": 5
+    },
+    "evaluation_metric_groups": ["confidence"],
+    "num_recycles_validation": 0,
+    "ipsae": {
+        "enabled": false
+    }
+}

--- a/examples/binder_design_evaluation/filters.json
+++ b/examples/binder_design_evaluation/filters.json
@@ -1,0 +1,26 @@
+{
+    "Average_pLDDT": {
+        "threshold": null,
+        "higher": true
+    },
+    "Average_pTM": {
+        "threshold": null,
+        "higher": true
+    },
+    "Average_i_pTM": {
+        "threshold": null,
+        "higher": true
+    },
+    "Average_IPSAE": {
+        "threshold": null,
+        "higher": true
+    },
+    "Average_pAE": {
+        "threshold": null,
+        "higher": false
+    },
+    "Average_i_pAE": {
+        "threshold": null,
+        "higher": false
+    }
+}

--- a/examples/binder_design_evaluation/settings.json
+++ b/examples/binder_design_evaluation/settings.json
@@ -1,0 +1,6 @@
+{
+    "design_path": "results/binder_design_evaluation",
+    "binder_name": "binder_design_evaluation",
+    "chains": "A",
+    "binder_chain": "B"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = "==3.12.*"
 dependencies = [
+    "biopython>=1.85",
     "dm-haiku>=0.0.13",
     "esm2quinox>=0.1.0",
     "flax>=0.10.2",
@@ -117,4 +118,3 @@ conflicts = [
     ],
 ]
 package = true
-

--- a/src/mosaic/binder_design/__init__.py
+++ b/src/mosaic/binder_design/__init__.py
@@ -1,0 +1,26 @@
+"""The binder design pipeline, running natively inside Mosaic.
+
+Four stages, all in one Python 3.12 process:
+
+==========  ========================  =============================
+stage       module                    what it does
+==========  ========================  =============================
+1           :mod:`.trajectory`        AF2 hallucination of a binder backbone
+2           :mod:`.mpnn`              ProteinMPNN sequence design
+3           :mod:`.validation`        refold designs, score confidence
+4           :mod:`.rosetta`,          PyRosetta interface scoring, DSSP
+            :mod:`.geometry`          secondary structure, clashes, RMSD
+==========  ========================  =============================
+
+:mod:`.pipeline` drives stages 2-4 over trajectory backbones, :mod:`.filters`
+applies the threshold configs and :mod:`.labels` defines the CSV schema, both
+kept compatible with DdCraft so existing configs and analysis scripts still
+work.  Run it with ``python -m mosaic.binder_design``.
+
+Because stage 3 only needs a Mosaic ``StructurePredictionModel``, the folding
+model is swappable: AlphaFold2 today, Boltz / ESMFold / Protenix / OpenFold3
+without touching the rest of the pipeline.
+
+Submodules are deliberately not imported eagerly -- importing PyRosetta and the
+AF2 parameters is slow, and most callers only need one stage.
+"""

--- a/src/mosaic/binder_design/__main__.py
+++ b/src/mosaic/binder_design/__main__.py
@@ -1,0 +1,249 @@
+"""Command line entry point for the native-Mosaic binder design pipeline.
+
+    python -m mosaic.binder_design \\
+        --settings  configs/settings_target/q26.json \\
+        --advanced  configs/settings_advanced/q26_advanced.json \\
+        --filters   configs/settings_filters/production.json \\
+        --mode      filter
+
+Modes mirror DdCraft's plus a standalone evaluation entry point:
+``trajectory`` runs stage 1 only, ``filter`` runs stages 2-4 over existing
+trajectories, ``full`` runs everything, and ``evaluate`` starts from existing
+complex PDBs and runs folding plus configured filters (never hallucination).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import jax
+
+logger = logging.getLogger(__name__)
+
+
+def _configure_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="mosaic.binder_design")
+    parser.add_argument("--settings", required=True, help="target settings JSON")
+    parser.add_argument("--advanced", required=True, help="advanced settings JSON")
+    parser.add_argument("--filters", required=True, help="filter thresholds JSON")
+    parser.add_argument(
+        "--mode",
+        default="full",
+        choices=("trajectory", "filter", "full", "evaluate"),
+        help="which stages to run",
+    )
+    parser.add_argument(
+        "--input-pdb",
+        action="append",
+        type=Path,
+        default=[],
+        help="complex PDB to evaluate; repeat for multiple inputs",
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        help="evaluate every .pdb directly inside this directory",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="override design_path from target settings for this invocation",
+    )
+    parser.add_argument(
+        "--evaluation-metric-group",
+        action="append",
+        choices=("confidence", "monomer", "geometry", "dssp", "pyrosetta"),
+        default=[],
+        help=(
+            "compute an evaluation metric family without making it an acceptance "
+            "filter; repeat to request multiple families"
+        ),
+    )
+    parser.add_argument(
+        "--binder-chain",
+        help="override the binder chain from target settings in evaluate mode",
+    )
+    parser.add_argument(
+        "--target-chains",
+        help="override comma-separated target chains in evaluate mode",
+    )
+    parser.add_argument(
+        "--max-trajectories",
+        type=int,
+        default=None,
+        help="stop after this many trajectory backbones",
+    )
+    parser.add_argument("--seed", type=int, default=0, help="master RNG seed")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _configure_logging(args.verbose)
+
+    import numpy as np
+
+    from mosaic.binder_design.pipeline import BinderDesignPipeline, PipelineConfig
+
+    config = PipelineConfig.from_files(args.settings, args.advanced, args.filters)
+    if args.output_dir is not None:
+        config.target_settings["design_path"] = str(args.output_dir.expanduser().resolve())
+    if args.evaluation_metric_group:
+        if args.mode != "evaluate":
+            print(
+                "--evaluation-metric-group is only valid with --mode evaluate",
+                file=sys.stderr,
+            )
+            return 1
+        configured_groups = config.advanced_settings.get(
+            "evaluation_metric_groups", []
+        ) or []
+        if isinstance(configured_groups, str):
+            configured_groups = [configured_groups]
+        config.advanced_settings["evaluation_metric_groups"] = list(
+            dict.fromkeys([*configured_groups, *args.evaluation_metric_group])
+        )
+    if args.binder_chain:
+        config.target_settings["binder_chain"] = args.binder_chain
+    if args.target_chains:
+        config.target_settings["chains"] = args.target_chains
+    pipeline = BinderDesignPipeline(config)
+
+    design_path = Path(config.target_settings["design_path"])
+    trajectory_dir = Path(pipeline.design_paths["Trajectory"])
+    mpnn_csv = design_path / "mpnn_design_stats.csv"
+    final_csv = design_path / "final_design_stats.csv"
+    key = jax.random.key(args.seed)
+
+    if args.mode == "evaluate":
+        inputs = list(args.input_pdb)
+        if args.input_dir is not None:
+            if not args.input_dir.is_dir():
+                print(f"Input directory not found: {args.input_dir}", file=sys.stderr)
+                return 1
+            inputs.extend(sorted(args.input_dir.glob("*.pdb")))
+        # Preserve order while avoiding duplicate work when a PDB is supplied
+        # both explicitly and through --input-dir.
+        inputs = list(dict.fromkeys(path.resolve() for path in inputs))
+        if not inputs:
+            print(
+                "Evaluate mode requires --input-pdb and/or --input-dir",
+                file=sys.stderr,
+            )
+            return 1
+
+        evaluation_csv = design_path / "evaluation_stats.csv"
+        records = []
+        for input_pdb in inputs:
+            key, sub = jax.random.split(key)
+            try:
+                record = pipeline.evaluate_pdb(input_pdb, key=sub)
+            except Exception:
+                logger.exception("Error evaluating %s", input_pdb)
+                continue
+            records.append(record)
+            pipeline.file_design(record)
+        pipeline.write_csv(evaluation_csv, records)
+        accepted = sum(record.accepted for record in records)
+        print(
+            f"Evaluated {len(records)}/{len(inputs)} complexes with "
+            f"{pipeline.folding_selection.name}; {accepted} passed filters. "
+            f"Results: {evaluation_csv}"
+        )
+        return 0 if records else 1
+
+    pipeline.load_seen_sequences(mpnn_csv)
+
+    if args.mode == "filter":
+        trajectories = sorted(trajectory_dir.glob("*.pdb"))
+        if args.max_trajectories:
+            trajectories = trajectories[: args.max_trajectories]
+        if not trajectories:
+            print(f"No trajectories found in {trajectory_dir}", file=sys.stderr)
+            return 1
+        accepted = attempted = 0
+        for trajectory in trajectories:
+            key, sub = jax.random.split(key)
+            try:
+                records = pipeline.run_trajectory(trajectory, key=sub)
+            except Exception:
+                logger.exception("Error processing %s", trajectory.name)
+                continue
+            pipeline.write_csv(mpnn_csv, records)
+            for record in records:
+                pipeline.file_design(record)
+            attempted += len(records)
+            accepted += sum(1 for record in records if record.accepted)
+        ranked = pipeline.write_final_csv(mpnn_csv, final_csv)
+        print(f"Ranked {ranked} accepted designs into {final_csv}")
+        print(
+            f"Processed {len(trajectories)} trajectories, "
+            f"{attempted} designs, {accepted} accepted"
+        )
+        return 0
+
+    # trajectory / full: drive stage 1 ourselves.
+    target = int(
+        args.max_trajectories
+        or config.advanced_settings.get("max_trajectories")
+        or config.target_settings.get("number_of_final_designs", 1)
+    )
+    # max_trajectories bounds the work; number_of_final_designs is what the run
+    # is actually for, and reaching it stops generation early.
+    final_target = int(config.target_settings.get("number_of_final_designs", 0) or 0)
+    master_seed = config.advanced_settings.get("trajectory_random_seed", args.seed)
+    rng = np.random.default_rng(int(master_seed))
+
+    backbones: list[Path] = []
+    accepted = attempted = 0
+    for index in range(target):
+        seed = pipeline.sample_seed(rng)
+        length = pipeline.sample_length(rng)
+        logger.info("Trajectory %d/%d (length %d, seed %d)", index + 1, target, length, seed)
+        backbone, _ = pipeline.generate_trajectory(seed=seed, length=length)
+        if backbone is None:
+            continue
+        backbones.append(backbone)
+        if args.mode != "full":
+            continue
+        key, sub = jax.random.split(key)
+        try:
+            records = pipeline.run_trajectory(backbone, key=sub)
+        except Exception:
+            logger.exception("Error processing %s", backbone.name)
+            continue
+        pipeline.write_csv(mpnn_csv, records)
+        for record in records:
+            pipeline.file_design(record)
+        attempted += len(records)
+        accepted += sum(1 for record in records if record.accepted)
+        if final_target and pipeline.accepted_design_count() >= final_target:
+            logger.info("Target number of final designs reached")
+            break
+
+    if args.mode == "full":
+        ranked = pipeline.write_final_csv(mpnn_csv, final_csv)
+        print(f"Ranked {ranked} accepted designs into {final_csv}")
+        print(
+            f"Generated {len(backbones)}/{target} usable backbones, "
+            f"{attempted} designs, {accepted} accepted"
+        )
+    else:
+        print(f"Generated {len(backbones)}/{target} usable backbones")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mosaic/binder_design/components.py
+++ b/src/mosaic/binder_design/components.py
@@ -1,0 +1,218 @@
+"""Configuration-driven structure-model registry for binder design.
+
+The binder pipeline has two independent structure-prediction slots:
+
+``hallucination``
+    The differentiable model whose confidence/geometry objective shapes a new
+    binder backbone.
+
+``folding``
+    The model used to refold and score finished binder sequences (including the
+    evaluation-only workflow).
+
+Keeping construction here gives both workflows one spelling and one validation
+path for model names.  Imports are deliberately lazy: importing every backend
+would initialize several large dependency stacks even when only AF2 is used.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "AVAILABLE_MODELS",
+    "ModelSelection",
+    "create_structure_model",
+    "model_selection",
+]
+
+
+AVAILABLE_MODELS = ("af2", "boltz2", "protenix-v2", "esmfold2")
+
+_ALIASES = {
+    "af2": "af2",
+    "alphafold2": "af2",
+    "alpha-fold2": "af2",
+    "boltz2": "boltz2",
+    "boltz-2": "boltz2",
+    "protenix2": "protenix-v2",
+    "protenix-v2": "protenix-v2",
+    "protenix_v2": "protenix-v2",
+    "esmfold2": "esmfold2",
+    "esm-fold2": "esmfold2",
+    "esmfold-2": "esmfold2",
+}
+
+_STAGE_KEYS = {
+    "hallucination": ("hallucination_model", "design_model"),
+    "folding": ("folding_model", "validation_model"),
+}
+
+
+def _canonical_name(value: Any) -> str:
+    name = str(value or "af2").strip().lower().replace(" ", "-")
+    try:
+        return _ALIASES[name]
+    except KeyError:
+        choices = ", ".join(AVAILABLE_MODELS)
+        raise ValueError(
+            f"Unknown structure model '{value}'. Choose one of: {choices}"
+        ) from None
+
+
+@dataclass(frozen=True)
+class ModelSelection:
+    """One configured model slot and its model-specific options."""
+
+    stage: str
+    name: str
+    options: dict[str, Any]
+
+    @property
+    def sampling_steps(self) -> int | None:
+        value = self.options.get("sampling_steps")
+        return None if value is None else int(value)
+
+    @property
+    def members(self) -> tuple[int, ...] | None:
+        configured = self.options.get("members")
+        if configured is not None:
+            if isinstance(configured, (str, bytes)):
+                raise TypeError(
+                    f"{self.stage}_model_options.members must be a JSON array"
+                )
+            members = tuple(int(member) for member in configured)
+            if not members:
+                raise ValueError(f"{self.stage}_model_options.members cannot be empty")
+            if len(members) > 5 or len(set(members)) != len(members):
+                raise ValueError(
+                    f"{self.stage}_model_options.members must contain 1-5 "
+                    "distinct member indices"
+                )
+            if any(member < 0 or member > 4 for member in members):
+                raise ValueError(
+                    f"{self.stage}_model_options.members uses zero-based indices "
+                    "from 0 through 4"
+                )
+            return members
+        samples = self.options.get("num_samples")
+        if samples is None:
+            return None
+        count = int(samples)
+        if not 1 <= count <= 5:
+            raise ValueError(
+                f"{self.stage}_model_options.num_samples must be between 1 and 5"
+            )
+        return tuple(range(count))
+
+
+def model_selection(settings: Mapping[str, Any], stage: str) -> ModelSelection:
+    """Parse a hallucination/folding model selection from advanced settings.
+
+    The concise form is a string::
+
+        "hallucination_model": "boltz2"
+
+    A mapping may keep the name and options together::
+
+        "folding_model": {"name": "esmfold2", "sampling_steps": 20}
+
+    Separate ``<stage>_model_options`` mappings are merged on top.  The legacy
+    aliases ``design_model`` and ``validation_model`` are accepted so early
+    experimental configs continue to load.
+    """
+
+    if stage not in _STAGE_KEYS:
+        raise ValueError(f"Unknown model stage '{stage}'")
+
+    raw: Any = None
+    for key in _STAGE_KEYS[stage]:
+        if settings.get(key) is not None:
+            raw = settings[key]
+            break
+    if raw is None:
+        raw = "af2"
+
+    options: dict[str, Any]
+    if isinstance(raw, Mapping):
+        options = dict(raw)
+        raw_name = options.pop("name", options.pop("model", "af2"))
+    else:
+        raw_name = raw
+        options = {}
+
+    extra = settings.get(f"{stage}_model_options", {}) or {}
+    if not isinstance(extra, Mapping):
+        raise TypeError(f"{stage}_model_options must be a JSON object")
+    options.update(extra)
+    return ModelSelection(stage=stage, name=_canonical_name(raw_name), options=options)
+
+
+def create_structure_model(
+    selection: ModelSelection,
+    settings: Mapping[str, Any],
+    *,
+    multimer: bool | None = None,
+    model_numbers: tuple[int, ...] | None = None,
+):
+    """Construct one registered model without importing unused backends."""
+
+    options = selection.options
+    if selection.name == "af2":
+        from mosaic.models.af2 import AlphaFold2
+
+        if selection.sampling_steps is not None:
+            raise ValueError("AF2 does not support sampling_steps")
+
+        data_dir = options.get("data_dir", options.get("params_dir"))
+        if data_dir is None:
+            data_dir = settings.get("af_params_dir")
+        if multimer is None:
+            setting = (
+                "use_multimer_design"
+                if selection.stage == "hallucination"
+                else "use_multimer_validation"
+            )
+            multimer = bool(settings.get(setting, True))
+        configured_numbers = options.get("model_numbers")
+        if configured_numbers is not None:
+            model_numbers = tuple(int(number) for number in configured_numbers)
+            if (
+                not model_numbers
+                or len(set(model_numbers)) != len(model_numbers)
+                or any(number < 1 or number > 5 for number in model_numbers)
+            ):
+                raise ValueError(
+                    "AF2 model_numbers must contain distinct one-based values 1-5"
+                )
+        return AlphaFold2(
+            data_dir=data_dir,
+            multimer=bool(multimer),
+            model_numbers=model_numbers,
+        )
+
+    if selection.name == "boltz2":
+        from mosaic.models.boltz2 import Boltz2
+
+        checkpoint = options.get("checkpoint_path", options.get("cache_path"))
+        return Boltz2(cache_path=Path(checkpoint).expanduser() if checkpoint else None)
+
+    if selection.name == "protenix-v2":
+        from mosaic.models.protenix import ProtenixV2
+
+        return ProtenixV2()
+
+    if selection.name == "esmfold2":
+        from mosaic.models.esmfold2 import ESMFold2Fast, ESMFold2Full
+
+        variant = str(options.get("variant", "fast")).strip().lower()
+        if variant == "fast":
+            return ESMFold2Fast()
+        if variant == "full":
+            return ESMFold2Full()
+        raise ValueError("esmfold2 variant must be 'fast' or 'full'")
+
+    raise AssertionError(f"unhandled registered model: {selection.name}")

--- a/src/mosaic/binder_design/filters.py
+++ b/src/mosaic/binder_design/filters.py
@@ -1,0 +1,104 @@
+"""Filter evaluation for binder designs.
+
+A faithful port of DdCraft's ``check_filters`` so existing filter JSON configs
+keep working unchanged.  Behaviour worth remembering:
+
+* A filter whose ``threshold`` is ``None`` is inactive.
+* ``InterfaceAAs`` filters are nested one level deeper, keyed by amino acid.
+* A missing value on a per-model metric (``1_``..``5_``) counts as a pass,
+  because not every model is necessarily run; a missing value on an averaged
+  metric counts as a failure -- and is logged loudly, since an uncomputed metric
+  otherwise rejects every design in a way that looks like bad designs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, Mapping
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["INTERFACE_AA_LABELS", "check_filters", "unmet_filters"]
+
+INTERFACE_AA_LABELS = frozenset(
+    {"Average_InterfaceAAs", *(f"{i}_InterfaceAAs" for i in range(1, 6))}
+)
+
+_PER_MODEL_PREFIXES = tuple(f"{i}_" for i in range(1, 6))
+
+
+def _fails(value: Any, threshold: Any, higher: bool, label: str) -> bool:
+    try:
+        return value < threshold if higher else value > threshold
+    except (TypeError, ValueError) as error:
+        logger.warning("Filter comparison error for %s: %s", label, error)
+        return True
+
+
+def unmet_filters(
+    values: Mapping[str, Any], filters: Mapping[str, Any]
+) -> list[str]:
+    """Return the labels of every filter ``values`` fails."""
+    unmet: list[str] = []
+
+    for label, conditions in filters.items():
+        if label in INTERFACE_AA_LABELS:
+            counts = values.get(label)
+            if counts is None:
+                continue
+            for aa, aa_conditions in conditions.items():
+                threshold = aa_conditions["threshold"]
+                value = counts.get(aa)
+                if value is None or threshold is None:
+                    continue
+                if _fails(value, threshold, aa_conditions["higher"], f"{label}_{aa}"):
+                    unmet.append(f"{label}_{aa}")
+            continue
+
+        threshold = conditions["threshold"]
+        if threshold is None:
+            continue
+
+        value = values.get(label)
+        if value is None:
+            if label.startswith(_PER_MODEL_PREFIXES):
+                continue
+            logger.warning(
+                "Filter '%s' has threshold %s but the value is None (metric not "
+                "computed) - rejecting design. If this repeats for every design, "
+                "the metric is missing rather than the designs being bad.",
+                label,
+                threshold,
+            )
+            unmet.append(label)
+            continue
+
+        if _fails(value, threshold, conditions["higher"], label):
+            unmet.append(label)
+
+    return unmet
+
+
+def check_filters(
+    design_values: Iterable[Any] | Mapping[str, Any],
+    design_labels: Iterable[str] | None = None,
+    filters: Mapping[str, Any] | None = None,
+) -> bool | list[str]:
+    """DdCraft-compatible entry point.
+
+    Accepts either a mapping of label to value, or a parallel
+    ``(values, labels)`` pair.  Returns ``True`` when every filter passes, or
+    the list of unmet filter labels otherwise.
+    """
+    if filters is None:
+        raise TypeError("filters is required")
+
+    if isinstance(design_values, Mapping):
+        values = dict(design_values)
+    else:
+        if design_labels is None:
+            raise TypeError("design_labels is required when passing a value sequence")
+        values = dict(zip(design_labels, design_values))
+
+    unmet = unmet_filters(values, filters)
+    return True if not unmet else unmet

--- a/src/mosaic/binder_design/geometry.py
+++ b/src/mosaic/binder_design/geometry.py
@@ -1,0 +1,405 @@
+"""BioPython-based structural metrics for binder design filtering.
+
+Migrated from ``ddcraft.utils.biopython`` (DdCraft py3.10 pipeline) to run
+natively inside Mosaic. Numerical behaviour is preserved exactly; only
+imports/logging were adapted to remove the dependency on the ``ddcraft``
+package.
+"""
+from __future__ import annotations
+
+import logging
+import math
+import os
+import tempfile
+from collections import defaultdict
+
+import numpy as np
+from Bio import BiopythonWarning
+from Bio.PDB import Chain, DSSP, PDBIO, PDBParser, Polypeptide, Select, Selection, Superimposer
+from Bio.PDB.Polypeptide import is_aa
+from Bio.PDB.Selection import unfold_entities
+from Bio.SeqUtils.ProtParam import ProteinAnalysis
+from scipy.spatial import cKDTree
+
+logger = logging.getLogger(__name__)
+
+
+def get_chain_length(pdb_file, chain_id):
+    parser = PDBParser(QUIET=True)
+    structure = parser.get_structure("pdb_structure", pdb_file)
+    residues = []
+
+    for model in structure:
+        for chain in model:
+            if chain.id == chain_id:
+                for residue in chain:
+                    if residue.id[0] == ' ':  # Ignore heteroatoms and waters
+                        residues.append(residue)
+
+                return len(residues)
+    return 0  # If chain not found
+
+# analyze sequence composition of design
+def validate_design_sequence(sequence, num_clashes, advanced_settings):
+    note_array = []
+
+    # Check if protein contains clashes after relaxation
+    if num_clashes is not None and num_clashes > 0:
+        note_array.append('Relaxed structure contains clashes.')
+
+    # Check if the sequence contains disallowed amino acids
+    if advanced_settings["omit_AAs"]:
+        restricted_AAs = advanced_settings["omit_AAs"].split(',')
+        for restricted_AA in restricted_AAs:
+            if restricted_AA in sequence:
+                note_array.append('Contains: '+restricted_AA+'!')
+
+    # Analyze the protein
+    analysis = ProteinAnalysis(sequence)
+
+    # Calculate the reduced extinction coefficient per 1% solution
+    extinction_coefficient_reduced = analysis.molar_extinction_coefficient()[0]
+    molecular_weight = round(analysis.molecular_weight() / 1000, 2)
+    extinction_coefficient_reduced_1 = round(extinction_coefficient_reduced / molecular_weight * 0.01, 2)
+
+    # Check if the absorption is high enough
+    if extinction_coefficient_reduced_1 <= 2:
+        note_array.append(f'Absorption value is {extinction_coefficient_reduced_1}, consider adding tryptophane to design.')
+
+    # Join the notes into a single string
+    notes = ' '.join(note_array)
+
+    return notes
+
+# temporary function, calculate RMSD of input PDB and trajectory target
+def chain_rmsd(reference_pdb, mobile_pdb, chain_id):
+    """CA RMSD of one chain between two structures, after superposing on that same chain.
+
+    Reports internal conformational deviation (e.g. did the target distort during prediction?)
+    independently of any rigid-body movement. Returns None if the chain cannot be compared.
+    """
+    parser = PDBParser(QUIET=True)
+    try:
+        ref = parser.get_structure('reference', reference_pdb)[0]
+        mob = parser.get_structure('mobile', mobile_pdb)[0]
+    except Exception:
+        return None
+
+    chain_id = chain_id.split(',')[0].strip()
+    if chain_id not in ref or chain_id not in mob:
+        return None
+
+    def ca_by_resid(model):
+        return {
+            residue.id[1]: residue['CA']
+            for residue in model[chain_id]
+            if is_aa(residue, standard=True) and 'CA' in residue
+        }
+
+    ref_ca, mob_ca = ca_by_resid(ref), ca_by_resid(mob)
+    shared = sorted(set(ref_ca) & set(mob_ca))
+    if len(shared) < 3:
+        return None
+
+    sup = Superimposer()
+    sup.set_atoms([ref_ca[i] for i in shared], [mob_ca[i] for i in shared])
+    return round(float(sup.rms), 2)
+
+
+def hotspot_rmsd(trajectory_pdb, prediction_pdb, target_chain, binder_chain):
+    """Binder RMSD between a predicted complex and its trajectory after superposing on the target.
+
+    Superposing on the target chain puts both structures in the target's frame, so the residual
+    binder RMSD reports whether the predicted design still engages the same epitope in the same
+    pose as the trajectory that was optimised against the hotspots. A design that slides to a
+    different surface patch yields a large value.
+
+    Returns None if the structures cannot be compared (missing chains / no shared residues).
+    """
+    parser = PDBParser(QUIET=True)
+    try:
+        ref = parser.get_structure('trajectory', trajectory_pdb)[0]
+        mob = parser.get_structure('prediction', prediction_pdb)[0]
+    except Exception:
+        return None
+
+    target_chain = target_chain.split(',')[0].strip()
+
+    def ca_by_resid(model, chain_id):
+        if chain_id not in model:
+            return {}
+        return {
+            residue.id[1]: residue['CA']
+            for residue in model[chain_id]
+            if is_aa(residue, standard=True) and 'CA' in residue
+        }
+
+    ref_target, mob_target = ca_by_resid(ref, target_chain), ca_by_resid(mob, target_chain)
+    shared_target = sorted(set(ref_target) & set(mob_target))
+    ref_binder, mob_binder = ca_by_resid(ref, binder_chain), ca_by_resid(mob, binder_chain)
+    shared_binder = sorted(set(ref_binder) & set(mob_binder))
+
+    if len(shared_target) < 3 or not shared_binder:
+        return None
+
+    sup = Superimposer()
+    sup.set_atoms([ref_target[i] for i in shared_target],
+                  [mob_target[i] for i in shared_target])
+    # Apply the target-frame transform to the mobile binder without altering the reference.
+    sup.apply([mob_binder[i] for i in shared_binder])
+
+    diff = np.array([mob_binder[i].coord - ref_binder[i].coord for i in shared_binder])
+    return round(float(np.sqrt((diff ** 2).sum(axis=1).mean())), 2)
+
+
+def target_pdb_rmsd(trajectory_pdb, starting_pdb, chain_ids_string):
+    # Parse the PDB files
+    parser = PDBParser(QUIET=True)
+    structure_trajectory = parser.get_structure('trajectory', trajectory_pdb)
+    structure_starting = parser.get_structure('starting', starting_pdb)
+    
+    # Extract chain A from trajectory_pdb
+    chain_trajectory = structure_trajectory[0]['A']
+    
+    # Extract the specified chains from starting_pdb
+    chain_ids = chain_ids_string.split(',')
+    residues_starting = []
+    for chain_id in chain_ids:
+        chain_id = chain_id.strip()
+        chain = structure_starting[0][chain_id]
+        for residue in chain:
+            if is_aa(residue, standard=True):
+                residues_starting.append(residue)
+    
+    # Extract residues from chain A in trajectory_pdb
+    residues_trajectory = [residue for residue in chain_trajectory if is_aa(residue, standard=True)]
+    
+    # Ensure that both structures have the same number of residues
+    min_length = min(len(residues_starting), len(residues_trajectory))
+    residues_starting = residues_starting[:min_length]
+    residues_trajectory = residues_trajectory[:min_length]
+    
+    # Collect CA atoms from the two sets of residues
+    atoms_starting = [residue['CA'] for residue in residues_starting if 'CA' in residue]
+    atoms_trajectory = [residue['CA'] for residue in residues_trajectory if 'CA' in residue]
+    
+    # Calculate RMSD using structural alignment
+    sup = Superimposer()
+    sup.set_atoms(atoms_starting, atoms_trajectory)
+    rmsd = sup.rms
+    
+    return round(rmsd, 2)
+
+# detect C alpha clashes for deformed trajectories
+def calculate_clash_score(pdb_file, threshold=2.4, only_ca=False):
+    parser = PDBParser(QUIET=True)
+    structure = parser.get_structure('protein', pdb_file)
+
+    atoms = []
+    atom_info = []  # Detailed atom info for debugging and processing
+
+    for model in structure:
+        for chain in model:
+            for residue in chain:
+                for atom in residue:
+                    if atom.element == 'H':  # Skip hydrogen atoms
+                        continue
+                    if only_ca and atom.get_name() != 'CA':
+                        continue
+                    atoms.append(atom.coord)
+                    atom_info.append((chain.id, residue.id[1], atom.get_name(), atom.coord))
+
+    tree = cKDTree(atoms)
+    pairs = tree.query_pairs(threshold)
+
+    valid_pairs = set()
+    for (i, j) in pairs:
+        chain_i, res_i, name_i, coord_i = atom_info[i]
+        chain_j, res_j, name_j, coord_j = atom_info[j]
+
+        # Exclude clashes within the same residue
+        if chain_i == chain_j and res_i == res_j:
+            continue
+
+        # Exclude directly sequential residues in the same chain for all atoms
+        if chain_i == chain_j and abs(res_i - res_j) == 1:
+            continue
+
+        # If calculating sidechain clashes, only consider clashes between different chains
+        if not only_ca and chain_i == chain_j:
+            continue
+
+        valid_pairs.add((i, j))
+
+    return len(valid_pairs)
+
+three_to_one_map = {
+    'ALA': 'A', 'CYS': 'C', 'ASP': 'D', 'GLU': 'E', 'PHE': 'F',
+    'GLY': 'G', 'HIS': 'H', 'ILE': 'I', 'LYS': 'K', 'LEU': 'L',
+    'MET': 'M', 'ASN': 'N', 'PRO': 'P', 'GLN': 'Q', 'ARG': 'R',
+    'SER': 'S', 'THR': 'T', 'VAL': 'V', 'TRP': 'W', 'TYR': 'Y'
+}
+
+# identify interacting residues at the binder interface
+def hotspot_residues(trajectory_pdb, binder_chain="B", atom_distance_cutoff=4.0):
+    # Parse the PDB file
+    parser = PDBParser(QUIET=True)
+    structure = parser.get_structure("complex", trajectory_pdb)
+
+    # Get the specified chain
+    binder_atoms = Selection.unfold_entities(structure[0][binder_chain], 'A')
+    binder_coords = np.array([atom.coord for atom in binder_atoms])
+
+    # Dynamically determine target chain (the chain that's not the binder)
+    available_chains = [chain.id for chain in structure[0]]
+    target_chain = None
+    for chain_id in available_chains:
+        if chain_id != binder_chain:
+            target_chain = chain_id
+            break
+    
+    if target_chain is None:
+        raise ValueError(f"Could not find target chain. Available chains: {available_chains}, binder chain: {binder_chain}")
+    
+    # Get atoms and coords for the target chain
+    target_atoms = Selection.unfold_entities(structure[0][target_chain], 'A')
+    target_coords = np.array([atom.coord for atom in target_atoms])
+
+    # Build KD trees for both chains
+    binder_tree = cKDTree(binder_coords)
+    target_tree = cKDTree(target_coords)
+
+    # Prepare to collect interacting residues
+    interacting_residues = {}
+
+    # Query the tree for pairs of atoms within the distance cutoff
+    pairs = binder_tree.query_ball_tree(target_tree, atom_distance_cutoff)
+
+    # Process each binder atom's interactions
+    for binder_idx, close_indices in enumerate(pairs):
+        binder_residue = binder_atoms[binder_idx].get_parent()
+        binder_resname = binder_residue.get_resname()
+
+        # Convert three-letter code to single-letter code using the manual dictionary
+        if binder_resname in three_to_one_map:
+            aa_single_letter = three_to_one_map[binder_resname]
+            for close_idx in close_indices:
+                target_residue = target_atoms[close_idx].get_parent()
+                interacting_residues[binder_residue.id[1]] = aa_single_letter
+
+    return interacting_residues
+
+class FirstModelSelect(Select):
+    def accept_model(self, model):
+        return model.id == 0  # Only first model
+
+def calc_ss_percentage(pdb_file, advanced_settings, chain_id="B", atom_distance_cutoff=4.0):
+    # Parse the structure
+    parser = PDBParser(QUIET=True)
+    structure = parser.get_structure('protein', pdb_file)
+    model = structure[0]  # Consider only the first model
+
+    # Save the first model to a temp file (removes MODEL/ENDMDL etc.)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp:
+        tmp_pdb_path = tmp.name
+    io = PDBIO()
+    io.set_structure(model)
+    io.save(tmp_pdb_path, select=FirstModelSelect())
+
+    # Inject a dummy CRYST1 line at the top
+    with open(tmp_pdb_path, "r") as f:
+        lines = f.readlines()
+    
+    # If the first line is not CRYST1, insert a dummy one
+    if not lines[0].startswith("CRYST1"):
+        lines.insert(0, "CRYST1   10.000   10.000   10.000  90.00  90.00  90.00 P 1           1\n")
+        with open(tmp_pdb_path, "w") as f:
+            f.writelines(lines)
+            
+    # Calculate DSSP for the cleaned model
+    dssp = DSSP(model, tmp_pdb_path, dssp=advanced_settings["dssp_path"])
+
+    # Prepare to count residues
+    ss_counts = defaultdict(int)
+    ss_interface_counts = defaultdict(int)
+    plddts_interface = []
+    plddts_ss = []
+
+    # Get chain and interacting residues once
+    chain = model[chain_id]
+    interacting_residues = set(hotspot_residues(pdb_file, chain_id, atom_distance_cutoff).keys())
+
+    for residue in chain:
+        residue_id = residue.id[1]
+        if (chain_id, residue_id) in dssp:
+            ss = dssp[(chain_id, residue_id)][2]  # Get the secondary structure
+            ss_type = 'loop'
+            if ss in ['H', 'G', 'I']:
+                ss_type = 'helix'
+            elif ss == 'E':
+                ss_type = 'sheet'
+
+            ss_counts[ss_type] += 1
+
+            if ss_type != 'loop':
+                avg_plddt_ss = sum(atom.bfactor for atom in residue) / len(residue)
+                plddts_ss.append(avg_plddt_ss)
+
+            if residue_id in interacting_residues:
+                ss_interface_counts[ss_type] += 1
+                avg_plddt_residue = sum(atom.bfactor for atom in residue) / len(residue)
+                plddts_interface.append(avg_plddt_residue)
+
+    # Clean up the temporary file
+    os.remove(tmp_pdb_path)
+
+    # Calculate percentages
+    total_residues = sum(ss_counts.values())
+    total_interface_residues = sum(ss_interface_counts.values())
+
+    percentages = calculate_percentages(total_residues, ss_counts['helix'], ss_counts['sheet'])
+    interface_percentages = calculate_percentages(total_interface_residues, ss_interface_counts['helix'], ss_interface_counts['sheet'])
+
+    i_plddt = round(sum(plddts_interface) / len(plddts_interface) / 100, 2) if plddts_interface else 0
+    ss_plddt = round(sum(plddts_ss) / len(plddts_ss) / 100, 2) if plddts_ss else 0
+
+    return (*percentages, *interface_percentages, i_plddt, ss_plddt)
+
+def mean_ca_bfactor(pdb_file):
+    """Mean CA B-factor of the first model, or ``None`` when there are no CAs.
+
+    Predicted structures carry per-residue pLDDT in the B-factor column, so this
+    ranks the five AF2 models of a design without re-reading their metrics.
+    """
+    structure = PDBParser(QUIET=True).get_structure("model", pdb_file)
+    values = [
+        float(residue["CA"].bfactor)
+        for chain in next(structure.get_models())
+        for residue in chain
+        if residue.id[0] == " " and "CA" in residue
+    ]
+    return sum(values) / len(values) if values else None
+
+
+def calculate_percentages(total, helix, sheet):
+    helix_percentage = round((helix / total) * 100,2) if total > 0 else 0
+    sheet_percentage = round((sheet / total) * 100,2) if total > 0 else 0
+    loop_percentage = round(((total - helix - sheet) / total) * 100,2) if total > 0 else 0
+
+    return helix_percentage, sheet_percentage, loop_percentage
+
+
+def clean_pdb(pdb_file):
+    """Strip a PDB file down to structural record lines only.
+
+    Migrated from ``ddcraft.utils.generic.clean_pdb``; used by :mod:`.rosetta`
+    after PyRosetta writes out a PDB (e.g. after alignment or relax) to
+    remove Rosetta-specific header/footer noise.
+    """
+    # Read the pdb file and filter relevant lines
+    with open(pdb_file, 'r') as f_in:
+        relevant_lines = [line for line in f_in if line.startswith(('ATOM', 'HETATM', 'MODEL', 'TER', 'END', 'LINK'))]
+
+    # Write the cleaned lines back to the original pdb file
+    with open(pdb_file, 'w') as f_out:
+        f_out.writelines(relevant_lines)

--- a/src/mosaic/binder_design/io.py
+++ b/src/mosaic/binder_design/io.py
@@ -1,0 +1,138 @@
+"""PDB conventions shared by the design stages.
+
+Mosaic's AF2 representation places the designed binder first, but DdCraft's
+filters, RMSD helpers and downstream analysis all expect target chains first
+with the binder last, using the residue numbering of the starting structure.
+Everything that writes a structure for the filtering stages goes through here.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from Bio.PDB import Chain, Model, PDBIO, PDBParser, Structure
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ChainLayoutError",
+    "normalize_binder_pdb",
+    "normalize_complex_pdb",
+    "reference_residue_ids",
+]
+
+
+class ChainLayoutError(RuntimeError):
+    """Raised when a predicted structure does not have the expected chains."""
+
+
+def _protein_residues(chain: Any) -> list[Any]:
+    return [residue for residue in chain if residue.id[0] == " "]
+
+
+def reference_residue_ids(starting_pdb: str | Path, chain_id: str) -> list[tuple]:
+    """Residue ids of ``chain_id`` in ``starting_pdb``, in order."""
+    model = PDBParser(QUIET=True).get_structure("reference", str(starting_pdb))[0]
+    if chain_id not in model:
+        raise ChainLayoutError(
+            f"Chain '{chain_id}' is missing from starting PDB {starting_pdb}"
+        )
+    return [residue.id for residue in _protein_residues(model[chain_id])]
+
+
+def _clone_and_rename_chain(
+    source_chain: Any, destination_id: str, residue_ids: Iterable[tuple]
+) -> Any:
+    protein_residues = _protein_residues(source_chain)
+    residue_ids = list(residue_ids)
+    if len(protein_residues) != len(residue_ids):
+        raise ChainLayoutError(
+            f"Predicted chain has {len(protein_residues)} residues but "
+            f"{destination_id} expects {len(residue_ids)}"
+        )
+    chain = Chain.Chain(destination_id)
+    for source_residue, residue_id in zip(protein_residues, residue_ids):
+        residue = source_residue.copy()
+        residue.id = residue_id
+        chain.add(residue)
+    return chain
+
+
+def _write(chains: Sequence[Any], output_pdb: str | Path) -> Path:
+    structure = Structure.Structure("mosaic")
+    model = Model.Model(0)
+    structure.add(model)
+    for chain in chains:
+        model.add(chain)
+
+    output_pdb = Path(output_pdb)
+    output_pdb.parent.mkdir(parents=True, exist_ok=True)
+    io = PDBIO()
+    io.set_structure(structure)
+    io.save(str(output_pdb))
+    return output_pdb
+
+
+def normalize_complex_pdb(
+    raw_pdb: str | Path,
+    output_pdb: str | Path,
+    starting_pdb: str | Path,
+    target_chain_ids: list[str],
+    binder_chain_id: str,
+    binder_length: int,
+    structure_conditioned: bool = False,
+) -> Path:
+    """Reorder a predicted complex into target-chains-then-binder order."""
+    raw_model = PDBParser(QUIET=True).get_structure("mosaic", str(raw_pdb))[0]
+    raw_chains = list(raw_model.get_chains())
+    expected = 1 + len(target_chain_ids)
+    if len(raw_chains) != expected:
+        raise ChainLayoutError(
+            f"Predicted structure contains {len(raw_chains)} chains; expected {expected}"
+        )
+
+    target_chains = [
+        _clone_and_rename_chain(
+            raw_chain, chain_id, reference_residue_ids(starting_pdb, chain_id)
+        )
+        for raw_chain, chain_id in zip(raw_chains[1:], target_chain_ids)
+    ]
+
+    binder_residue_ids = (
+        reference_residue_ids(starting_pdb, binder_chain_id)
+        if structure_conditioned
+        else [(" ", index, " ") for index in range(1, binder_length + 1)]
+    )
+    binder_chain = _clone_and_rename_chain(
+        raw_chains[0], binder_chain_id, binder_residue_ids
+    )
+
+    return _write([*target_chains, binder_chain], output_pdb)
+
+
+def normalize_binder_pdb(
+    raw_pdb: str | Path,
+    output_pdb: str | Path,
+    binder_length: int,
+    chain_id: str = "A",
+) -> Path:
+    """Rename a binder-alone prediction to a single chain numbered from 1.
+
+    DdCraft predicts the binder on its own as chain ``A`` and aligns it against
+    the trajectory, so the monomer output has to use that chain id regardless of
+    what the folding model emitted.
+    """
+    raw_model = PDBParser(QUIET=True).get_structure("mosaic", str(raw_pdb))[0]
+    raw_chains = list(raw_model.get_chains())
+    if len(raw_chains) != 1:
+        raise ChainLayoutError(
+            f"Binder-alone prediction has {len(raw_chains)} chains; expected 1"
+        )
+    chain = _clone_and_rename_chain(
+        raw_chains[0],
+        chain_id,
+        [(" ", index, " ") for index in range(1, binder_length + 1)],
+    )
+    return _write([chain], output_pdb)

--- a/src/mosaic/binder_design/labels.py
+++ b/src/mosaic/binder_design/labels.py
@@ -1,0 +1,63 @@
+"""Column layouts for the design CSVs.
+
+Kept byte-compatible with DdCraft's ``generate_dataframe_labels`` so existing
+analysis scripts and filter configs read the output unchanged.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "CORE_LABELS",
+    "TRAJECTORY_LABELS",
+    "design_labels",
+    "final_labels",
+    "trajectory_labels",
+]
+
+TRAJECTORY_LABELS = [
+    "Design", "Protocol", "Length", "Seed", "Helicity", "Target_Hotspot",
+    "Sequence", "InterfaceResidues", "pLDDT", "pTM", "i_pTM", "IPSAE", "pAE",
+    "i_pAE", "i_pLDDT", "ss_pLDDT", "Unrelaxed_Clashes", "Relaxed_Clashes",
+    "Binder_Energy_Score", "Surface_Hydrophobicity", "ShapeComplementarity",
+    "PackStat", "dG", "dSASA", "dG/dSASA", "Interface_SASA_%",
+    "Interface_Hydrophobicity", "n_InterfaceResidues", "n_InterfaceHbonds",
+    "InterfaceHbondsPercentage", "n_InterfaceUnsatHbonds",
+    "InterfaceUnsatHbondsPercentage", "Interface_Helix%", "Interface_BetaSheet%",
+    "Interface_Loop%", "Binder_Helix%", "Binder_BetaSheet%", "Binder_Loop%",
+    "InterfaceAAs", "Target_RMSD", "TrajectoryTime", "Notes", "TargetSettings",
+    "Filters", "AdvancedSettings",
+]
+
+CORE_LABELS = [
+    "pLDDT", "pTM", "i_pTM", "IPSAE", "pAE", "i_pAE", "i_pLDDT", "ss_pLDDT",
+    "Unrelaxed_Clashes", "Relaxed_Clashes", "Binder_Energy_Score",
+    "Surface_Hydrophobicity", "ShapeComplementarity", "PackStat", "dG", "dSASA",
+    "dG/dSASA", "Interface_SASA_%", "Interface_Hydrophobicity",
+    "n_InterfaceResidues", "n_InterfaceHbonds", "InterfaceHbondsPercentage",
+    "n_InterfaceUnsatHbonds", "InterfaceUnsatHbondsPercentage",
+    "Interface_Helix%", "Interface_BetaSheet%", "Interface_Loop%",
+    "Binder_Helix%", "Binder_BetaSheet%", "Binder_Loop%", "InterfaceAAs",
+    "Hotspot_RMSD", "Target_RMSD", "Binder_pLDDT", "Binder_pTM", "Binder_pAE",
+    "Binder_RMSD",
+]
+
+_BASE_DESIGN_LABELS = [
+    "Design", "Protocol", "Length", "Seed", "Helicity", "Target_Hotspot",
+    "Sequence", "InterfaceResidues", "MPNN_score", "MPNN_seq_recovery",
+]
+
+
+def trajectory_labels() -> list[str]:
+    return list(TRAJECTORY_LABELS)
+
+
+def design_labels() -> list[str]:
+    labels = list(_BASE_DESIGN_LABELS)
+    for label in CORE_LABELS:
+        labels += [f"Average_{label}"] + [f"{i}_{label}" for i in range(1, 6)]
+    labels += ["DesignTime", "Notes", "TargetSettings", "Filters", "AdvancedSettings"]
+    return labels
+
+
+def final_labels() -> list[str]:
+    return ["Rank"] + design_labels()

--- a/src/mosaic/binder_design/matrix.py
+++ b/src/mosaic/binder_design/matrix.py
@@ -1,0 +1,251 @@
+"""Run the same binder complexes through multiple Mosaic folding backends.
+
+Each backend runs in a fresh subprocess and writes to its own directory. This
+both releases model memory between runs and prevents one backend from appending
+to another backend's ``evaluation_stats.csv``. Arbitrary filter configs and
+explicit metric groups are forwarded unchanged, so PyRosetta remains optional.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+BACKEND_PRESETS = {
+    "af2": "af2.json",
+    "boltz2": "boltz2.json",
+    "protenix-v2": "protenix_v2.json",
+    "esmfold2": "esmfold2_fast.json",
+}
+METRIC_GROUPS = ("confidence", "monomer", "geometry", "dssp", "pyrosetta")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="mosaic.binder_design.matrix")
+    parser.add_argument("--settings", required=True, type=Path)
+    parser.add_argument("--filters", required=True, type=Path)
+    parser.add_argument("--advanced-dir", required=True, type=Path)
+    parser.add_argument("--output-root", required=True, type=Path)
+    parser.add_argument(
+        "--backend",
+        action="append",
+        choices=tuple(BACKEND_PRESETS),
+        dest="backends",
+        help="backend to run; repeat as needed (default: all)",
+    )
+    parser.add_argument("--input-pdb", action="append", type=Path, default=[])
+    parser.add_argument("--input-dir", type=Path)
+    parser.add_argument("--binder-chain")
+    parser.add_argument("--target-chains")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--metric-group",
+        action="append",
+        choices=METRIC_GROUPS,
+        default=[],
+        help="compute a metric family without adding an acceptance threshold",
+    )
+    parser.add_argument(
+        "--device",
+        action="append",
+        default=[],
+        metavar="BACKEND=CUDA_MASK|cpu",
+        help="per-backend device assignment; repeat as needed",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="reuse backend results that already contain evaluation_stats.csv",
+    )
+    return parser
+
+
+def _device_map(values: Sequence[str]) -> dict[str, str]:
+    devices: dict[str, str] = {}
+    for value in values:
+        backend, separator, device = value.partition("=")
+        backend, device = backend.strip(), device.strip()
+        if not separator or backend not in BACKEND_PRESETS or not device:
+            choices = ", ".join(BACKEND_PRESETS)
+            raise ValueError(
+                f"Invalid --device '{value}'; expected BACKEND=CUDA_MASK|cpu "
+                f"with BACKEND in: {choices}"
+            )
+        devices[backend] = device
+    return devices
+
+
+def _require_file(path: Path, label: str) -> Path:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise ValueError(f"{label} not found: {resolved}")
+    return resolved
+
+
+def _write_combined_csv(output_root: Path, backends: Sequence[str]) -> Path:
+    rows: list[dict[str, str]] = []
+    fieldnames: list[str] = ["Backend"]
+    for backend in backends:
+        stats = output_root / backend / "evaluation_stats.csv"
+        if not stats.is_file():
+            continue
+        with stats.open(newline="") as handle:
+            for row in csv.DictReader(handle):
+                rows.append({"Backend": backend, **row})
+                for field in row:
+                    if field not in fieldnames:
+                        fieldnames.append(field)
+
+    combined = output_root / "evaluation_matrix.csv"
+    with combined.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+    return combined
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    runner: Callable[..., Any] = subprocess.run,
+) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        settings = _require_file(args.settings, "settings config")
+        filters = _require_file(args.filters, "filter config")
+        devices = _device_map(args.device)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    try:
+        inputs = [_require_file(path, "input PDB") for path in args.input_pdb]
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 2
+    input_dir = None
+    if args.input_dir is not None:
+        input_dir = args.input_dir.expanduser().resolve()
+        if not input_dir.is_dir():
+            print(f"input directory not found: {input_dir}", file=sys.stderr)
+            return 2
+    if not inputs and input_dir is None:
+        print("provide --input-pdb and/or --input-dir", file=sys.stderr)
+        return 2
+
+    backends = args.backends or list(BACKEND_PRESETS)
+    advanced_dir = args.advanced_dir.expanduser().resolve()
+    output_root = args.output_root.expanduser().resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, Any] = {
+        "settings": str(settings),
+        "filters": str(filters),
+        "metric_groups": list(dict.fromkeys(args.metric_group)),
+        "backends": {},
+    }
+    failed = False
+
+    for backend in backends:
+        try:
+            advanced = _require_file(
+                advanced_dir / BACKEND_PRESETS[backend],
+                f"{backend} advanced config",
+            )
+        except ValueError as error:
+            print(error, file=sys.stderr)
+            return 2
+        backend_output = output_root / backend
+        stats = backend_output / "evaluation_stats.csv"
+        log_path = backend_output / "run.log"
+        if stats.is_file():
+            if not args.resume:
+                print(
+                    f"refusing to append duplicate results for {backend}: {stats}; "
+                    "use --resume to reuse them",
+                    file=sys.stderr,
+                )
+                return 2
+            manifest["backends"][backend] = {
+                "status": "reused",
+                "output_dir": str(backend_output),
+                "evaluation_stats": str(stats),
+                "log": str(log_path),
+            }
+            continue
+
+        backend_output.mkdir(parents=True, exist_ok=True)
+        command = [
+            sys.executable,
+            "-m",
+            "mosaic.binder_design",
+            "--settings",
+            str(settings),
+            "--advanced",
+            str(advanced),
+            "--filters",
+            str(filters),
+            "--mode",
+            "evaluate",
+            "--output-dir",
+            str(backend_output),
+            "--seed",
+            str(args.seed),
+        ]
+        for path in inputs:
+            command.extend(["--input-pdb", str(path)])
+        if input_dir is not None:
+            command.extend(["--input-dir", str(input_dir)])
+        if args.binder_chain:
+            command.extend(["--binder-chain", args.binder_chain])
+        if args.target_chains:
+            command.extend(["--target-chains", args.target_chains])
+        for group in dict.fromkeys(args.metric_group):
+            command.extend(["--evaluation-metric-group", group])
+
+        environment = os.environ.copy()
+        device = devices.get(backend)
+        if device:
+            mask = "" if device.lower() == "cpu" else device
+            environment["CUDA_VISIBLE_DEVICES"] = mask
+            environment["NVIDIA_VISIBLE_DEVICES"] = mask
+
+        with log_path.open("w", encoding="utf-8") as log_handle:
+            result = runner(
+                command,
+                env=environment,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+            )
+        return_code = int(getattr(result, "returncode", 1))
+        status = "completed" if return_code == 0 and stats.is_file() else "failed"
+        failed |= status == "failed"
+        manifest["backends"][backend] = {
+            "status": status,
+            "return_code": return_code,
+            "device": device or "inherited",
+            "advanced": str(advanced),
+            "output_dir": str(backend_output),
+            "evaluation_stats": str(stats) if stats.is_file() else None,
+            "log": str(log_path),
+        }
+
+    combined = _write_combined_csv(output_root, backends)
+    manifest["combined_csv"] = str(combined)
+    (output_root / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+    print(f"Combined evaluation matrix: {combined}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mosaic/binder_design/metrics.py
+++ b/src/mosaic/binder_design/metrics.py
@@ -1,0 +1,151 @@
+"""AF2 confidence metrics for binder design.
+
+These reproduce the definitions ColabDesign's binder protocol reports, so that
+numbers coming out of the native-Mosaic pipeline can be compared directly with
+the ones DdCraft produces (and with the thresholds in existing filter configs).
+
+Two conventions are easy to get wrong and are handled explicitly here:
+
+* PAE is symmetrised and divided by 62 (i.e. ``(pae + pae.T) / 2 / 31``) so it
+  lands on ColabDesign's 0-1 scale.
+* ``i_ptm`` is scored with exactly two asym groups, binder versus everything
+  else.  Mosaic gives every chain its own ``asym_id``, which would wrongly count
+  target-target pairs as interface pairs for a multi-chain target.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import jax.numpy as jnp
+import numpy as np
+
+from mosaic.losses import structure_prediction as sp
+
+__all__ = ["ConfidenceMetrics", "normalized_symmetric_pae", "complex_metrics", "monomer_metrics"]
+
+
+def normalized_symmetric_pae(pae) -> np.ndarray:
+    """Symmetrise PAE and rescale to ColabDesign's 0-1 range."""
+    pae = np.asarray(pae)
+    return (pae + np.swapaxes(pae, -1, -2)) / 62.0
+
+
+@dataclass
+class ConfidenceMetrics:
+    plddt: float
+    ptm: float
+    pae: float
+    i_ptm: float | None = None
+    i_pae: float | None = None
+    ipsae: float | None = None
+
+    def as_dict(self, prefix: str = "") -> dict[str, float | None]:
+        out = {
+            f"{prefix}pLDDT": self.plddt,
+            f"{prefix}pTM": self.ptm,
+            f"{prefix}pAE": self.pae,
+        }
+        if self.i_ptm is not None:
+            out[f"{prefix}i_pTM"] = self.i_ptm
+        if self.i_pae is not None:
+            out[f"{prefix}i_pAE"] = self.i_pae
+        if self.ipsae is not None:
+            out[f"{prefix}ipSAE"] = self.ipsae
+        return out
+
+
+def _masked_mean(values, mask) -> float:
+    mask = np.asarray(mask, dtype=np.float64)
+    return float((np.asarray(values) * mask).sum() / (mask.sum() + 1e-8))
+
+
+def _binder_asym_id(total_length: int, binder_length: int):
+    return jnp.concatenate(
+        (jnp.zeros(binder_length), jnp.ones(total_length - binder_length))
+    ).astype(jnp.int32)
+
+
+def complex_metrics(
+    prediction,
+    *,
+    binder_length: int,
+    binder_mask: np.ndarray | None = None,
+    target_mask: np.ndarray | None = None,
+    ipsae_cutoff: float | None = None,
+) -> ConfidenceMetrics:
+    """Confidence metrics for a binder/target complex prediction.
+
+    ``binder_mask`` / ``target_mask`` restrict the averages to the residues the
+    design actually optimises (DdCraft excludes fixed positions).
+    """
+    model_output = prediction.model_output
+    pae = normalized_symmetric_pae(prediction.pae)
+    total_length = pae.shape[0]
+    target_length = total_length - binder_length
+
+    if binder_mask is None:
+        binder_mask = np.ones(binder_length, dtype=np.float32)
+    if target_mask is None:
+        target_mask = np.ones(target_length, dtype=np.float32)
+
+    plddt = _masked_mean(np.asarray(prediction.plddt)[:binder_length], binder_mask)
+
+    ptm = float(
+        sp.predicted_tm_score(
+            logits=model_output.pae_logits,
+            bin_centers=model_output.pae_bins,
+            pair_mask=jnp.ones(pae.shape, dtype=bool),
+        ).max()
+    )
+
+    asym_id = _binder_asym_id(total_length, binder_length)
+    i_ptm = float(
+        sp.predicted_tm_score(
+            logits=model_output.pae_logits,
+            bin_centers=model_output.pae_bins,
+            pair_mask=asym_id[:, None] != asym_id[None, :],
+        ).max()
+    )
+
+    intra = _masked_mean(
+        pae[:binder_length], binder_mask[:, None] * np.ones((binder_length, total_length))
+    )
+    inter = _masked_mean(
+        pae[:binder_length, binder_length:], binder_mask[:, None] * target_mask[None, :]
+    )
+
+    ipsae = None
+    if ipsae_cutoff is not None:
+        ipsae = float(
+            jnp.max(
+                sp.interaction_prediction_score(
+                    logits=model_output.pae_logits,
+                    bin_centers=model_output.pae_bins,
+                    asym_id=asym_id,
+                    pae_cutoff=float(ipsae_cutoff),
+                )
+            )
+        )
+
+    return ConfidenceMetrics(
+        plddt=plddt, ptm=ptm, pae=intra, i_ptm=i_ptm, i_pae=inter, ipsae=ipsae
+    )
+
+
+def monomer_metrics(prediction) -> ConfidenceMetrics:
+    """Confidence metrics for a binder-alone prediction."""
+    model_output = prediction.model_output
+    pae = normalized_symmetric_pae(prediction.pae)
+    ptm = float(
+        sp.predicted_tm_score(
+            logits=model_output.pae_logits,
+            bin_centers=model_output.pae_bins,
+            pair_mask=jnp.ones(pae.shape, dtype=bool),
+        ).max()
+    )
+    return ConfidenceMetrics(
+        plddt=float(np.asarray(prediction.plddt).mean()),
+        ptm=ptm,
+        pae=float(pae.mean()),
+    )

--- a/src/mosaic/binder_design/mpnn.py
+++ b/src/mosaic/binder_design/mpnn.py
@@ -1,0 +1,145 @@
+"""Stage 2: ProteinMPNN sequence design on a trajectory backbone.
+
+Wraps :mod:`mosaic.proteinmpnn.sampling` with the position-fixing policy DdCraft
+uses: the target chain is always fixed, and optionally the interface residues
+found on the trajectory plus any user-specified positions.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from mosaic.proteinmpnn import sampling
+from mosaic.proteinmpnn.inputs import MPNNInputs, inputs_from_pdb, parse_fixed_positions
+from mosaic.proteinmpnn.mpnn import load_abmpnn, load_mpnn, load_mpnn_sol
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["DesignedSequence", "MPNNDesigner", "load_mpnn_weights"]
+
+_WEIGHTS = {
+    "original": load_mpnn,
+    "soluble": load_mpnn_sol,
+    "abmpnn": load_abmpnn,
+}
+
+
+def load_mpnn_weights(weights: str = "soluble", backbone_noise: float = 0.0):
+    """Load ProteinMPNN weights by DdCraft's ``mpnn_weights`` name."""
+    try:
+        loader = _WEIGHTS[weights]
+    except KeyError:
+        raise ValueError(
+            f"unknown mpnn weights {weights!r}, expected one of {sorted(_WEIGHTS)}"
+        ) from None
+    return loader(backbone_noise=backbone_noise)
+
+
+@dataclass
+class DesignedSequence:
+    """One MPNN design: the binder sequence plus its MPNN statistics."""
+
+    sequence: str
+    score: float | None
+    seqid: float | None
+    full_sequence: str
+
+    def as_dict(self) -> dict[str, float | str | None]:
+        return {
+            "Sequence": self.sequence,
+            "MPNN_score": self.score,
+            "MPNN_seq_recovery": self.seqid,
+        }
+
+
+class MPNNDesigner:
+    """Designs binder sequences for trajectory backbones."""
+
+    def __init__(
+        self,
+        *,
+        weights: str = "soluble",
+        backbone_noise: float = 0.0,
+        sampling_temp: float = 0.1,
+        num_seqs: int = 20,
+        omit_AAs: str = "C",
+        batch_size: int | None = None,
+    ):
+        self.model = load_mpnn_weights(weights, backbone_noise)
+        self.sampling_temp = sampling_temp
+        self.num_seqs = num_seqs
+        self.omit_AAs = omit_AAs
+        self.batch_size = batch_size
+
+    def fixed_positions(
+        self,
+        inputs: MPNNInputs,
+        *,
+        target_chain: str = "A",
+        interface_residues: str = "",
+        fix_pos: str = "",
+    ) -> np.ndarray:
+        """Resolve the positions MPNN must not redesign.
+
+        The target chain is always fixed; interface and user-specified residues
+        are added on top.  Mirrors DdCraft's ``mpnn_gen_sequence``.
+        """
+        spec = target_chain
+        if interface_residues:
+            spec += "," + interface_residues
+            logger.info("Fixing interface residues: %s", interface_residues)
+        if fix_pos:
+            spec += "," + fix_pos
+            logger.info("Fixing user-specified positions: %s", fix_pos)
+        spec = spec.rstrip(",")
+        logger.info("Total fixed positions for MPNN: %s", spec)
+        return parse_fixed_positions(spec, inputs)
+
+    def design(
+        self,
+        trajectory_pdb: str | Path,
+        *,
+        key,
+        binder_chain: str = "B",
+        target_chain: str = "A",
+        interface_residues: str = "",
+        fix_pos: str = "",
+        num_seqs: int | None = None,
+    ) -> list[DesignedSequence]:
+        inputs = inputs_from_pdb(trajectory_pdb, f"{target_chain},{binder_chain}")
+        fixed = self.fixed_positions(
+            inputs,
+            target_chain=target_chain,
+            interface_residues=interface_residues,
+            fix_pos=fix_pos,
+        )
+
+        samples = sampling.sample_batch(
+            self.model,
+            X=inputs.X,
+            S_native=inputs.S,
+            residue_idx=inputs.residue_idx,
+            chain_encoding_all=inputs.chain_index,
+            mask=inputs.mask,
+            key=key,
+            num_seqs=self.num_seqs if num_seqs is None else num_seqs,
+            batch_size=self.batch_size,
+            temperature=self.sampling_temp,
+            fix_pos=fixed,
+            omit_AAs=self.omit_AAs,
+        )
+
+        binder = inputs.chain_slice(binder_chain)
+        return [
+            DesignedSequence(
+                sequence=s.sequence[binder],
+                score=s.score,
+                seqid=s.seqid,
+                full_sequence=s.sequence,
+            )
+            for s in samples
+        ]

--- a/src/mosaic/binder_design/pipeline.py
+++ b/src/mosaic/binder_design/pipeline.py
@@ -1,0 +1,1171 @@
+"""The full binder design pipeline, running natively inside Mosaic.
+
+Four stages, all in one Python 3.12 process:
+
+1. **Trajectory** -- hallucinate a binder backbone against the target
+   (:mod:`mosaic.binder_design.trajectory`).
+2. **Sequence design** -- ProteinMPNN with fixed target/interface positions
+   (:mod:`mosaic.binder_design.mpnn`).
+3. **Validation** -- refold each design as a complex and on its own
+   (:mod:`mosaic.binder_design.validation`).
+4. **Filtering** -- PyRosetta interface scoring, DSSP secondary structure,
+   clash and RMSD checks (:mod:`mosaic.binder_design.rosetta`,
+   :mod:`mosaic.binder_design.geometry`, :mod:`mosaic.binder_design.filters`).
+
+Output layout and CSV columns match DdCraft so existing configs, filter files
+and analysis scripts keep working.
+"""
+
+from __future__ import annotations
+
+import csv
+import gc
+import json
+import logging
+import os
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar
+
+import jax
+import numpy as np
+
+from mosaic.binder_design import filters as filter_utils
+from mosaic.binder_design import geometry
+from mosaic.binder_design.components import create_structure_model, model_selection
+from mosaic.binder_design.io import normalize_binder_pdb, normalize_complex_pdb
+from mosaic.binder_design.labels import (
+    CORE_LABELS,
+    design_labels,
+    final_labels,
+)
+from mosaic.binder_design.mpnn import DesignedSequence, MPNNDesigner
+from mosaic.binder_design.validation import ComplexPredictor, MonomerPredictor
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["BinderDesignPipeline", "DesignRecord", "PipelineConfig"]
+
+DESIGN_DIRECTORIES = (
+    "Accepted",
+    "Accepted/Ranked",
+    "Accepted/Animation",
+    "Accepted/Plots",
+    "Accepted/Pickle",
+    "Trajectory",
+    "Trajectory/Relaxed",
+    "Trajectory/Plots",
+    "Trajectory/Clashing",
+    "Trajectory/LowConfidence",
+    "Trajectory/Animation",
+    "Trajectory/Pickle",
+    "MPNN",
+    "MPNN/Binder",
+    "MPNN/Sequences",
+    "MPNN/Relaxed",
+    "MPNN/Failed",
+    "Rejected",
+)
+
+
+def load_helicity(advanced_settings: dict[str, Any]) -> float:
+    """Per-trajectory helicity bias, sampled or preset, as DdCraft does."""
+    if advanced_settings.get("random_helicity") is True:
+        return round(float(np.random.uniform(-3, 1)), 2)
+    return float(advanced_settings.get("weights_helicity", 0) or 0)
+
+
+def generate_directories(design_path: str | Path) -> dict[str, str]:
+    """Create DdCraft's output tree and return the path lookup it uses."""
+    design_path = Path(design_path)
+    paths = {}
+    for name in DESIGN_DIRECTORIES:
+        directory = design_path / name
+        directory.mkdir(parents=True, exist_ok=True)
+        paths[name] = str(directory)
+    return paths
+
+
+@dataclass
+class PipelineConfig:
+    target_settings: dict[str, Any]
+    advanced_settings: dict[str, Any]
+    filters: dict[str, Any]
+
+    @property
+    def binder_chain(self) -> str:
+        return self.target_settings.get("binder_chain", "B")
+
+    @property
+    def target_chains(self) -> str:
+        return self.target_settings["chains"]
+
+    @property
+    def first_target_chain(self) -> str:
+        return self.target_chains.split(",")[0].strip()
+
+    @classmethod
+    def from_files(
+        cls,
+        target: str | Path,
+        advanced: str | Path,
+        filters: str | Path,
+        root: str | Path | None = None,
+    ) -> PipelineConfig:
+        config = cls(
+            target_settings=json.loads(Path(target).read_text()),
+            advanced_settings=json.loads(Path(advanced).read_text()),
+            filters=json.loads(Path(filters).read_text()),
+        )
+        config.resolve_paths(root)
+        return config
+
+    def resolve_paths(self, root: str | Path | None = None) -> None:
+        """Expand ``${DDCRAFT_DIR}`` and fill in the default asset locations.
+
+        Mirrors DdCraft's ``perform_advanced_settings_check`` so the same config
+        files work unchanged.
+        """
+        root = Path(root or os.environ.get("DDCRAFT_DIR", ".")).resolve()
+
+        for key, value in list(self.target_settings.items()):
+            if isinstance(value, str) and "${DDCRAFT_DIR}" in value:
+                self.target_settings[key] = value.replace("${DDCRAFT_DIR}", str(root))
+
+        defaults = {
+            "af_params_dir": str(root),
+            "dssp_path": str(root / "functions" / "dssp"),
+            "dalphaball_path": str(root / "functions" / "DAlphaBall.gcc"),
+        }
+        for key, default in defaults.items():
+            if not self.advanced_settings.get(key):
+                self.advanced_settings[key] = default
+
+        omit = self.advanced_settings.get("omit_AAs")
+        if omit in (None, False, ""):
+            self.advanced_settings["omit_AAs"] = None
+        elif isinstance(omit, str):
+            self.advanced_settings["omit_AAs"] = omit.strip()
+
+    def validation_models(self) -> list[int]:
+        """AF2 models used for validation.
+
+        DdCraft keeps design and validation models disjoint when designing with
+        the multimer weights, so validation never sees a model that shaped the
+        backbone.
+        """
+        configured = self.advanced_settings.get("predict_models")
+        if configured:
+            return [int(m) for m in configured]
+        if self.advanced_settings.get("use_multimer_design", True):
+            return [3, 4]
+        return [0, 1, 2, 3, 4]
+
+
+@dataclass
+class DesignRecord:
+    """One MPNN design with every metric the filters can reference."""
+
+    name: str
+    sequence: str
+    values: dict[str, Any] = field(default_factory=dict)
+    accepted: bool = False
+    unmet: list[str] = field(default_factory=list)
+
+    def row(self, labels: Iterable[str]) -> list[Any]:
+        return [self.values.get(label) for label in labels]
+
+
+def _average(values: list[Any]) -> Any:
+    present = [v for v in values if v is not None]
+    if not present:
+        return None
+    if isinstance(present[0], dict):
+        keys = set().union(*(set(v) for v in present))
+        return {k: float(np.mean([v.get(k, 0) for v in present])) for k in keys}
+    return float(np.mean(present))
+
+
+def _spread(
+    values: dict[int, dict[str, Any]], model_indices: list[int]
+) -> dict[str, Any]:
+    """Turn per-model metric dicts into DdCraft's Average_/1_../5_ columns."""
+    out: dict[str, Any] = {}
+    for label in CORE_LABELS:
+        per_model = []
+        for model_number in range(1, 6):
+            value = values.get(model_number, {}).get(label)
+            out[f"{model_number}_{label}"] = value
+            if model_number in [i + 1 for i in model_indices]:
+                per_model.append(value)
+        out[f"Average_{label}"] = _average(per_model)
+    return out
+
+
+class BinderDesignPipeline:
+    """Runs stages 2-4 for trajectories produced by stage 1."""
+
+    def __init__(
+        self,
+        config: PipelineConfig,
+        *,
+        design_paths: dict[str, str] | None = None,
+        structure_model=None,
+    ):
+        self.config = config
+        self.target_settings = config.target_settings
+        self.advanced_settings = config.advanced_settings
+        self.filters = config.filters
+        self.design_paths = design_paths or generate_directories(
+            self.target_settings["design_path"]
+        )
+
+        self.hallucination_selection = model_selection(
+            self.advanced_settings, "hallucination"
+        )
+        self.folding_selection = model_selection(self.advanced_settings, "folding")
+        self._designer = None
+        self._rosetta = None
+        self._structure_model = structure_model
+        self._monomer_model = None
+        self.design_labels = design_labels()
+        self.final_labels = final_labels()
+        self._seen_sequences: set[str] = set()
+
+    @property
+    def designer(self) -> MPNNDesigner:
+        """Load ProteinMPNN only when sequence design is actually requested."""
+        if self._designer is None:
+            self._designer = MPNNDesigner(
+                weights=self.advanced_settings.get("mpnn_weights", "soluble"),
+                backbone_noise=float(self.advanced_settings.get("backbone_noise", 0.0)),
+                sampling_temp=float(self.advanced_settings.get("sampling_temp", 0.1)),
+                num_seqs=int(self.advanced_settings.get("num_seqs", 20)),
+                omit_AAs=self.advanced_settings.get("omit_AAs", "C"),
+            )
+        return self._designer
+
+    def _load_rosetta(self):
+        """Import and initialize PyRosetta only for filters that need it."""
+        if self._rosetta is None:
+            from mosaic.binder_design import rosetta
+
+            rosetta.init_pyrosetta(self.advanced_settings.get("dalphaball_path", ""))
+            self._rosetta = rosetta
+        return self._rosetta
+
+    def load_seen_sequences(self, mpnn_csv: str | Path) -> int:
+        """Remember sequences already in the CSV so a resumed run skips them."""
+        mpnn_csv = Path(mpnn_csv)
+        if not mpnn_csv.exists():
+            return 0
+        with mpnn_csv.open(newline="") as handle:
+            for row in csv.DictReader(handle):
+                sequence = (row.get("Sequence") or "").strip()
+                if sequence:
+                    self._seen_sequences.add(sequence)
+        return len(self._seen_sequences)
+
+    @property
+    def structure_model(self):
+        """The folding model used to validate the binder/target complex."""
+        if self._structure_model is None:
+            self._structure_model = create_structure_model(
+                self.folding_selection,
+                self.advanced_settings,
+            )
+        return self._structure_model
+
+    @property
+    def monomer_model(self):
+        """The folding model used to predict the binder on its own.
+
+        Deliberately *not* the complex model. DdCraft builds the binder-alone
+        predictor with ``use_multimer=False``, and the multimer network scores a
+        lone chain systematically lower: reusing it here failed
+        ``5_Binder_pLDDT`` on 38% of designs where DdCraft failed none.
+        """
+        if self._monomer_model is None:
+            if self.folding_selection.name == "af2":
+                self._monomer_model = create_structure_model(
+                    self.folding_selection,
+                    self.advanced_settings,
+                    multimer=False,
+                    model_numbers=tuple(i + 1 for i in self._model_indices()),
+                )
+            else:
+                self._monomer_model = self.structure_model
+        return self._monomer_model
+
+    # -- stage 2 ---------------------------------------------------------
+
+    def _interface_spec(self, trajectory_pdb: str) -> tuple[str, list[int]]:
+        interface = geometry.hotspot_residues(
+            trajectory_pdb,
+            binder_chain=self.config.binder_chain,
+            atom_distance_cutoff=4.0,
+        )
+        residues = list(interface.keys())
+        spec = ",".join(f"{self.config.binder_chain}{r}" for r in residues)
+        return spec, residues
+
+    def design_sequences(
+        self, trajectory_pdb: str, *, key
+    ) -> tuple[list[DesignedSequence], str]:
+        interface_spec, _ = (
+            self._interface_spec(trajectory_pdb)
+            if self.advanced_settings.get("mpnn_fix_interface", True)
+            else ("", [])
+        )
+        sequences = self.designer.design(
+            trajectory_pdb,
+            key=key,
+            binder_chain=self.config.binder_chain,
+            target_chain=self.config.first_target_chain,
+            interface_residues=interface_spec,
+            fix_pos=self.target_settings.get("fix_pos", ""),
+        )
+        return self._rank_sequences(sequences), interface_spec
+
+    def _rank_sequences(
+        self, sequences: list[DesignedSequence]
+    ) -> list[DesignedSequence]:
+        """Deduplicate, drop restricted sequences and sort by MPNN score.
+
+        Every survivor is returned. ``max_mpnn_sequences`` is *not* applied
+        here: DdCraft treats it as a cap on how many designs may be **accepted**
+        per trajectory, and keeps evaluating candidates until it is reached.
+        """
+        restricted = self._restricted_amino_acids()
+        best: dict[str, DesignedSequence] = {}
+        for sequence in sequences:
+            if sequence.sequence in self._seen_sequences:
+                continue
+            if restricted and any(aa in sequence.sequence.upper() for aa in restricted):
+                continue
+            existing = best.get(sequence.sequence)
+            if existing is None or sequence.score < existing.score:
+                best[sequence.sequence] = sequence
+        return sorted(best.values(), key=lambda s: s.score)
+
+    def _restricted_amino_acids(self) -> set[str]:
+        if not self.advanced_settings.get("force_reject_AA", False):
+            return set()
+        omit = str(self.advanced_settings.get("omit_AAs", ""))
+        return {aa.strip().upper() for aa in omit.split(",") if aa.strip()}
+
+    # -- stage 1 ---------------------------------------------------------
+
+    def design_models(self) -> list[int]:
+        """Configured members/samples used for the trajectory stage."""
+        if self.hallucination_selection.members is not None:
+            return list(self.hallucination_selection.members)
+        if self.hallucination_selection.name != "af2":
+            return [0]
+        configured_numbers = self.hallucination_selection.options.get("model_numbers")
+        if configured_numbers is not None:
+            return [int(number) - 1 for number in configured_numbers]
+        if self.advanced_settings.get("use_multimer_design", True):
+            return [0, 1, 2]
+        return [0, 1]
+
+    def sample_seed(self, rng) -> int:
+        return int(rng.integers(0, 999999))
+
+    def sample_length(self, rng) -> int:
+        min_length, max_length = self.target_settings["lengths"]
+        return int(rng.integers(min_length, max_length + 1))
+
+    def generate_trajectory(self, *, seed: int, length: int):
+        """Hallucinate one binder backbone.
+
+        Returns ``(pdb, metrics)`` where ``pdb`` is ``None`` when the backbone
+        was rejected as clashing or low confidence, matching DdCraft, which
+        files those trajectories away instead of designing sequences for them.
+        """
+        from mosaic.binder_design.trajectory import run_job
+
+        design_name = f"{self.target_settings['binder_name']}_l{length}_s{seed}"
+        raw_dir = Path(self.target_settings["design_path"]) / "Mosaic" / "Raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        raw_pdb = raw_dir / f"{design_name}.pdb"
+
+        target_chains = [
+            chain.strip()
+            for chain in str(self.target_settings["chains"]).split(",")
+            if chain.strip()
+        ]
+        binder_chain = str(self.target_settings.get("binder_chain", "")).strip()
+
+        result = run_job(
+            {
+                "schema_version": 1,
+                "design_name": design_name,
+                "seed": seed,
+                "length": length,
+                "helicity_value": load_helicity(self.advanced_settings),
+                "starting_pdb": self.target_settings["starting_pdb"],
+                "target_chains": target_chains,
+                "binder_chain": binder_chain,
+                "target_settings": self.target_settings,
+                "advanced_settings": self.advanced_settings,
+                "design_models": self.design_models(),
+                "af_params_dir": self.advanced_settings["af_params_dir"],
+                "output_pdb": str(raw_pdb),
+            }
+        )
+
+        trajectory_pdb = Path(self.design_paths["Trajectory"]) / f"{design_name}.pdb"
+        normalize_complex_pdb(
+            raw_pdb=raw_pdb,
+            output_pdb=trajectory_pdb,
+            starting_pdb=Path(self.target_settings["starting_pdb"]),
+            target_chain_ids=target_chains,
+            binder_chain_id=binder_chain or self.config.binder_chain,
+            binder_length=length,
+            structure_conditioned=bool(binder_chain),
+        )
+        raw_pdb.unlink(missing_ok=True)
+
+        metrics = result.get("metrics", {})
+        rejection = self._trajectory_rejection(trajectory_pdb, result)
+        if rejection is not None:
+            (Path(self.design_paths[rejection]) / trajectory_pdb.name).write_bytes(
+                trajectory_pdb.read_bytes()
+            )
+            trajectory_pdb.unlink()
+            logger.warning("Trajectory %s filed under %s", design_name, rejection)
+            return None, metrics
+        return trajectory_pdb, metrics
+
+    def _trajectory_rejection(self, trajectory_pdb: Path, result: dict) -> str | None:
+        """Where a backbone belongs, or ``None`` when it is usable."""
+        if result.get("status") == "low_confidence":
+            return "Trajectory/LowConfidence"
+
+        plddt = result.get("metrics", {}).get("plddt")
+        threshold = self.advanced_settings.get("start_monitoring_plddt")
+        if (
+            plddt is not None
+            and threshold is not None
+            and float(plddt) < float(threshold)
+        ):
+            return "Trajectory/LowConfidence"
+
+        clashes = geometry.calculate_clash_score(str(trajectory_pdb), 2.4)
+        limit = self.advanced_settings.get("max_trajectory_clashes")
+        if limit is not None and clashes > float(limit):
+            return "Trajectory/Clashing"
+        return None
+
+    # -- stages 3 and 4 --------------------------------------------------
+
+    def _model_indices(self) -> list[int]:
+        selection = getattr(self, "folding_selection", None)
+        if selection is None:
+            validation_models = getattr(self.config, "validation_models", None)
+            if validation_models is not None:
+                return validation_models()
+            return [
+                int(member)
+                for member in self.advanced_settings.get("predict_models", [3, 4])
+            ]
+        if selection.members is not None:
+            return list(selection.members)
+        if selection.name == "af2":
+            configured_numbers = selection.options.get("model_numbers")
+            if configured_numbers is not None:
+                return [int(number) - 1 for number in configured_numbers]
+            return self.config.validation_models()
+        return list(self.structure_model.ensemble_members())
+
+    def _folding_sampling_steps(self) -> int | None:
+        selection = getattr(self, "folding_selection", None)
+        return None if selection is None else selection.sampling_steps
+
+    #: Metrics the complex prediction yields directly. The gate below must not
+    #: reference anything computed later (binder-alone confidences, PyRosetta
+    #: scores), otherwise every design fails on a missing value.
+    BASE_METRICS = ("pLDDT", "pTM", "i_pTM", "pAE", "i_pAE", "IPSAE")
+
+    MONOMER_METRICS = frozenset(
+        {
+            "Binder_pLDDT",
+            "Binder_pTM",
+            "Binder_pAE",
+            "Binder_RMSD",
+        }
+    )
+    PYROSETTA_METRICS = frozenset(
+        {
+            "Relaxed_Clashes",
+            "Binder_Energy_Score",
+            "Surface_Hydrophobicity",
+            "ShapeComplementarity",
+            "PackStat",
+            "dG",
+            "dSASA",
+            "dG/dSASA",
+            "Interface_SASA_%",
+            "Interface_Hydrophobicity",
+            "n_InterfaceResidues",
+            "n_InterfaceHbonds",
+            "InterfaceHbondsPercentage",
+            "n_InterfaceUnsatHbonds",
+            "InterfaceUnsatHbondsPercentage",
+        }
+    )
+    SECONDARY_STRUCTURE_METRICS = frozenset(
+        {
+            "Binder_Helix%",
+            "Binder_BetaSheet%",
+            "Binder_Loop%",
+            "Interface_Helix%",
+            "Interface_BetaSheet%",
+            "Interface_Loop%",
+            "i_pLDDT",
+            "ss_pLDDT",
+        }
+    )
+    STRUCTURE_METRICS = frozenset(
+        set(CORE_LABELS) - set(BASE_METRICS) - MONOMER_METRICS
+    )
+    EVALUATION_METRIC_GROUPS: ClassVar[dict[str, frozenset[str]]] = {
+        # Complex confidence is always returned by the folding model. Keeping
+        # it as an explicit group makes batch manifests self-describing.
+        "confidence": frozenset(BASE_METRICS),
+        # Binder_RMSD uses PyRosetta alignment, so the weight-free monomer group
+        # contains only confidence values from the binder-alone fold.
+        "monomer": frozenset(
+            {"Binder_pLDDT", "Binder_pTM", "Binder_pAE"}
+        ),
+        "geometry": frozenset(
+            {"Unrelaxed_Clashes", "Hotspot_RMSD", "Target_RMSD", "InterfaceAAs"}
+        ),
+        "dssp": SECONDARY_STRUCTURE_METRICS,
+        "pyrosetta": frozenset({*PYROSETTA_METRICS, "Binder_RMSD"}),
+    }
+
+    @staticmethod
+    def _base_metric_name(label: str) -> str:
+        if label.startswith("Average_"):
+            return label[len("Average_") :]
+        prefix, separator, remainder = label.partition("_")
+        if separator and prefix in {"1", "2", "3", "4", "5"}:
+            return remainder
+        return label
+
+    def _active_metrics(self) -> set[str]:
+        """Metrics requested explicitly or by a non-null filter threshold.
+
+        ``evaluation_metric_groups`` requests computation only. Acceptance is
+        still controlled exclusively by ``filters``. This separation lets an
+        evaluator collect PyRosetta or DSSP distributions before choosing any
+        thresholds and keeps those dependencies lazy when no group/filter asks
+        for them.
+        """
+        active: set[str] = set()
+        configured_groups = getattr(self, "advanced_settings", {}).get(
+            "evaluation_metric_groups", []
+        ) or []
+        if isinstance(configured_groups, str):
+            configured_groups = [configured_groups]
+        if not isinstance(configured_groups, (list, tuple, set)):
+            raise TypeError("evaluation_metric_groups must be a JSON array or string")
+        for group in configured_groups:
+            name = str(group).strip().lower()
+            try:
+                active.update(self.EVALUATION_METRIC_GROUPS[name])
+            except KeyError:
+                choices = ", ".join(self.EVALUATION_METRIC_GROUPS)
+                raise ValueError(
+                    f"Unknown evaluation metric group '{group}'. Choose one of: {choices}"
+                ) from None
+        for label, conditions in self.filters.items():
+            if self._base_metric_name(label) == "InterfaceAAs":
+                if any(
+                    condition.get("threshold") is not None
+                    for condition in conditions.values()
+                ):
+                    active.add("InterfaceAAs")
+            elif conditions.get("threshold") is not None:
+                active.add(self._base_metric_name(label))
+        return active
+
+    def _base_confidence_filters_pass(self, values: dict[str, Any]) -> list[str]:
+        """Cheap confidence gate, run before any PyRosetta work.
+
+        Only the *per-model* thresholds of the models actually predicted apply,
+        exactly as in ``predict_binder_complex``. The ``Average_*`` thresholds
+        deliberately play no part: they are enforced later, on the full record.
+
+        The distinction is not academic. Validation runs models 4 and 5, and
+        production filter sets leave ``4_*``/``5_*`` at ``null`` while setting
+        ``Average_*``, which makes this gate a no-op there. Including the
+        averages rejected 45% of designs before they were ever scored.
+        """
+        labels = {
+            f"{index}_{metric}"
+            for index in (i + 1 for i in self._model_indices())
+            for metric in self.BASE_METRICS
+        }
+        cheap = {
+            label: conditions
+            for label, conditions in self.filters.items()
+            if label in labels
+        }
+        return filter_utils.unmet_filters(values, cheap)
+
+    # Backward-compatible private name for callers/tests from the AF2-only era.
+    _base_af2_filters_pass = _base_confidence_filters_pass
+
+    def evaluate_design(
+        self,
+        design: DesignedSequence,
+        *,
+        design_name: str,
+        trajectory_pdb: str,
+        complex_predictor: ComplexPredictor,
+        monomer_predictor: MonomerPredictor | None,
+        key,
+        reference_pdb: str | None = None,
+        configured_only: bool = False,
+    ) -> DesignRecord:
+        model_indices = self._model_indices()
+        reference_pdb = reference_pdb or trajectory_pdb
+        requested_metrics = self._active_metrics() if configured_only else None
+        record = DesignRecord(name=design_name, sequence=design.sequence)
+        record.values.update(
+            {
+                "Design": design_name,
+                "Protocol": f"folding:{self.folding_selection.name}",
+                "Sequence": design.sequence,
+                "Length": len(design.sequence),
+                "MPNN_score": design.score,
+                "MPNN_seq_recovery": design.seqid,
+            }
+        )
+
+        key, complex_key, monomer_key = jax.random.split(key, 3)
+        predictions = complex_predictor.predict(
+            design.sequence, key=complex_key, model_indices=model_indices
+        )
+
+        per_model: dict[int, dict[str, Any]] = {}
+        complex_pdbs: dict[int, str] = {}
+        for prediction in predictions:
+            model_number = prediction.model_index + 1
+            metrics = prediction.metrics
+            per_model[model_number] = {
+                "pLDDT": metrics.plddt,
+                "pTM": metrics.ptm,
+                "i_pTM": metrics.i_ptm,
+                "pAE": metrics.pae,
+                "i_pAE": metrics.i_pae,
+                "IPSAE": metrics.ipsae,
+            }
+            raw = prediction.write_pdb(
+                Path(self.design_paths["MPNN"])
+                / f"{design_name}_model{model_number}.raw.pdb"
+            )
+            complex_pdbs[model_number] = str(
+                normalize_complex_pdb(
+                    raw,
+                    Path(self.design_paths["MPNN"])
+                    / f"{design_name}_model{model_number}.pdb",
+                    reference_pdb,
+                    [
+                        c.strip()
+                        for c in self.config.target_chains.split(",")
+                        if c.strip()
+                    ],
+                    self.config.binder_chain,
+                    len(design.sequence),
+                    structure_conditioned=configured_only,
+                )
+            )
+            raw.unlink()
+
+        record.values.update(_spread(per_model, model_indices))
+
+        unmet = self._base_confidence_filters_pass(record.values)
+        if unmet:
+            record.unmet = unmet
+            return record
+
+        logger.info(
+            "%s passed confidence filters, proceeding with requested calculations",
+            design_name,
+        )
+
+        needs_monomer = requested_metrics is None or bool(
+            requested_metrics & self.MONOMER_METRICS
+        )
+        if needs_monomer:
+            if monomer_predictor is None:
+                raise RuntimeError(
+                    "monomer predictor is required by the active filters"
+                )
+            monomer = monomer_predictor.predict(
+                design.sequence, key=monomer_key, model_indices=model_indices
+            )
+            for prediction in monomer:
+                model_number = prediction.model_index + 1
+                raw = prediction.write_pdb(
+                    Path(self.design_paths["MPNN/Binder"])
+                    / f"{design_name}_model{model_number}.raw.pdb"
+                )
+                binder_pdb = normalize_binder_pdb(
+                    raw,
+                    Path(self.design_paths["MPNN/Binder"])
+                    / f"{design_name}_model{model_number}.pdb",
+                    len(design.sequence),
+                )
+                raw.unlink()
+                metrics = {
+                    "Binder_pLDDT": prediction.metrics.plddt,
+                    "Binder_pTM": prediction.metrics.ptm,
+                    "Binder_pAE": prediction.metrics.pae,
+                }
+                if requested_metrics is None or "Binder_RMSD" in requested_metrics:
+                    rosetta = self._load_rosetta()
+                    rosetta.align_pdbs(
+                        reference_pdb,
+                        str(binder_pdb),
+                        self.config.binder_chain,
+                        "A",
+                    )
+                    metrics["Binder_RMSD"] = rosetta.unaligned_rmsd(
+                        reference_pdb,
+                        str(binder_pdb),
+                        self.config.binder_chain,
+                        "A",
+                    )
+                per_model[model_number].update(metrics)
+                if self.advanced_settings.get("remove_binder_monomer", True):
+                    binder_pdb.unlink(missing_ok=True)
+
+        needs_structure_scores = requested_metrics is None or bool(
+            requested_metrics & self.STRUCTURE_METRICS
+        )
+        if needs_structure_scores:
+            for model_number, complex_pdb in complex_pdbs.items():
+                per_model[model_number].update(
+                    self._score_structure(
+                        complex_pdb,
+                        design_name,
+                        model_number,
+                        reference_pdb,
+                        requested_metrics=requested_metrics,
+                    )
+                )
+
+        record.values.update(_spread(per_model, model_indices))
+        unmet = filter_utils.unmet_filters(record.values, self.filters)
+        record.unmet = unmet
+        record.accepted = not unmet
+        return record
+
+    def _score_structure(
+        self,
+        complex_pdb: str,
+        design_name: str,
+        model_number: int,
+        trajectory_pdb: str,
+        *,
+        requested_metrics: set[str] | None = None,
+    ) -> dict[str, Any]:
+        """Run only the requested structure-filter groups for one complex."""
+        binder_chain = self.config.binder_chain
+
+        def wants(metric: str) -> bool:
+            return requested_metrics is None or metric in requested_metrics
+
+        values: dict[str, Any] = {}
+        if wants("Unrelaxed_Clashes"):
+            values["Unrelaxed_Clashes"] = geometry.calculate_clash_score(
+                complex_pdb, 2.4
+            )
+
+        relaxed_pdb = str(
+            Path(self.design_paths["MPNN/Relaxed"])
+            / f"{design_name}_model{model_number}.pdb"
+        )
+        needs_pyrosetta = requested_metrics is None or bool(
+            requested_metrics & self.PYROSETTA_METRICS
+        )
+        scored_pdb = complex_pdb
+        interface_aa = None
+        if needs_pyrosetta:
+            rosetta = self._load_rosetta()
+            rosetta.pr_relax(complex_pdb, relaxed_pdb, binder_chain=binder_chain)
+            scores, interface_aa, _ = rosetta.score_interface(
+                relaxed_pdb, binder_chain=binder_chain
+            )
+            scored_pdb = relaxed_pdb
+            score_map = {
+                "Binder_Energy_Score": "binder_score",
+                "Surface_Hydrophobicity": "surface_hydrophobicity",
+                "ShapeComplementarity": "interface_sc",
+                "PackStat": "interface_packstat",
+                "dG": "interface_dG",
+                "dSASA": "interface_dSASA",
+                "dG/dSASA": "interface_dG_SASA_ratio",
+                "Interface_SASA_%": "interface_fraction",
+                "Interface_Hydrophobicity": "interface_hydrophobicity",
+                "n_InterfaceResidues": "interface_nres",
+                "n_InterfaceHbonds": "interface_interface_hbonds",
+                "InterfaceHbondsPercentage": "interface_hbond_percentage",
+                "n_InterfaceUnsatHbonds": "interface_delta_unsat_hbonds",
+                "InterfaceUnsatHbondsPercentage": (
+                    "interface_delta_unsat_hbonds_percentage"
+                ),
+            }
+            for metric, score_key in score_map.items():
+                if wants(metric):
+                    values[metric] = scores.get(score_key)
+            if wants("Relaxed_Clashes"):
+                values["Relaxed_Clashes"] = geometry.calculate_clash_score(
+                    relaxed_pdb, 2.4
+                )
+
+        if wants("InterfaceAAs"):
+            if interface_aa is None:
+                interface_aa = {aa: 0 for aa in "ACDEFGHIKLMNPQRSTVWY"}
+                for amino_acid in geometry.hotspot_residues(
+                    scored_pdb, binder_chain=binder_chain
+                ).values():
+                    if amino_acid in interface_aa:
+                        interface_aa[amino_acid] += 1
+            values["InterfaceAAs"] = interface_aa
+
+        if requested_metrics is None or bool(
+            requested_metrics & self.SECONDARY_STRUCTURE_METRICS
+        ):
+            # (binder helix/sheet/loop, interface helix/sheet/loop,
+            #  interface pLDDT, secondary-structure pLDDT)
+            ss = geometry.calc_ss_percentage(
+                scored_pdb, self.advanced_settings, binder_chain
+            )
+            for metric, value in zip(
+                (
+                    "Binder_Helix%",
+                    "Binder_BetaSheet%",
+                    "Binder_Loop%",
+                    "Interface_Helix%",
+                    "Interface_BetaSheet%",
+                    "Interface_Loop%",
+                    "i_pLDDT",
+                    "ss_pLDDT",
+                ),
+                ss,
+            ):
+                if wants(metric):
+                    values[metric] = value
+
+        if wants("Hotspot_RMSD"):
+            values["Hotspot_RMSD"] = geometry.hotspot_rmsd(
+                trajectory_pdb,
+                scored_pdb,
+                self.config.first_target_chain,
+                binder_chain,
+            )
+        if wants("Target_RMSD"):
+            values["Target_RMSD"] = geometry.chain_rmsd(
+                trajectory_pdb, scored_pdb, self.config.first_target_chain
+            )
+        return values
+
+    # -- drivers ---------------------------------------------------------
+
+    def evaluate_pdb(
+        self,
+        complex_pdb: str | Path,
+        *,
+        key,
+        design_name: str | None = None,
+    ) -> DesignRecord:
+        """Evaluate an existing binder/target complex without hallucination or MPNN.
+
+        The binder sequence is read from ``config.binder_chain`` in the input
+        PDB. The configured folding model refolds the complex, then only filter
+        groups with active thresholds are run. This makes confidence-only,
+        model+DSSP/geometry, and model+PyRosetta evaluation independent entry
+        points into the same result schema.
+        """
+        import gemmi
+
+        complex_pdb = Path(complex_pdb)
+        if not complex_pdb.is_file():
+            raise FileNotFoundError(f"Evaluation PDB not found: {complex_pdb}")
+        structure = gemmi.read_structure(str(complex_pdb))
+        if not len(structure):
+            raise ValueError(f"No model found in evaluation PDB: {complex_pdb}")
+        chains = {chain.name: chain for chain in structure[0]}
+        required = {
+            self.config.binder_chain,
+            *(
+                chain.strip()
+                for chain in self.config.target_chains.split(",")
+                if chain.strip()
+            ),
+        }
+        missing = sorted(required - set(chains))
+        if missing:
+            raise ValueError(
+                f"{complex_pdb}: required chains {', '.join(missing)} not found"
+            )
+        sequence = gemmi.one_letter_code(
+            [residue.name for residue in chains[self.config.binder_chain]]
+        ).upper()
+        if not sequence or "X" in sequence:
+            raise ValueError(
+                f"{complex_pdb}: binder chain {self.config.binder_chain} has "
+                "missing or unsupported protein residues"
+            )
+
+        started = time.time()
+        model_indices = self._model_indices()
+        complex_predictor = ComplexPredictor(
+            self.structure_model,
+            target_pdb=complex_pdb,
+            target_chains=self.config.target_chains,
+            binder_length=len(sequence),
+            recycling_steps=self._recycling_steps(),
+            model_indices=model_indices,
+            sampling_steps=self._folding_sampling_steps(),
+            ipsae_cutoff=self._ipsae_cutoff(),
+            advanced_settings=self.advanced_settings,
+        )
+        active_metrics = self._active_metrics()
+        monomer_predictor = None
+        if active_metrics & self.MONOMER_METRICS:
+            monomer_predictor = MonomerPredictor(
+                self.monomer_model,
+                binder_length=len(sequence),
+                recycling_steps=self._recycling_steps(),
+                model_indices=model_indices,
+                sampling_steps=self._folding_sampling_steps(),
+            )
+
+        name = design_name or complex_pdb.stem
+        design = DesignedSequence(
+            sequence=sequence,
+            score=None,
+            seqid=None,
+            full_sequence=sequence,
+        )
+        record = self.evaluate_design(
+            design,
+            design_name=name,
+            trajectory_pdb=str(complex_pdb),
+            reference_pdb=str(complex_pdb),
+            complex_predictor=complex_predictor,
+            monomer_predictor=monomer_predictor,
+            key=key,
+            configured_only=True,
+        )
+        record.values["Protocol"] = f"evaluation:{self.folding_selection.name}"
+        record.values["DesignTime"] = round(time.time() - started, 2)
+        return record
+
+    def run_trajectory(self, trajectory_pdb: str | Path, *, key) -> list[DesignRecord]:
+        """Stages 2-4 for one trajectory backbone."""
+        trajectory_pdb = str(trajectory_pdb)
+        stem = Path(trajectory_pdb).stem
+        started = time.time()
+
+        length = geometry.get_chain_length(trajectory_pdb, self.config.binder_chain)
+        key, design_key = jax.random.split(key)
+        sequences, interface_spec = self.design_sequences(
+            trajectory_pdb, key=design_key
+        )
+        if not sequences:
+            logger.warning("No valid MPNN sequences generated for %s", stem)
+            return []
+
+        complex_predictor = ComplexPredictor(
+            self.structure_model,
+            target_pdb=self.target_settings["starting_pdb"],
+            target_chains=self.config.target_chains,
+            binder_length=length,
+            recycling_steps=self._recycling_steps(),
+            model_indices=self._model_indices(),
+            sampling_steps=self._folding_sampling_steps(),
+            ipsae_cutoff=self._ipsae_cutoff(),
+            advanced_settings=self.advanced_settings,
+        )
+        monomer_predictor = MonomerPredictor(
+            self.monomer_model,
+            binder_length=length,
+            recycling_steps=self._recycling_steps(),
+            model_indices=self._model_indices(),
+            sampling_steps=self._folding_sampling_steps(),
+        )
+
+        records = []
+        accepted_target = int(self.advanced_settings.get("max_mpnn_sequences", 2) or 0)
+        accepted_count = 0
+        for number, design in enumerate(sequences, start=1):
+            if accepted_target and accepted_count >= accepted_target:
+                logger.debug(
+                    "%s reached %d accepted designs, skipping the remaining %d "
+                    "candidates",
+                    stem,
+                    accepted_count,
+                    len(sequences) - number + 1,
+                )
+                break
+            key, design_key = jax.random.split(key)
+            try:
+                record = self.evaluate_design(
+                    design,
+                    design_name=f"{stem}_mpnn{number}",
+                    trajectory_pdb=trajectory_pdb,
+                    complex_predictor=complex_predictor,
+                    monomer_predictor=monomer_predictor,
+                    key=design_key,
+                )
+            except Exception:
+                # PyRosetta occasionally fails on a single structure. DdCraft
+                # logs and moves to the next candidate rather than abandoning
+                # every remaining trajectory, so a transient error costs one
+                # design instead of the whole run.
+                logger.exception("Error processing %s_mpnn%d", stem, number)
+                self._seen_sequences.add(design.sequence)
+                continue
+            record.values.setdefault("InterfaceResidues", interface_spec)
+            record.values.setdefault("DesignTime", round(time.time() - started, 2))
+            records.append(record)
+            self._seen_sequences.add(design.sequence)
+            accepted_count += bool(record.accepted)
+            logger.info(
+                "%s %s", record.name, "ACCEPTED" if record.accepted else "FILTER_FAIL"
+            )
+
+        gc.collect()
+        return records
+
+    def _recycling_steps(self) -> int:
+        """Forward passes for validation.
+
+        ColabDesign runs ``num_recycles + 1`` passes, while Mosaic's recycling
+        scan length *is* the number of passes. The same off-by-one bit stage 1
+        and showed up there as systematically lower pLDDT.
+        """
+        return int(self.advanced_settings.get("num_recycles_validation", 3)) + 1
+
+    def _ipsae_cutoff(self) -> float | None:
+        config = self.advanced_settings.get("ipsae", {})
+        if isinstance(config, dict) and config.get("enabled", False):
+            return float(config.get("cutoff", 10.0))
+        return None
+
+    def accepted_design_count(self) -> int:
+        """How many accepted designs are on disk.
+
+        Counted from the Accepted directory rather than from this run's tally so
+        that a resumed run stops at the same total, which is how DdCraft decides
+        it has enough.
+        """
+        accepted = Path(self.design_paths["Accepted"])
+        if not accepted.exists():
+            return 0
+        return sum(1 for f in accepted.iterdir() if f.suffix == ".pdb")
+
+    def file_design(self, record: DesignRecord) -> Path | None:
+        """Copy a design's best model into ``Accepted`` or ``Rejected``.
+
+        DdCraft keeps one representative structure per design, picked by mean CA
+        B-factor (the relaxed PDBs carry pLDDT there), so downstream tooling can
+        glob a single directory instead of five per-model files.
+        """
+        best = self._best_model_pdb(record.name)
+        if best is None:
+            logger.warning("No folded model found for %s", record.name)
+            return None
+        folder = "Accepted" if record.accepted else "Rejected"
+        destination = Path(self.design_paths[folder]) / f"{record.name}.pdb"
+        destination.write_bytes(best.read_bytes())
+        return destination
+
+    def _best_model_pdb(self, design_name: str) -> Path | None:
+        best: tuple[float, Path] | None = None
+        # Prefer relaxed structures when PyRosetta ran. Confidence-only and
+        # geometry-only evaluation intentionally produce only the folded PDBs.
+        for directory in ("MPNN/Relaxed", "MPNN"):
+            for model in range(1, 6):
+                path = Path(self.design_paths[directory]) / (
+                    f"{design_name}_model{model}.pdb"
+                )
+                if not path.exists():
+                    continue
+                try:
+                    score = geometry.mean_ca_bfactor(str(path))
+                except Exception as error:  # noqa: BLE001 - one bad PDB is skippable
+                    logger.warning("Cannot rank folded model %s: %s", path, error)
+                    continue
+                if score is None:
+                    continue
+                if best is None or score > best[0]:
+                    best = (score, path)
+            if best is not None:
+                break
+        return best[1] if best else None
+
+    def write_final_csv(self, mpnn_csv: str | Path, final_csv: str | Path) -> int:
+        """Rank the accepted designs by ``Average_i_pTM`` and record them.
+
+        Mirrors DdCraft's ``check_accepted_designs``: ranked copies land in
+        ``Accepted/Ranked`` with a rank prefix, and the CSV is rewritten from
+        scratch so re-running after more designs land renumbers everything.
+        """
+        mpnn_csv, final_csv = Path(mpnn_csv), Path(final_csv)
+        accepted_dir = Path(self.design_paths["Accepted"])
+        ranked_dir = Path(self.design_paths["Accepted/Ranked"])
+        accepted = {path.stem: path for path in accepted_dir.glob("*.pdb")}
+        if not accepted or not mpnn_csv.exists():
+            return 0
+
+        for stale in ranked_dir.glob("*.pdb"):
+            stale.unlink()
+
+        with mpnn_csv.open(newline="") as handle:
+            rows = list(csv.DictReader(handle))
+
+        def sort_key(row: dict[str, str]) -> float:
+            try:
+                return -float(row.get("Average_i_pTM") or "nan")
+            except ValueError:
+                return float("inf")
+
+        ranked_rows = []
+        rank = 1
+        for row in sorted(rows, key=sort_key):
+            source = accepted.get(row.get("Design", ""))
+            if source is None:
+                continue
+            (ranked_dir / f"{rank}_{source.name}").write_bytes(source.read_bytes())
+            ranked_rows.append(
+                {"Rank": rank, **{k: row.get(k, "") for k in self.design_labels}}
+            )
+            rank += 1
+
+        with final_csv.open("w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=self.final_labels)
+            writer.writeheader()
+            writer.writerows(ranked_rows)
+        return len(ranked_rows)
+
+    def write_csv(self, path: str | Path, records: list[DesignRecord]) -> Path:
+        path = Path(path)
+        exists = path.exists()
+        with path.open("a", newline="") as handle:
+            writer = csv.writer(handle)
+            if not exists:
+                writer.writerow(self.design_labels)
+            for record in records:
+                writer.writerow(record.row(self.design_labels))
+        return path

--- a/src/mosaic/binder_design/pipeline.py
+++ b/src/mosaic/binder_design/pipeline.py
@@ -96,7 +96,9 @@ class PipelineConfig:
 
     @property
     def binder_chain(self) -> str:
-        return self.target_settings.get("binder_chain", "B")
+        # Launchers use an empty value to mean a de-novo binder. Downstream
+        # PDB normalization still needs a concrete one-character chain ID.
+        return str(self.target_settings.get("binder_chain", "") or "").strip() or "B"
 
     @property
     def target_chains(self) -> str:

--- a/src/mosaic/binder_design/rosetta.py
+++ b/src/mosaic/binder_design/rosetta.py
@@ -1,0 +1,290 @@
+"""PyRosetta-based interface scoring and relaxation for binder design.
+
+Migrated from ``ddcraft.utils.pyrosetta`` (DdCraft py3.10 pipeline) to run
+natively inside Mosaic. Numerical behaviour is preserved exactly; only
+imports/logging were adapted to remove the dependency on the ``ddcraft``
+package (``clean_pdb`` and ``hotspot_residues`` now come from sibling
+modules in this package).
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+import pyrosetta as pr
+from pyrosetta.rosetta.core.kinematics import MoveMap
+from pyrosetta.rosetta.core.select.residue_selector import ChainSelector
+from pyrosetta.rosetta.protocols.simple_moves import AlignChainMover
+from pyrosetta.rosetta.protocols.analysis import InterfaceAnalyzerMover
+from pyrosetta.rosetta.protocols.relax import FastRelax
+from pyrosetta.rosetta.core.simple_metrics.metrics import RMSDMetric
+from pyrosetta.rosetta.core.select import get_residues_from_subset
+from pyrosetta.rosetta.core.io import pose_from_pose
+from pyrosetta.rosetta.protocols.rosetta_scripts import XmlObjects
+
+from .geometry import clean_pdb, hotspot_residues
+
+logger = logging.getLogger(__name__)
+
+
+def _make_interface_spec(interface_str):
+    """
+    Build the interface argument expected by InterfaceAnalyzerMover.set_interface().
+
+    Newer PyRosetta releases (e.g. 2026.x) changed set_interface() to require a
+    core.pose.DockingPartners object instead of a plain "A_B" string. Support both
+    APIs so this works across PyRosetta versions.
+    """
+    try:
+        from pyrosetta.rosetta.core.pose import DockingPartners
+        return DockingPartners.docking_partners_from_string(interface_str)
+    except ImportError:
+        # Older PyRosetta versions accept the raw string directly.
+        return interface_str
+
+def init_pyrosetta(dalphaball_path):
+    """
+    Initialize PyRosetta with appropriate settings.
+    
+    Args:
+        dalphaball_path: Path to DAlphaBall executable
+    """
+    pr.init(f'-ignore_unrecognized_res -ignore_zero_occupancy -mute all -holes:dalphaball {dalphaball_path} -corrections::beta_nov16 true -relax:default_repeats 1')
+
+# Rosetta interface scores
+def score_interface(pdb_file, binder_chain="B"):
+    # load pose
+    pose = pr.pose_from_pdb(pdb_file)
+
+    # analyze interface statistics
+    chain_ids = [
+        pose.pdb_info().chain(pose.conformation().chain_begin(i))
+        for i in range(1, pose.num_chains() + 1)
+    ]
+    target_chain = next((chain_id for chain_id in chain_ids if chain_id != binder_chain), None)
+    if target_chain is None:
+        raise ValueError(f"Could not determine target chain for binder chain '{binder_chain}'")
+
+    iam = InterfaceAnalyzerMover()
+    iam.set_interface(_make_interface_spec(f"{target_chain}_{binder_chain}"))
+    scorefxn = pr.get_fa_scorefxn()
+    iam.set_scorefunction(scorefxn)
+    iam.set_compute_packstat(True)
+    iam.set_compute_interface_energy(True)
+    iam.set_calc_dSASA(True)
+    iam.set_calc_hbond_sasaE(True)
+    iam.set_compute_interface_sc(True)
+    iam.set_pack_separated(True)
+    iam.apply(pose)
+
+    # Initialize dictionary with all amino acids
+    interface_AA = {aa: 0 for aa in 'ACDEFGHIKLMNPQRSTVWY'}
+
+    # Initialize list to store PDB residue IDs at the interface
+    interface_residues_set = hotspot_residues(pdb_file, binder_chain)
+    interface_residues_pdb_ids = []
+    
+    # Iterate over the interface residues
+    for pdb_res_num, aa_type in interface_residues_set.items():
+        # Increase the count for this amino acid type
+        interface_AA[aa_type] += 1
+
+        # Append the binder_chain and the PDB residue number to the list
+        interface_residues_pdb_ids.append(f"{binder_chain}{pdb_res_num}")
+
+    # count interface residues
+    interface_nres = len(interface_residues_pdb_ids)
+
+    # Convert the list into a comma-separated string
+    interface_residues_pdb_ids_str = ','.join(interface_residues_pdb_ids)
+
+    # Calculate the percentage of hydrophobic residues at the interface of the binder
+    hydrophobic_aa = set('ACFILMPVWY')
+    hydrophobic_count = sum(interface_AA[aa] for aa in hydrophobic_aa)
+    if interface_nres != 0:
+        interface_hydrophobicity = (hydrophobic_count / interface_nres) * 100
+    else:
+        interface_hydrophobicity = 0
+
+    # retrieve statistics
+    interfacescore = iam.get_all_data()
+    interface_sc = interfacescore.sc_value # shape complementarity
+    interface_interface_hbonds = interfacescore.interface_hbonds # number of interface H-bonds
+    interface_dG = iam.get_interface_dG() # interface dG
+    interface_dSASA = iam.get_interface_delta_sasa() # interface dSASA (interface surface area)
+    interface_packstat = iam.get_interface_packstat() # interface pack stat score
+    interface_dG_SASA_ratio = interfacescore.dG_dSASA_ratio * 100 # ratio of dG/dSASA (normalised energy for interface area size)
+    buns_filter = XmlObjects.static_get_filter('<BuriedUnsatHbonds report_all_heavy_atom_unsats="true" scorefxn="scorefxn" ignore_surface_res="false" use_ddG_style="true" dalphaball_sasa="1" probe_radius="1.1" burial_cutoff_apo="0.2" confidence="0" />')
+    interface_delta_unsat_hbonds = buns_filter.report_sm(pose)
+
+    if interface_nres != 0:
+        interface_hbond_percentage = (interface_interface_hbonds / interface_nres) * 100 # Hbonds per interface size percentage
+        interface_bunsch_percentage = (interface_delta_unsat_hbonds / interface_nres) * 100 # Unsaturated H-bonds per percentage
+    else:
+        interface_hbond_percentage = 0  # Use 0 instead of None for consistency
+        interface_bunsch_percentage = 0  # Use 0 instead of None for consistency
+
+    # calculate binder energy score
+    chain_design = ChainSelector(binder_chain)
+    tem = pr.rosetta.core.simple_metrics.metrics.TotalEnergyMetric()
+    tem.set_scorefunction(scorefxn)
+    tem.set_residue_selector(chain_design)
+    binder_score = tem.calculate(pose)
+
+    # calculate binder SASA fraction
+    bsasa = pr.rosetta.core.simple_metrics.metrics.SasaMetric()
+    bsasa.set_residue_selector(chain_design)
+    binder_sasa = bsasa.calculate(pose)
+
+    if binder_sasa is not None and binder_sasa > 0:
+        interface_binder_fraction = (interface_dSASA / binder_sasa) * 100
+    else:
+        interface_binder_fraction = 0
+
+    # calculate surface hydrophobicity
+    binder_pose = {pose.pdb_info().chain(pose.conformation().chain_begin(i)): p for i, p in zip(range(1, pose.num_chains()+1), pose.split_by_chain())}[binder_chain]
+
+    layer_sel = pr.rosetta.core.select.residue_selector.LayerSelector()
+    layer_sel.set_layers(pick_core = False, pick_boundary = False, pick_surface = True)
+    surface_res = layer_sel.apply(binder_pose)
+
+    exp_apol_count = 0
+    total_count = 0 
+    
+    # count apolar and aromatic residues at the surface
+    for i in range(1, len(surface_res) + 1):
+        if surface_res[i] == True:
+            res = binder_pose.residue(i)
+
+            # count apolar and aromatic residues as hydrophobic
+            if res.is_apolar() == True or res.name() == 'PHE' or res.name() == 'TRP' or res.name() == 'TYR':
+                exp_apol_count += 1
+            total_count += 1
+
+    # Protect against division by zero
+    if total_count > 0:
+        surface_hydrophobicity = exp_apol_count / total_count
+    else:
+        surface_hydrophobicity = 0
+
+    # output interface score array and amino acid counts at the interface
+    interface_scores = {
+    'binder_score': binder_score,
+    'surface_hydrophobicity': surface_hydrophobicity,
+    'interface_sc': interface_sc,
+    'interface_packstat': interface_packstat,
+    'interface_dG': interface_dG,
+    'interface_dSASA': interface_dSASA,
+    'interface_dG_SASA_ratio': interface_dG_SASA_ratio,
+    'interface_fraction': interface_binder_fraction,
+    'interface_hydrophobicity': interface_hydrophobicity,
+    'interface_nres': interface_nres,
+    'interface_interface_hbonds': interface_interface_hbonds,
+    'interface_hbond_percentage': interface_hbond_percentage,
+    'interface_delta_unsat_hbonds': interface_delta_unsat_hbonds,
+    'interface_delta_unsat_hbonds_percentage': interface_bunsch_percentage
+    }
+
+    # round to two decimal places
+    interface_scores = {k: round(v, 2) if isinstance(v, float) else v for k, v in interface_scores.items()}
+
+    return interface_scores, interface_AA, interface_residues_pdb_ids_str
+
+# align pdbs to have same orientation
+def align_pdbs(reference_pdb, align_pdb, reference_chain_id, align_chain_id):
+    # initiate poses
+    reference_pose = pr.pose_from_pdb(reference_pdb)
+    align_pose = pr.pose_from_pdb(align_pdb)
+
+    align = AlignChainMover()
+    align.pose(reference_pose)
+
+    # If the chain IDs contain commas, split them and only take the first value
+    reference_chain_id = reference_chain_id.split(',')[0]
+    align_chain_id = align_chain_id.split(',')[0]
+
+    # Get the chain number corresponding to the chain ID in the poses
+    reference_chain = pr.rosetta.core.pose.get_chain_id_from_chain(reference_chain_id, reference_pose)
+    align_chain = pr.rosetta.core.pose.get_chain_id_from_chain(align_chain_id, align_pose)
+
+    align.source_chain(align_chain)
+    align.target_chain(reference_chain)
+    align.apply(align_pose)
+
+    # Overwrite aligned pdb
+    align_pose.dump_pdb(align_pdb)
+    clean_pdb(align_pdb)
+
+# calculate the rmsd without alignment
+def unaligned_rmsd(reference_pdb, align_pdb, reference_chain_id, align_chain_id):
+    reference_pose = pr.pose_from_pdb(reference_pdb)
+    align_pose = pr.pose_from_pdb(align_pdb)
+
+    # Define chain selectors for the reference and align chains
+    reference_chain_selector = ChainSelector(reference_chain_id)
+    align_chain_selector = ChainSelector(align_chain_id)
+
+    # Apply selectors to get residue subsets
+    reference_chain_subset = reference_chain_selector.apply(reference_pose)
+    align_chain_subset = align_chain_selector.apply(align_pose)
+
+    # Convert subsets to residue index vectors
+    reference_residue_indices = get_residues_from_subset(reference_chain_subset)
+    align_residue_indices = get_residues_from_subset(align_chain_subset)
+
+    # Create empty subposes
+    reference_chain_pose = pr.Pose()
+    align_chain_pose = pr.Pose()
+
+    # Fill subposes
+    pose_from_pose(reference_chain_pose, reference_pose, reference_residue_indices)
+    pose_from_pose(align_chain_pose, align_pose, align_residue_indices)
+
+    # Calculate RMSD using the RMSDMetric
+    rmsd_metric = RMSDMetric()
+    rmsd_metric.set_comparison_pose(reference_chain_pose)
+    rmsd = rmsd_metric.calculate(align_chain_pose)
+
+    return round(rmsd, 2)
+
+# Relax designed structure
+def pr_relax(pdb_file, relaxed_pdb_path, binder_chain=None):
+    if not os.path.exists(relaxed_pdb_path):
+        # Generate pose
+        pose = pr.pose_from_pdb(pdb_file)
+        start_pose = pose.clone()
+
+        ### Generate movemaps
+        mmf = MoveMap()
+        mmf.set_chi(True) # enable sidechain movement
+        mmf.set_bb(True) # enable backbone movement, can be disabled to increase speed by 30% but makes metrics look worse on average
+        mmf.set_jump(False) # disable whole chain movement
+
+        # Run FastRelax
+        fastrelax = FastRelax()
+        scorefxn = pr.get_fa_scorefxn()
+        fastrelax.set_scorefxn(scorefxn)
+        fastrelax.set_movemap(mmf) # set MoveMap
+        fastrelax.max_iter(200) # default iterations is 2500
+        fastrelax.min_type("lbfgs_armijo_nonmonotone")
+        fastrelax.constrain_relax_to_start_coords(True)
+        fastrelax.apply(pose)
+
+        # Align relaxed structure to original trajectory
+        align = AlignChainMover()
+        align.source_chain(0)
+        align.target_chain(0)
+        align.pose(start_pose)
+        align.apply(pose)
+
+        # Copy B factors from start_pose to pose
+        for resid in range(1, pose.total_residue() + 1):
+            if pose.residue(resid).is_protein():
+                # Get the B factor of the first heavy atom in the residue
+                bfactor = start_pose.pdb_info().bfactor(resid, 1)
+                for atom_id in range(1, pose.residue(resid).natoms() + 1):
+                    pose.pdb_info().bfactor(resid, atom_id, bfactor)
+
+        # output relaxed and aligned PDB
+        pose.dump_pdb(relaxed_pdb_path)
+        clean_pdb(relaxed_pdb_path)

--- a/src/mosaic/binder_design/trajectory.py
+++ b/src/mosaic/binder_design/trajectory.py
@@ -1,0 +1,1413 @@
+#!/usr/bin/env python3
+"""Stage 1: structure-model hallucination trajectories.
+
+Generates a binder backbone against a target by optimising a composite Mosaic
+objective, then folding the result. Runs standalone as a CLI (one job per
+process, which is how the DdCraft bridge drives it) or via ``run_job``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+import traceback
+import warnings
+from pathlib import Path
+from typing import Any
+
+POSITION_RE = re.compile(r"^([A-Za-z]?)(-?\d+)(?:-(-?\d+))?$")
+
+
+def _normalized_symmetric_pae(pae: Any, array_module: Any) -> Any:
+    pae = array_module.asarray(pae)
+    return (pae + array_module.swapaxes(pae, -1, -2)) / 62.0
+
+
+def load_job(path: Path) -> dict[str, Any]:
+    job = json.loads(path.read_text())
+    validate_job(job)
+    return job
+
+
+def validate_job(job: dict[str, Any]) -> None:
+    required = {
+        "design_name",
+        "seed",
+        "length",
+        "starting_pdb",
+        "target_chains",
+        "target_settings",
+        "advanced_settings",
+        "output_pdb",
+    }
+    missing = sorted(required - set(job))
+    if missing:
+        raise ValueError(f"Mosaic job is missing required fields: {', '.join(missing)}")
+    if int(job["length"]) < 1:
+        raise ValueError("Mosaic binder length must be positive")
+    if not Path(job["starting_pdb"]).is_file():
+        raise FileNotFoundError(f"Starting PDB not found: {job['starting_pdb']}")
+    if not job["target_chains"]:
+        raise ValueError("At least one target chain is required")
+    if job["advanced_settings"].get("design_algorithm", "4stage") != "4stage":
+        raise ValueError(
+            "The Mosaic backend currently supports DdCraft's 4stage design algorithm"
+        )
+    if job["advanced_settings"].get("optimise_beta", False):
+        raise ValueError(
+            "optimise_beta is not implemented in the Mosaic backend; the native engine "
+            "extends the soft/temporary schedules and changes recycling when a beta "
+            "sheeted trajectory is detected. Set optimise_beta to false to use --engine mosaic."
+        )
+    from mosaic.binder_design.components import model_selection
+
+    selection = model_selection(job["advanced_settings"], "hallucination")
+    if (
+        selection.name == "af2"
+        and not job.get("af_params_dir")
+        and not job["advanced_settings"].get("af_params_dir")
+        and not selection.options.get("data_dir")
+        and not selection.options.get("params_dir")
+    ):
+        raise ValueError("AF2 hallucination requires af_params_dir")
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    temporary_path.write_text(json.dumps(value, indent=2) + "\n")
+    temporary_path.replace(path)
+
+
+def _chain_sequence(chain: Any) -> str:
+    import gemmi
+
+    sequence = gemmi.one_letter_code([residue.name for residue in chain])
+    if not sequence or "X" in sequence:
+        raise ValueError(
+            f"Chain {chain.name} contains missing or unsupported protein residues"
+        )
+    return sequence
+
+
+def _position_index_map(chain: Any) -> dict[int, int]:
+    return {int(residue.seqid.num): index for index, residue in enumerate(chain)}
+
+
+def _expand_positions(
+    specification: Any,
+    default_chain: str,
+    chain_maps: dict[str, dict[int, int]],
+    chain_offsets: dict[str, int] | None = None,
+) -> list[int]:
+    if specification in (None, "", []):
+        return []
+    if isinstance(specification, (list, tuple)):
+        tokens = [str(item).strip() for item in specification if str(item).strip()]
+    else:
+        tokens = [token.strip() for token in str(specification).split(",") if token.strip()]
+
+    positions: list[int] = []
+    for token in tokens:
+        match = POSITION_RE.match(token)
+        if not match:
+            raise ValueError(f"Invalid residue position '{token}'")
+        chain_id = match.group(1) or default_chain
+        start = int(match.group(2))
+        end = int(match.group(3)) if match.group(3) is not None else start
+        if chain_id not in chain_maps:
+            raise ValueError(f"Unknown chain '{chain_id}' in residue position '{token}'")
+        step = 1 if end >= start else -1
+        for residue_number in range(start, end + step, step):
+            if residue_number not in chain_maps[chain_id]:
+                raise ValueError(
+                    f"Residue {chain_id}{residue_number} is missing from the starting PDB"
+                )
+            index = chain_maps[chain_id][residue_number]
+            if chain_offsets is not None:
+                index += chain_offsets[chain_id]
+            positions.append(index)
+    return sorted(set(positions))
+
+
+def _pseudo_beta_coordinates(chain: Any) -> tuple[list[list[float]], list[bool]]:
+    coordinates: list[list[float]] = []
+    mask: list[bool] = []
+    for residue in chain:
+        atom = residue.find_atom("CB", "\0")
+        if atom is None:
+            atom = residue.find_atom("CA", "\0")
+        if atom is None:
+            coordinates.append([0.0, 0.0, 0.0])
+            mask.append(False)
+        else:
+            coordinates.append([atom.pos.x, atom.pos.y, atom.pos.z])
+            mask.append(True)
+    return coordinates, mask
+
+
+def _align_stage_trajectory(entry_logits, trajectory):
+    """Pair each recorded loss with the sequence that produced it.
+
+    ``colabdesign_stage`` applies the gradient update before calling
+    ``trajectory_fn``, so every entry holds a loss measured on the pre-update
+    sequence alongside the post-update sequence. Shifting the sequences by one
+    step recovers the iterate that actually produced each loss, which is what
+    ColabDesign's ``save_best`` records.
+    """
+    aligned = []
+    previous_logits = entry_logits
+    for step in trajectory:
+        aligned.append(
+            {
+                "loss": step["loss"],
+                "plddt": step["plddt"],
+                "logits": previous_logits,
+            }
+        )
+        previous_logits = step["logits"]
+    return aligned
+
+
+def _apply_template_masks(
+    features: dict[str, Any],
+    binder_length: int,
+    advanced: dict[str, Any],
+    stage: str = "design",
+) -> dict[str, Any]:
+    """Mask the template the way ColabDesign does.
+
+    ``stage`` selects which pair of settings to read: the trajectory stage uses
+    ``rm_template_{seq,sc}_design`` and validation uses the ``_predict`` pair.
+    """
+    import jax.numpy as jnp
+
+    from mosaic.alphafold.common import residue_constants
+
+    required = {"template_aatype", "template_all_atom_mask"}
+    if not required <= set(features):
+        requested = any(
+            advanced.get(f"rm_template_{kind}_{stage}", False)
+            for kind in ("seq", "sc")
+        )
+        if requested:
+            warnings.warn(
+                f"Template seq/sidechain masks are AF2-specific and are not "
+                f"available for this model's {stage} feature pack; the model's "
+                "native template representation is being used unchanged.",
+                stacklevel=2,
+            )
+        return features
+
+    features = dict(features)
+    binder_slice = slice(0, binder_length)
+    target_slice = slice(binder_length, None)
+    if advanced.get(f"rm_template_seq_{stage}", False):
+        template_aatype = jnp.asarray(features["template_aatype"])
+        features["template_aatype"] = template_aatype.at[:, target_slice].set(20)
+    backbone_atoms = {
+        residue_constants.atom_order[name] for name in ("N", "CA", "C", "O")
+    }
+    template_mask = jnp.asarray(features["template_all_atom_mask"])
+    atom_mask = jnp.zeros(template_mask.shape[-1], dtype=template_mask.dtype)
+    atom_mask = atom_mask.at[jnp.array(sorted(backbone_atoms))].set(1)
+    template_mask = template_mask.at[:, binder_slice].multiply(atom_mask)
+    if advanced.get(f"rm_template_sc_{stage}", False):
+        features["template_all_atom_mask"] = template_mask.at[:, target_slice].multiply(
+            atom_mask
+        )
+    else:
+        features["template_all_atom_mask"] = template_mask
+    return features
+
+
+def run_job(job: dict[str, Any]) -> dict[str, Any]:
+    os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+
+    import equinox as eqx
+    import gemmi
+    import jax
+    import jax.numpy as jnp
+    import numpy as np
+    from jaxtyping import Array, Float, Int
+
+    import mosaic.losses.structure_prediction as sp
+    from mosaic.alphafold.common import residue_constants
+    from mosaic.binder_design.components import (
+        create_structure_model,
+        model_selection,
+    )
+    from mosaic.common import TOKENS, LossTerm, tokenize
+    from mosaic.models.af2 import af2_atom_positions
+    from mosaic.optimizers import colabdesign_stage
+    from mosaic.structure_prediction import TargetChain
+
+    # ColabDesign derives two different bin conventions from AF2's 64-bin
+    # distogram, and Mosaic's AF2_DISTOGRAM_BINS (a 64-point linspace) matches
+    # neither:
+    #   get_dgram_loss uses the 63 bin *edges* and assigns a distance by
+    #     interval membership, (d^2 > edges^2).sum(-1);
+    #   get_dgram_bins prepends a 0 to those edges and thresholds the result
+    #     with `bins < cutoff` for the contact and helix losses.
+    # Using the linspace as if it were bin centres shifts assignments by up to
+    # one bin, so reproduce both conventions explicitly.
+    DGRAM_BIN_EDGES = jnp.linspace(2.3125, 21.6875, 63)
+    DGRAM_CONTACT_BINS = jnp.append(0.0, DGRAM_BIN_EDGES)
+
+    class SequenceConstraintLoss(LossTerm):
+        loss: Any
+        wildtype: Float[Array, "N 20"]
+        variable_positions: Int[Array, " M"]
+        allowed_indices: Int[Array, " K"]
+
+        def sequence(self, variable_sequence: Float[Array, "M K"]):
+            expanded = jnp.zeros((variable_sequence.shape[0], len(TOKENS)))
+            expanded = expanded.at[:, self.allowed_indices].set(variable_sequence)
+            return self.wildtype.at[self.variable_positions].set(expanded)
+
+        def __call__(self, variable_sequence: Float[Array, "M K"], *, key):
+            return self.loss(self.sequence(variable_sequence), key=key)
+
+    class DdCraftPLDDTLoss(LossTerm):
+        binder_mask: Float[Array, " B"]
+
+        def __call__(self, sequence, output, key):
+            losses = 1 - output.plddt[: sequence.shape[0]]
+            value = (losses * self.binder_mask).sum() / (
+                self.binder_mask.sum() + 1e-8
+            )
+            return value, {"plddt": 1 - value}
+
+    class BinderPLDDTMetric(LossTerm):
+        """Unweighted binder pLDDT used for DdCraft's stage continuation gates."""
+
+        def __call__(self, sequence, output, key):
+            value = output.plddt[: sequence.shape[0]].mean()
+            return 0.0 * value, {"binder_plddt": value}
+
+    class DdCraftIPTMLoss(LossTerm):
+        def __call__(self, sequence, output, key):
+            iptm = -sp.IPTMLoss()(sequence, output, key=key)[0]
+            return 1 - iptm, {"i_ptm": iptm}
+
+    class DdCraftBinderPAE(LossTerm):
+        binder_mask: Float[Array, " B"]
+
+        def __call__(self, sequence, output, key):
+            binder_length = sequence.shape[0]
+            pae = _normalized_symmetric_pae(output.pae, jnp)[:binder_length]
+            pair_mask = self.binder_mask[:, None] * jnp.ones_like(pae)
+            value = (pae * pair_mask).sum() / (pair_mask.sum() + 1e-8)
+            return value, {"pae": value}
+
+    class DdCraftInterfacePAE(LossTerm):
+        binder_mask: Float[Array, " B"]
+        target_mask: Float[Array, " T"]
+
+        def __call__(self, sequence, output, key):
+            binder_length = sequence.shape[0]
+            pae = _normalized_symmetric_pae(output.pae, jnp)[
+                :binder_length, binder_length:
+            ]
+            pair_mask = self.binder_mask[:, None] * self.target_mask[None, :]
+            value = (pae * pair_mask).sum() / (pair_mask.sum() + 1e-8)
+            return value, {"i_pae": value}
+
+    class DdCraftWithinBinderContact(LossTerm):
+        binder_mask: Float[Array, " B"]
+        contact_distance: float
+        af2_convention: bool = eqx.field(static=True)
+        sequence_separation: int = eqx.field(static=True)
+        num_contacts: int = eqx.field(static=True)
+
+        def __call__(self, sequence, output, key):
+            binder_length = sequence.shape[0]
+            log_contact = sp.contact_cross_entropy(
+                output.distogram_logits[:binder_length, :binder_length],
+                self.contact_distance,
+                DGRAM_CONTACT_BINS if self.af2_convention else output.distogram_bins,
+            )
+            positions = jnp.arange(binder_length)
+            pair_mask = (
+                jnp.abs(positions[:, None] - positions[None, :])
+                >= self.sequence_separation
+            )
+            pair_mask &= self.binder_mask[:, None].astype(bool)
+            pair_mask &= self.binder_mask[None, :].astype(bool)
+            sorted_log_contact = jnp.sort(
+                jnp.where(pair_mask, log_contact, -jnp.inf),
+                descending=True,
+                axis=-1,
+            )[:, : self.num_contacts]
+            valid = jnp.isfinite(sorted_log_contact)
+            per_position = jnp.where(valid, sorted_log_contact, 0).sum(-1) / (
+                valid.sum(-1) + 1e-8
+            )
+            value = -(
+                (per_position * self.binder_mask).sum()
+                / (self.binder_mask.sum() + 1e-8)
+            )
+            return value, {"intra_contact": -value}
+
+    class DdCraftBinderTargetContact(LossTerm):
+        binder_mask: Float[Array, " B"]
+        target_mask: Float[Array, " T"]
+        contact_distance: float
+        af2_convention: bool = eqx.field(static=True)
+        num_contacts: int = eqx.field(static=True)
+        target_hotspot_mode: bool = eqx.field(static=True)
+
+        def __call__(self, sequence, output, key):
+            binder_length = sequence.shape[0]
+            log_contact = sp.contact_cross_entropy(
+                output.distogram_logits[:binder_length, binder_length:],
+                self.contact_distance,
+                DGRAM_CONTACT_BINS if self.af2_convention else output.distogram_bins,
+            )
+            if self.target_hotspot_mode:
+                log_contact = log_contact.T
+                row_mask = self.target_mask
+                column_mask = self.binder_mask
+            else:
+                row_mask = self.binder_mask
+                column_mask = self.target_mask
+            pair_mask = row_mask[:, None].astype(bool) & column_mask[None, :].astype(
+                bool
+            )
+            sorted_log_contact = jnp.sort(
+                jnp.where(pair_mask, log_contact, -jnp.inf),
+                descending=True,
+                axis=-1,
+            )[:, : self.num_contacts]
+            valid = jnp.isfinite(sorted_log_contact)
+            per_position = jnp.where(valid, sorted_log_contact, 0).sum(-1) / (
+                valid.sum(-1) + 1e-8
+            )
+            value = (per_position * row_mask).sum() / (row_mask.sum() + 1e-8)
+            return -value, {"target_contact": value}
+
+    class TemplateDistogramCrossEntropy(LossTerm):
+        reference_distances: Float[Array, "N M"]
+        pair_mask: Float[Array, "N M"]
+        region: str = eqx.field(static=True)
+        name: str = eqx.field(static=True)
+        af2_convention: bool = eqx.field(static=True)
+
+        def __call__(self, sequence, output, key):
+            binder_length = sequence.shape[0]
+            if self.region == "binder":
+                logits = output.distogram_logits[:binder_length, :binder_length]
+            elif self.region == "target":
+                logits = output.distogram_logits[binder_length:, binder_length:]
+            else:
+                logits = output.distogram_logits[:binder_length, binder_length:]
+            if self.af2_convention:
+                bin_index = (
+                    jnp.square(self.reference_distances)[..., None]
+                    > jnp.square(DGRAM_BIN_EDGES)
+                ).sum(-1)
+            else:
+                bin_index = jnp.abs(
+                    self.reference_distances[..., None] - output.distogram_bins
+                ).argmin(-1)
+            nll = -jnp.take_along_axis(
+                jax.nn.log_softmax(logits, axis=-1),
+                bin_index[..., None],
+                axis=-1,
+            )[..., 0]
+            if self.region == "interface":
+                reverse_logits = output.distogram_logits[
+                    binder_length:, :binder_length
+                ].swapaxes(0, 1)
+                reverse_nll = -jnp.take_along_axis(
+                    jax.nn.log_softmax(reverse_logits, axis=-1),
+                    bin_index[..., None],
+                    axis=-1,
+                )[..., 0]
+                nll = (nll + reverse_nll) / 2
+            value = (nll * self.pair_mask).sum() / (self.pair_mask.sum() + 1e-8)
+            return value, {self.name: value}
+
+    class FixedModelLoss(LossTerm):
+        model: Any
+        features: Any
+        loss: Any
+        recycling_steps: int = eqx.field(static=True)
+        sampling_steps: int | None = eqx.field(static=True)
+        member: int = eqx.field(static=True)
+        use_dropout: bool = eqx.field(static=True)
+
+        def __call__(self, sequence, *, key):
+            model_kwargs = self.model.design_member_kwargs(
+                self.member, use_dropout=self.use_dropout
+            )
+            if self.sampling_steps is not None:
+                model_kwargs["sampling_steps"] = self.sampling_steps
+            output = self.model.model_output(
+                PSSM=sequence,
+                features=self.features,
+                recycling_steps=self.recycling_steps,
+                key=key,
+                **model_kwargs,
+            )
+            value, auxiliary = self.loss(sequence, output=output, key=key)
+            return value, {
+                "ddcraft": auxiliary,
+                "ddcraft/model_idx": jnp.asarray(self.member),
+                "ddcraft/loss": value,
+            }
+
+    class SampledAlphaFoldLoss(LossTerm):
+        model: Any
+        features: Any
+        loss: Any
+        member_indices: Int[Array, " M"]
+        stack_indices: Int[Array, " M"]
+        recycling_steps: int = eqx.field(static=True)
+        use_dropout: bool = eqx.field(static=True)
+
+        def __call__(self, sequence, *, key):
+            sample_key, model_key = jax.random.split(key)
+            choice = jax.random.randint(
+                sample_key, (), 0, self.member_indices.shape[0]
+            )
+            member_index = self.member_indices[choice]
+            stack_index = self.stack_indices[choice]
+            output = self.model.model_output(
+                PSSM=sequence,
+                features=self.features,
+                recycling_steps=self.recycling_steps,
+                model_idx=stack_index,
+                use_dropout=self.use_dropout,
+                key=model_key,
+            )
+            value, auxiliary = self.loss(sequence, output=output, key=model_key)
+            return value, {
+                "ddcraft": auxiliary,
+                "ddcraft/model_idx": member_index,
+                "ddcraft/loss": value,
+            }
+
+    class TerminiDistanceLoss(LossTerm):
+        threshold: float = 7.0
+
+        def __call__(self, sequence, output, key):
+            binder_length = sequence.shape[0]
+            ca = output.atom37_coords[:binder_length, residue_constants.atom_order["CA"]]
+            distance = jnp.linalg.norm(ca[0] - ca[-1])
+            value = jax.nn.relu(jax.nn.elu(distance - self.threshold))
+            return value, {"termini_distance": distance}
+
+    class DdCraftRadiusOfGyration(LossTerm):
+        def __call__(self, sequence, output, key):
+            binder_length = sequence.shape[0]
+            ca = output.atom37_coords[
+                :binder_length, residue_constants.atom_order["CA"]
+            ]
+            radius = jnp.sqrt(
+                jnp.square(ca - ca.mean(0)).sum(-1).mean() + 1e-8
+            )
+            threshold = 2.38 * binder_length**0.365
+            value = jax.nn.elu(radius - threshold)
+            return value, {"radius_of_gyration": radius}
+
+    class DdCraftHelixLoss(LossTerm):
+        af2_convention: bool = eqx.field(static=True)
+
+        def __call__(self, sequence, output, key):
+            binder_length = sequence.shape[0]
+            log_contact = sp.contact_log_probability(
+                output.distogram_logits[:binder_length, :binder_length],
+                6.0,
+                bins=(
+                    DGRAM_CONTACT_BINS
+                    if self.af2_convention
+                    else output.distogram_bins
+                ),
+            )
+            value = -jnp.diagonal(log_contact, 3).mean()
+            return value, {"helix": value}
+
+    class TemplateSidechainLoss(LossTerm):
+        positions: Int[Array, " P"]
+        template_coords: Float[Array, "P 37 3"]
+        template_mask: Float[Array, "P 37"]
+        mode: str = eqx.field(static=True)
+
+        def _local_coordinates(self, coords):
+            n = coords[:, residue_constants.atom_order["N"]]
+            ca = coords[:, residue_constants.atom_order["CA"]]
+            c = coords[:, residue_constants.atom_order["C"]]
+            x = c - ca
+            x = x / (jnp.linalg.norm(x, axis=-1, keepdims=True) + 1e-8)
+            y0 = n - ca
+            y = y0 - (y0 * x).sum(-1, keepdims=True) * x
+            y = y / (jnp.linalg.norm(y, axis=-1, keepdims=True) + 1e-8)
+            z = jnp.cross(x, y)
+            basis = jnp.stack((x, y, z), axis=-1)
+            centered = coords - ca[:, None, :]
+            return jnp.einsum("paj,pjk->pak", centered, basis)
+
+        def __call__(self, sequence, output, key):
+            predicted = output.atom37_coords[self.positions]
+            difference = predicted - self.template_coords
+            squared = (difference**2).sum(-1)
+            rmsd = jnp.sqrt(
+                (squared * self.template_mask).sum()
+                / (self.template_mask.sum() + 1e-8)
+            )
+            if self.mode == "rmsd":
+                return rmsd, {"template_sc_rmsd": rmsd}
+            predicted_local = self._local_coordinates(predicted)
+            template_local = self._local_coordinates(self.template_coords)
+            fape_distance = jnp.sqrt(
+                ((predicted_local - template_local) ** 2).sum(-1) + 1e-8
+            )
+            fape = (
+                jnp.minimum(fape_distance, 10.0) * self.template_mask
+            ).sum() / (self.template_mask.sum() + 1e-8)
+            if self.mode == "fape":
+                return fape, {"template_sc_fape": fape}
+            return rmsd + fape, {
+                "template_sc_rmsd": rmsd,
+                "template_sc_fape": fape,
+            }
+
+    target = job["target_settings"]
+    advanced = job["advanced_settings"]
+    design_selection = model_selection(advanced, "hallucination")
+    model_settings = dict(advanced)
+    if job.get("af_params_dir") and not model_settings.get("af_params_dir"):
+        model_settings["af_params_dir"] = job["af_params_dir"]
+    design_model = create_structure_model(design_selection, model_settings)
+    uses_af2_distogram = design_selection.name == "af2"
+    structure = gemmi.read_structure(job["starting_pdb"])
+    if len(structure) == 0:
+        raise ValueError(f"No model found in {job['starting_pdb']}")
+    model = structure[0]
+    chain_lookup = {chain.name: chain for chain in model}
+    target_chain_ids = list(job["target_chains"])
+    binder_chain_id = str(job.get("binder_chain", "")).strip()
+
+    for chain_id in target_chain_ids:
+        if chain_id not in chain_lookup:
+            raise ValueError(f"Target chain '{chain_id}' is missing from starting PDB")
+
+    structure_conditioned = bool(binder_chain_id)
+    binder_length = int(job["length"])
+    if structure_conditioned:
+        if binder_chain_id not in chain_lookup:
+            raise ValueError(
+                f"Binder chain '{binder_chain_id}' is missing from starting PDB"
+            )
+        binder_chain = chain_lookup[binder_chain_id]
+        binder_sequence = _chain_sequence(binder_chain)
+        if len(binder_sequence) != binder_length:
+            raise ValueError(
+                f"Configured binder length {binder_length} does not match "
+                f"template chain length {len(binder_sequence)}"
+            )
+    else:
+        binder_chain = None
+        binder_sequence = "A" * binder_length
+
+    target_sequences = {
+        chain_id: _chain_sequence(chain_lookup[chain_id])
+        for chain_id in target_chain_ids
+    }
+    supports_templates = design_model.supports_template_chains()
+    target_specs = [
+        TargetChain(
+            sequence=target_sequences[chain_id],
+            use_msa=False,
+            template_chain=chain_lookup[chain_id] if supports_templates else None,
+        )
+        for chain_id in target_chain_ids
+    ]
+
+    if structure_conditioned and supports_templates:
+        binder_spec = TargetChain(
+            sequence=binder_sequence,
+            use_msa=False,
+            template_chain=binder_chain,
+        )
+        features, writer = design_model.target_only_features(
+            [binder_spec] + target_specs
+        )
+    else:
+        if structure_conditioned and not supports_templates:
+            warnings.warn(
+                f"{design_selection.name} does not accept template chains; fixed "
+                "binder residues will be sequence-constrained but its starting "
+                "coordinates cannot condition hallucination.",
+                stacklevel=2,
+            )
+        features, writer = design_model.binder_features(
+            binder_length=binder_length,
+            chains=target_specs,
+        )
+    features = _apply_template_masks(features, binder_length, advanced)
+
+    binder_map = (
+        _position_index_map(binder_chain)
+        if structure_conditioned
+        else {index: index - 1 for index in range(1, binder_length + 1)}
+    )
+    target_maps = {
+        chain_id: _position_index_map(chain_lookup[chain_id])
+        for chain_id in target_chain_ids
+    }
+    target_offsets: dict[str, int] = {}
+    offset = 0
+    for chain_id in target_chain_ids:
+        target_offsets[chain_id] = offset
+        offset += len(target_sequences[chain_id])
+
+    epitope_indices = _expand_positions(
+        target.get("target_hotspot_residues", ""),
+        target_chain_ids[0],
+        target_maps,
+        target_offsets,
+    )
+    target_coldspot_indices = _expand_positions(
+        target.get("target_coldspot_residues", ""),
+        target_chain_ids[0],
+        target_maps,
+        target_offsets,
+    )
+    paratope_indices = _expand_positions(
+        target.get("binder_hotspot_residues", ""),
+        binder_chain_id or "B",
+        {binder_chain_id or "B": binder_map},
+    )
+    binder_coldspot_indices = _expand_positions(
+        target.get("binder_coldspot_residues", ""),
+        binder_chain_id or "B",
+        {binder_chain_id or "B": binder_map},
+    )
+    if binder_coldspot_indices:
+        binder_active_indices = sorted(
+            set(range(binder_length)) - set(binder_coldspot_indices)
+        )
+    elif paratope_indices:
+        binder_active_indices = paratope_indices
+    else:
+        binder_active_indices = list(range(binder_length))
+    target_length = sum(len(sequence) for sequence in target_sequences.values())
+    target_active_indices = (
+        epitope_indices if epitope_indices else list(range(target_length))
+    )
+    target_active_indices = sorted(
+        set(target_active_indices) - set(target_coldspot_indices)
+    )
+    binder_loss_mask = jnp.zeros(binder_length, dtype=jnp.float32).at[
+        jnp.asarray(binder_active_indices, dtype=jnp.int32)
+    ].set(1)
+    target_loss_mask = jnp.zeros(target_length, dtype=jnp.float32).at[
+        jnp.asarray(target_active_indices, dtype=jnp.int32)
+    ].set(1)
+
+    terms: list[Any] = []
+
+    def add_term(weight: Any, loss: Any) -> None:
+        numeric_weight = float(weight or 0)
+        if numeric_weight != 0:
+            terms.append(numeric_weight * loss)
+
+    add_term(
+        advanced.get("weights_plddt", 0),
+        DdCraftPLDDTLoss(binder_mask=binder_loss_mask),
+    )
+    add_term(
+        advanced.get("weights_pae_intra", 0),
+        DdCraftBinderPAE(binder_mask=binder_loss_mask),
+    )
+    add_term(
+        advanced.get("weights_pae_inter", 0),
+        DdCraftInterfacePAE(
+            binder_mask=binder_loss_mask,
+            target_mask=target_loss_mask,
+        ),
+    )
+    add_term(
+        advanced.get("weights_con_intra", 0),
+        DdCraftWithinBinderContact(
+            binder_mask=binder_loss_mask,
+            contact_distance=float(advanced.get("intra_contact_distance", 14.0)),
+            af2_convention=uses_af2_distogram,
+            sequence_separation=9,
+            num_contacts=max(1, int(advanced.get("intra_contact_number", 2))),
+        ),
+    )
+    add_term(
+        advanced.get("weights_con_inter", 0),
+        DdCraftBinderTargetContact(
+            binder_mask=binder_loss_mask,
+            target_mask=target_loss_mask,
+            contact_distance=float(advanced.get("inter_contact_distance", 6.0)),
+            af2_convention=uses_af2_distogram,
+            num_contacts=max(1, int(advanced.get("inter_contact_number", 3))),
+            target_hotspot_mode=bool(epitope_indices),
+        ),
+    )
+    if advanced.get("use_i_ptm_loss", False):
+        add_term(advanced.get("weights_iptm", 0), DdCraftIPTMLoss())
+    if advanced.get("use_rg_loss", False):
+        add_term(
+            advanced.get("weights_rg", 0),
+            DdCraftRadiusOfGyration(),
+        )
+    add_term(
+        job.get("helicity_value", 0),
+        DdCraftHelixLoss(af2_convention=uses_af2_distogram),
+    )
+    if advanced.get("use_termini_distance_loss", False):
+        add_term(
+            advanced.get("weights_termini_loss", 0),
+            TerminiDistanceLoss(),
+        )
+
+    if structure_conditioned:
+        binder_coords, binder_coord_mask = _pseudo_beta_coordinates(binder_chain)
+        binder_coords_array = jnp.asarray(binder_coords)
+        binder_mask_array = jnp.asarray(binder_coord_mask, dtype=jnp.float32)
+        target_coordinates = []
+        target_coordinate_masks = []
+        for chain_id in target_chain_ids:
+            coordinates, coordinate_mask = _pseudo_beta_coordinates(
+                chain_lookup[chain_id]
+            )
+            target_coordinates.extend(coordinates)
+            target_coordinate_masks.extend(coordinate_mask)
+        target_coords_array = jnp.asarray(target_coordinates)
+        target_mask_array = jnp.asarray(target_coordinate_masks, dtype=jnp.float32)
+
+        binder_distances = jnp.linalg.norm(
+            binder_coords_array[:, None, :] - binder_coords_array[None, :, :],
+            axis=-1,
+        )
+        binder_pair_mask = (
+            binder_mask_array[:, None] * binder_mask_array[None, :]
+        ) * (1 - jnp.eye(binder_length))
+        add_term(
+            advanced.get("weight_dgram_binder", 0),
+            TemplateDistogramCrossEntropy(
+                reference_distances=binder_distances,
+                pair_mask=binder_pair_mask,
+                region="binder",
+                name="dgram_binder",
+                af2_convention=uses_af2_distogram,
+            ),
+        )
+        target_distances = jnp.linalg.norm(
+            target_coords_array[:, None, :] - target_coords_array[None, :, :],
+            axis=-1,
+        )
+        target_pair_mask = (
+            target_mask_array[:, None] * target_mask_array[None, :]
+        ) * (1 - jnp.eye(target_coords_array.shape[0]))
+        add_term(
+            advanced.get("weight_dgram_target", 0),
+            TemplateDistogramCrossEntropy(
+                reference_distances=target_distances,
+                pair_mask=target_pair_mask,
+                region="target",
+                name="dgram_target",
+                af2_convention=uses_af2_distogram,
+            ),
+        )
+        interface_distances = jnp.linalg.norm(
+            binder_coords_array[:, None, :] - target_coords_array[None, :, :],
+            axis=-1,
+        )
+        interface_pair_mask = binder_mask_array[:, None] * target_mask_array[None, :]
+        add_term(
+            advanced.get("weight_dgram_interface", 0),
+            TemplateDistogramCrossEntropy(
+                reference_distances=interface_distances,
+                pair_mask=interface_pair_mask,
+                region="interface",
+                name="dgram_interface",
+                af2_convention=uses_af2_distogram,
+            ),
+        )
+
+        if advanced.get("use_template_sidechain_loss", False):
+            sidechain_positions = _expand_positions(
+                target.get("template_sidechain_positions")
+                or target.get("fix_pos", ""),
+                binder_chain_id,
+                {binder_chain_id: binder_map},
+            )
+            if not sidechain_positions:
+                raise ValueError(
+                    "Template sidechain loss requires template_sidechain_positions "
+                    "or fix_pos"
+                )
+            template_coords, template_mask = af2_atom_positions(binder_chain)
+            template_coords = jnp.asarray(template_coords[0])[sidechain_positions]
+            template_mask = jnp.asarray(template_mask[0])[sidechain_positions]
+            excluded = {
+                str(atom).strip().upper()
+                for atom in advanced.get(
+                    "template_sidechain_atoms_exclude", ["N", "C", "O"]
+                )
+            }
+            excluded_indices = [
+                residue_constants.atom_order[name]
+                for name in excluded
+                if name in residue_constants.atom_order
+            ]
+            template_mask = template_mask.at[:, jnp.asarray(excluded_indices)].set(0)
+            mode = str(
+                advanced.get("template_sidechain_loss_mode", "rmsd")
+            ).lower()
+            if mode not in {"rmsd", "fape", "combined"}:
+                raise ValueError(
+                    "template_sidechain_loss_mode must be rmsd, fape, or combined"
+                )
+            sidechain_kwargs = {
+                "positions": jnp.asarray(sidechain_positions, dtype=jnp.int32),
+                "template_coords": template_coords,
+                "template_mask": template_mask,
+            }
+            if mode in {"rmsd", "combined"}:
+                add_term(
+                    advanced.get("weights_template_sidechain", 0),
+                    TemplateSidechainLoss(mode="rmsd", **sidechain_kwargs),
+                )
+            if mode in {"fape", "combined"}:
+                add_term(
+                    advanced.get("weights_template_sidechain_fape", 0),
+                    TemplateSidechainLoss(mode="fape", **sidechain_kwargs),
+                )
+
+    if not terms:
+        raise ValueError("Mosaic objective has no enabled loss terms")
+    # Always evaluated (at zero weight) so the stage gates can read an unweighted
+    # binder pLDDT regardless of which loss terms the configuration enables.
+    terms.append(0.0 * BinderPLDDTMetric())
+    objective = terms[0]
+    for term in terms[1:]:
+        objective = objective + term
+
+    # ColabDesign runs num_recycles + 1 forward passes (af/design.py: `cycles =
+    # (num_recycles + 1)`), whereas Mosaic's recycling scan length *is* the number of
+    # passes and starts from a zeroed recycling state. Passing num_recycles_design
+    # straight through therefore gave the Mosaic backend half of native's recycling,
+    # which showed up as systematically lower stage-1 binder pLDDT.
+    recycling_steps = int(advanced.get("num_recycles_design", 1)) + 1
+    configured_members = design_selection.members
+    if configured_members is not None:
+        design_model_indices = list(configured_members)
+    elif design_selection.name == "af2":
+        configured_numbers = design_selection.options.get("model_numbers")
+        if configured_numbers is not None:
+            design_model_indices = [
+                int(model_number) - 1 for model_number in configured_numbers
+            ]
+        else:
+            design_model_indices = [
+                int(model_index) for model_index in job.get("design_models", [0])
+            ] or [0]
+    else:
+        design_model_indices = list(design_model.ensemble_members())
+
+    def build_model_loss(use_dropout: bool):
+        if (
+            design_selection.name == "af2"
+            and advanced.get("sample_models", True)
+            and len(design_model_indices) > 1
+        ):
+            stack_indices = [
+                design_model.member_kwargs(member)["model_idx"]
+                for member in design_model_indices
+            ]
+            return SampledAlphaFoldLoss(
+                model=design_model,
+                features=features,
+                loss=objective,
+                member_indices=jnp.asarray(design_model_indices, dtype=jnp.int32),
+                stack_indices=jnp.asarray(stack_indices, dtype=jnp.int32),
+                recycling_steps=recycling_steps,
+                use_dropout=use_dropout,
+            )
+        return FixedModelLoss(
+            model=design_model,
+            features=features,
+            loss=objective,
+            recycling_steps=recycling_steps,
+            sampling_steps=design_selection.sampling_steps,
+            member=design_model_indices[0],
+            use_dropout=use_dropout,
+        )
+
+    gradient_model_loss = build_model_loss(use_dropout=True)
+    deterministic_model_loss = build_model_loss(use_dropout=False)
+
+    fixed_positions = (
+        _expand_positions(
+            target.get("fix_pos", ""),
+            binder_chain_id,
+            {binder_chain_id: binder_map},
+        )
+        if structure_conditioned
+        else []
+    )
+    variable_positions = [
+        index for index in range(binder_length) if index not in set(fixed_positions)
+    ]
+    if not variable_positions:
+        raise ValueError("All binder positions are fixed; there is nothing to design")
+
+    omitted = {
+        amino_acid.strip().upper()
+        for amino_acid in str(advanced.get("omit_AAs", "") or "").split(",")
+        if amino_acid.strip()
+    }
+    allowed_indices = [
+        index for index, amino_acid in enumerate(TOKENS) if amino_acid not in omitted
+    ]
+    if not allowed_indices:
+        raise ValueError("omit_AAs excludes the entire amino-acid alphabet")
+
+    wildtype = jax.nn.one_hot(tokenize(binder_sequence), len(TOKENS))
+    constraint_kwargs = {
+        "wildtype": wildtype,
+        "variable_positions": jnp.asarray(variable_positions, dtype=jnp.int32),
+        "allowed_indices": jnp.asarray(allowed_indices, dtype=jnp.int32),
+    }
+    gradient_constrained_loss = SequenceConstraintLoss(
+        loss=gradient_model_loss,
+        **constraint_kwargs,
+    )
+    deterministic_constrained_loss = SequenceConstraintLoss(
+        loss=deterministic_model_loss,
+        **constraint_kwargs,
+    )
+
+    seed = int(job["seed"])
+    key = jax.random.key(seed)
+    optimization_key, prediction_key = jax.random.split(key)
+    logits = 0.01 * jax.random.normal(
+        optimization_key,
+        (len(variable_positions), len(allowed_indices)),
+    )
+    learning_rate = float(advanced.get("mosaic_learning_rate", 0.1))
+
+    def find_auxiliary_metric(value, name):
+        if isinstance(value, dict):
+            if name in value:
+                candidate = value[name]
+                if hasattr(candidate, "shape") and candidate.shape == ():
+                    return float(candidate)
+                if isinstance(candidate, (int, float)):
+                    return float(candidate)
+            for nested in value.values():
+                candidate = find_auxiliary_metric(nested, name)
+                if candidate is not None:
+                    return candidate
+        elif isinstance(value, (list, tuple)):
+            for nested in value:
+                candidate = find_auxiliary_metric(nested, name)
+                if candidate is not None:
+                    return candidate
+        return None
+
+    def collect_stage_step(auxiliary, stage_logits):
+        return {
+            "loss": float(auxiliary["loss"]),
+            "plddt": find_auxiliary_metric(auxiliary, "binder_plddt"),
+            "logits": stage_logits,
+        }
+
+    stage_best_logits = None
+
+    def run_stage(*, dropout: bool, **stage_kwargs):
+        nonlocal logits, optimization_key, stage_best_logits
+        optimization_key, stage_key = jax.random.split(optimization_key)
+        entry_logits = logits
+        logits, trajectory = colabdesign_stage(
+            loss_function=(
+                gradient_constrained_loss
+                if dropout
+                else deterministic_constrained_loss
+            ),
+            x=logits,
+            lr=learning_rate,
+            key=stage_key,
+            trajectory_fn=collect_stage_step,
+            **stage_kwargs,
+        )
+        # colabdesign_stage applies the gradient update *before* invoking
+        # trajectory_fn, so each entry pairs a loss measured on the pre-update
+        # sequence with the post-update sequence. Re-align them so that the
+        # recorded logits are the ones that actually produced the loss.
+        steps = _align_stage_trajectory(entry_logits, trajectory)
+        best_step = min(steps, key=lambda step: step["loss"])
+        if best_step["plddt"] is None:
+            raise RuntimeError("Mosaic stage did not report binder pLDDT")
+        # ColabDesign runs every stage with save_best=True and calls clear_best()
+        # at each stage boundary, so the lowest-loss iterate of the most recent
+        # stage is what save_pdb()/get_seqs() return. Optimisation itself is not
+        # rewound, so `logits` deliberately keeps the last iterate.
+        stage_best_logits = best_step["logits"]
+        # DdCraft's get_best_plddt rounds before comparing against the 0.65 gate.
+        return round(best_step["plddt"], 2)
+
+    initial_logits_steps = min(50, int(advanced.get("soft_iterations", 100)))
+    stage_plddt = run_stage(
+        dropout=True,
+        n_steps=initial_logits_steps,
+        soft_start=0.0,
+        soft_end=0.9,
+        temp_start=1.0,
+        temp_end=1.0,
+        hard=False,
+    )
+    print(f"logits binder pLDDT: {stage_plddt:.4f}", flush=True)
+    status = "ok"
+    failure_stage = None
+    if stage_plddt <= 0.65:
+        status = "low_confidence"
+        failure_stage = "logits"
+    else:
+        remaining_logits = max(
+            0, int(advanced.get("soft_iterations", 100)) - initial_logits_steps
+        )
+        if remaining_logits:
+            stage_plddt = run_stage(
+                dropout=True,
+                n_steps=remaining_logits,
+                soft_start=0.9,
+                soft_end=1.0,
+                temp_start=1.0,
+                temp_end=1.0,
+                hard=False,
+            )
+            print(f"additional logits binder pLDDT: {stage_plddt:.4f}", flush=True)
+
+        temporary_iterations = int(advanced.get("temporary_iterations", 50))
+        if temporary_iterations:
+            stage_plddt = run_stage(
+                dropout=True,
+                n_steps=temporary_iterations,
+                soft_start=1.0,
+                soft_end=1.0,
+                temp_start=1.0,
+                temp_end=1e-2,
+                hard=False,
+            )
+        print(f"softmax binder pLDDT: {stage_plddt:.4f}", flush=True)
+        if stage_plddt <= 0.65:
+            status = "low_confidence"
+            failure_stage = "softmax"
+        else:
+            hard_iterations = int(advanced.get("hard_iterations", 50))
+            if hard_iterations:
+                stage_plddt = run_stage(
+                    dropout=False,
+                    n_steps=hard_iterations,
+                    soft_start=1.0,
+                    soft_end=1.0,
+                    temp_start=1e-2,
+                    temp_end=1e-2,
+                    hard=True,
+                )
+            print(f"one-hot binder pLDDT: {stage_plddt:.4f}", flush=True)
+            if stage_plddt <= 0.65:
+                status = "low_confidence"
+                failure_stage = "one-hot"
+
+    # The semigreedy walk continues from the last iterate, matching ColabDesign,
+    # but the stage's best-loss iterate stays eligible for the final output.
+    variable_ids = jax.nn.softmax(logits).argmax(-1)
+    stage_best_ids = (
+        jax.nn.softmax(stage_best_logits).argmax(-1)
+        if stage_best_logits is not None
+        else variable_ids
+    )
+    if status == "ok" and int(advanced.get("greedy_iterations", 0)) > 0:
+        greedy_tries = max(
+            1,
+            math.ceil(
+                binder_length
+                * (float(advanced.get("greedy_percentage", 30)) / 100.0)
+            ),
+        )
+        design_models = design_model_indices
+        rng = np.random.default_rng(seed)
+
+        def evaluate_discrete(ids, model_index, evaluation_key):
+            pssm = deterministic_constrained_loss.sequence(
+                jax.nn.one_hot(ids, len(allowed_indices))
+            )
+            prediction_kwargs = design_model.member_kwargs(model_index)
+            if design_selection.sampling_steps is not None:
+                prediction_kwargs["sampling_steps"] = design_selection.sampling_steps
+            prediction = design_model.predict(
+                PSSM=pssm,
+                features=features,
+                writer=writer,
+                recycling_steps=recycling_steps,
+                key=evaluation_key,
+                **prediction_kwargs,
+            )
+            value, _ = objective(
+                pssm,
+                output=prediction.model_output,
+                key=evaluation_key,
+            )
+            return float(value), prediction
+
+        initial_model = design_models[0]
+        optimization_key, evaluation_key = jax.random.split(optimization_key)
+        best_greedy_score, current_prediction = evaluate_discrete(
+            variable_ids,
+            initial_model,
+            evaluation_key,
+        )
+        best_variable_ids = variable_ids
+        # ColabDesign does not clear_best() before the semigreedy stage, so the
+        # preceding stage's best iterate competes with the greedy candidates.
+        if not bool(jnp.array_equal(stage_best_ids, variable_ids)):
+            optimization_key, stage_best_key = jax.random.split(optimization_key)
+            stage_best_score, _ = evaluate_discrete(
+                stage_best_ids,
+                initial_model,
+                stage_best_key,
+            )
+            if stage_best_score < best_greedy_score:
+                best_greedy_score = stage_best_score
+                best_variable_ids = stage_best_ids
+        for iteration in range(int(advanced.get("greedy_iterations", 0))):
+            if advanced.get("sample_models", True):
+                model_index = int(rng.choice(design_models))
+            else:
+                model_index = design_models[0]
+            binder_plddt = np.asarray(current_prediction.plddt)[:binder_length]
+            position_weights = np.maximum(
+                1.0 - binder_plddt[np.asarray(variable_positions)],
+                0.0,
+            )
+            if not np.isfinite(position_weights).all() or position_weights.sum() <= 0:
+                position_weights = np.ones(len(variable_positions))
+            position_weights = position_weights / position_weights.sum()
+
+            candidates = []
+            optimization_key, iteration_key = jax.random.split(optimization_key)
+            candidate_keys = jax.random.split(iteration_key, greedy_tries)
+            for candidate_index in range(greedy_tries):
+                candidate = np.asarray(variable_ids).copy()
+                position = int(
+                    rng.choice(len(variable_positions), p=position_weights)
+                )
+                probabilities = np.ones(len(allowed_indices), dtype=float)
+                probabilities[int(candidate[position])] = 0
+                probabilities /= probabilities.sum()
+                candidate[position] = int(
+                    rng.choice(len(allowed_indices), p=probabilities)
+                )
+                score, prediction = evaluate_discrete(
+                    jnp.asarray(candidate),
+                    model_index,
+                    candidate_keys[candidate_index],
+                )
+                candidates.append((score, candidate, prediction))
+
+            score, selected_ids, current_prediction = min(
+                candidates, key=lambda candidate: candidate[0]
+            )
+            variable_ids = jnp.asarray(selected_ids)
+            if score < best_greedy_score:
+                best_greedy_score = score
+                best_variable_ids = variable_ids
+            print(
+                f"semigreedy {iteration}: loss={score:.4f} "
+                f"model={model_index} tries={greedy_tries}",
+                flush=True,
+            )
+        variable_ids = best_variable_ids
+    else:
+        # No semigreedy stage ran, so the output is the last stage's best-loss
+        # iterate, matching ColabDesign's save_pdb()/get_seqs() defaults.
+        variable_ids = stage_best_ids
+
+    variable_pssm = jax.nn.one_hot(variable_ids, len(allowed_indices))
+
+    final_pssm = deterministic_constrained_loss.sequence(variable_pssm)
+    candidate_models = design_model_indices
+    best_prediction = None
+    best_score = float("inf")
+    best_model_index = candidate_models[0]
+    for model_index in candidate_models:
+        prediction_key, model_key = jax.random.split(prediction_key)
+        prediction_kwargs = design_model.member_kwargs(model_index)
+        if design_selection.sampling_steps is not None:
+            prediction_kwargs["sampling_steps"] = design_selection.sampling_steps
+        prediction = design_model.predict(
+            PSSM=final_pssm,
+            features=features,
+            writer=writer,
+            recycling_steps=recycling_steps,
+            key=model_key,
+            **prediction_kwargs,
+        )
+        value, _ = objective(
+            final_pssm,
+            output=prediction.model_output,
+            key=model_key,
+        )
+        score = float(value)
+        if score < best_score:
+            best_score = score
+            best_prediction = prediction
+            best_model_index = model_index
+
+    if best_prediction is None:
+        raise RuntimeError("Mosaic final prediction did not produce a candidate")
+
+    output_pdb = Path(job["output_pdb"])
+    output_pdb.parent.mkdir(parents=True, exist_ok=True)
+    best_prediction.st.write_pdb(str(output_pdb))
+
+    model_output = best_prediction.model_output
+    binder_metric_mask = np.zeros(binder_length, dtype=np.float32)
+    binder_metric_mask[binder_active_indices] = 1
+    target_metric_mask = np.zeros(target_length, dtype=np.float32)
+    target_metric_mask[target_active_indices] = 1
+    binder_plddt = np.asarray(best_prediction.plddt)[:binder_length]
+    plddt = float(
+        (binder_plddt * binder_metric_mask).sum()
+        / (binder_metric_mask.sum() + 1e-8)
+    )
+    raw_pae = np.asarray(best_prediction.pae)
+    pae = _normalized_symmetric_pae(raw_pae, np)
+    pair_mask = jnp.ones(pae.shape, dtype=bool)
+    ptm = float(
+        sp.predicted_tm_score(
+            logits=model_output.pae_logits,
+            bin_centers=model_output.pae_bins,
+            pair_mask=pair_mask,
+        ).max()
+    )
+    # Mosaic gives every chain its own asym_id, so a multi-chain target would
+    # count target-target pairs as interface. ColabDesign's binder mode uses
+    # _lengths = [target_len, binder_len], i.e. exactly two groups, so score the
+    # binder against the rest of the complex the way IPTMLoss already does.
+    iptm_asym_id = jnp.concatenate(
+        (
+            jnp.zeros(binder_length),
+            jnp.ones(pae.shape[0] - binder_length),
+        )
+    ).astype(jnp.int32)
+    iptm = float(
+        sp.predicted_tm_score(
+            logits=model_output.pae_logits,
+            bin_centers=model_output.pae_bins,
+            pair_mask=iptm_asym_id[:, None] != iptm_asym_id[None, :],
+        ).max()
+    )
+    ipsae_config = advanced.get("ipsae", {})
+    ipsae = None
+    if isinstance(ipsae_config, dict) and ipsae_config.get("enabled", False):
+        ipsae_values = sp.interaction_prediction_score(
+            logits=model_output.pae_logits,
+            bin_centers=model_output.pae_bins,
+            asym_id=iptm_asym_id,
+            pae_cutoff=float(ipsae_config.get("cutoff", 10.0)),
+        )
+        ipsae = float(jnp.max(ipsae_values))
+
+    sequence_ids = np.asarray(final_pssm).argmax(-1)
+    sequence = "".join(TOKENS[index] for index in sequence_ids)
+    return {
+        "status": status,
+        "failure_stage": failure_stage,
+        "design_name": job["design_name"],
+        "selected_model": best_model_index,
+        "objective": best_score,
+        "metrics": {
+            "sequence": sequence,
+            "plddt": plddt,
+            "ptm": ptm,
+            "i_ptm": iptm,
+            "pae": float(
+                (pae[:binder_length] * binder_metric_mask[:, None]).sum()
+                / (
+                    (
+                        binder_metric_mask[:, None]
+                        * np.ones_like(pae[:binder_length])
+                    ).sum()
+                    + 1e-8
+                )
+            ),
+            "i_pae": float(
+                (
+                    pae[:binder_length, binder_length:]
+                    * binder_metric_mask[:, None]
+                    * target_metric_mask[None, :]
+                ).sum()
+                / (
+                    (
+                        binder_metric_mask[:, None]
+                        * target_metric_mask[None, :]
+                    ).sum()
+                    + 1e-8
+                )
+            ),
+            "ipsae": ipsae,
+            "mosaic_objective": best_score,
+        },
+    }
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--job", type=Path, required=True)
+    parser.add_argument("--result", type=Path)
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Validate the job without importing Mosaic/JAX",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = create_parser().parse_args(argv)
+    try:
+        job = load_job(args.job)
+        if args.validate_only:
+            print("Mosaic job configuration is valid")
+            return 0
+        if args.result is None:
+            raise ValueError("--result is required unless --validate-only is used")
+        result = run_job(job)
+        _write_json(args.result, result)
+        print(
+            f"Completed {result['design_name']} with status={result['status']} "
+            f"pLDDT={result['metrics']['plddt']:.4f} "
+            f"iPTM={result['metrics']['i_ptm']:.4f}"
+        )
+        return 0
+    except Exception as exc:
+        if args.result is not None:
+            _write_json(
+                args.result,
+                {
+                    "status": "error",
+                    "error": str(exc),
+                    "traceback": traceback.format_exc(),
+                },
+            )
+        print(f"Mosaic job failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mosaic/binder_design/validation.py
+++ b/src/mosaic/binder_design/validation.py
@@ -1,0 +1,242 @@
+"""Stage 3: fold the designed sequences and score their confidence.
+
+DdCraft runs this stage through ColabDesign; here it runs on a Mosaic
+``StructurePredictionModel``.  The predictor is deliberately model-agnostic --
+anything implementing ``target_only_features``/``binder_features``/``predict``
+(AlphaFold2 today, Boltz / ESMFold / Protenix / OpenFold3 tomorrow) can be
+dropped in, which is the whole point of moving the pipeline into Mosaic.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import gemmi
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from mosaic.binder_design.metrics import (
+    ConfidenceMetrics,
+    complex_metrics,
+    monomer_metrics,
+)
+from mosaic.structure_prediction import TargetChain
+
+__all__ = ["ComplexPredictor", "ModelPrediction", "MonomerPredictor", "clean_sequence"]
+
+_AA_ORDER = "ARNDCQEGHILKMFPSTWYV"
+_AA_INDEX = {aa: i for i, aa in enumerate(_AA_ORDER)}
+
+
+def clean_sequence(sequence: str) -> str:
+    """Strip chain separators and anything that is not a residue letter."""
+    return re.sub("[^A-Z]", "", sequence.upper())
+
+
+def _one_hot(sequence: str) -> jnp.ndarray:
+    idx = np.array([_AA_INDEX[aa] for aa in sequence], dtype=np.int32)
+    return jax.nn.one_hot(jnp.asarray(idx), len(_AA_ORDER))
+
+
+@dataclass
+class ModelPrediction:
+    model_index: int
+    metrics: ConfidenceMetrics
+    structure: gemmi.Structure
+
+    def write_pdb(self, path: str | Path) -> Path:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.structure.write_pdb(str(path))
+        return path
+
+
+def _chain_sequence(chain: gemmi.Chain) -> str:
+    return gemmi.one_letter_code([residue.name for residue in chain]).upper()
+
+
+class ComplexPredictor:
+    """Predicts binder + target complexes with the target supplied as template.
+
+    Features are built once and reused for every sequence, which is what makes
+    validation cheap: only the binder one-hot changes between designs.
+    """
+
+    def __init__(
+        self,
+        model,
+        *,
+        target_pdb: str | Path,
+        target_chains: list[str] | str,
+        binder_length: int,
+        recycling_steps: int = 3,
+        model_indices: list[int] | None = None,
+        sampling_steps: int | None = None,
+        ipsae_cutoff: float | None = None,
+        advanced_settings: dict | None = None,
+    ):
+        if isinstance(target_chains, str):
+            target_chains = [c.strip() for c in target_chains.split(",") if c.strip()]
+
+        structure = gemmi.read_structure(str(target_pdb))
+        structure.setup_entities()
+        structure.remove_ligands_and_waters()
+        structure.remove_hydrogens()
+        lookup = {chain.name: chain for chain in structure[0]}
+        missing = [c for c in target_chains if c not in lookup]
+        if missing:
+            raise ValueError(f"{target_pdb}: target chains {missing} not found")
+
+        self.model = model
+        self.binder_length = binder_length
+        self.recycling_steps = recycling_steps
+        self.ipsae_cutoff = ipsae_cutoff
+        self.sampling_steps = sampling_steps
+        self.target_lengths = [len(_chain_sequence(lookup[c])) for c in target_chains]
+        self.target_length = sum(self.target_lengths)
+
+        target_specs = [
+            TargetChain(
+                sequence=_chain_sequence(lookup[c]),
+                use_msa=False,
+                template_chain=(
+                    lookup[c] if model.supports_template_chains() else None
+                ),
+            )
+            for c in target_chains
+        ]
+        self.target_specs = target_specs
+        if model.prediction_features_depend_on_sequence():
+            self.features, self.writer = None, None
+        else:
+            self.features, self.writer = model.binder_features(
+                binder_length=binder_length, chains=target_specs
+            )
+        if advanced_settings and self.features is not None:
+            from mosaic.binder_design.trajectory import _apply_template_masks
+
+            self.features = _apply_template_masks(
+                self.features, binder_length, advanced_settings, stage="predict"
+            )
+        self.model_indices = list(
+            model.ensemble_members() if model_indices is None else model_indices
+        )
+
+    def _prediction_inputs(self, sequence: str):
+        if self.model.prediction_features_depend_on_sequence():
+            features, writer = self.model.target_only_features(
+                [TargetChain(sequence=sequence, use_msa=False), *self.target_specs]
+            )
+            return None, features, writer
+        return _one_hot(sequence), self.features, self.writer
+
+    def predict(
+        self,
+        sequence: str,
+        *,
+        key,
+        binder_mask: np.ndarray | None = None,
+        target_mask: np.ndarray | None = None,
+        model_indices: list[int] | None = None,
+    ) -> list[ModelPrediction]:
+        sequence = clean_sequence(sequence)
+        if len(sequence) != self.binder_length:
+            raise ValueError(
+                f"sequence length {len(sequence)} != binder length {self.binder_length}"
+            )
+        pssm, features, writer = self._prediction_inputs(sequence)
+
+        results = []
+        for model_index in model_indices or self.model_indices:
+            key, sub = jax.random.split(key)
+            model_kwargs = self.model.member_kwargs(model_index)
+            if self.sampling_steps is not None:
+                model_kwargs["sampling_steps"] = self.sampling_steps
+            prediction = self.model.predict(
+                PSSM=pssm,
+                features=features,
+                writer=writer,
+                recycling_steps=self.recycling_steps,
+                key=sub,
+                **model_kwargs,
+            )
+            results.append(
+                ModelPrediction(
+                    model_index=model_index,
+                    metrics=complex_metrics(
+                        prediction,
+                        binder_length=self.binder_length,
+                        binder_mask=binder_mask,
+                        target_mask=target_mask,
+                        ipsae_cutoff=self.ipsae_cutoff,
+                    ),
+                    structure=prediction.st,
+                )
+            )
+        return results
+
+
+class MonomerPredictor:
+    """Predicts the binder on its own, with no target and no templates."""
+
+    def __init__(
+        self,
+        model,
+        *,
+        binder_length: int,
+        recycling_steps: int = 3,
+        model_indices: list[int] | None = None,
+        sampling_steps: int | None = None,
+    ):
+        self.model = model
+        self.binder_length = binder_length
+        self.recycling_steps = recycling_steps
+        self.sampling_steps = sampling_steps
+        if model.prediction_features_depend_on_sequence():
+            self.features, self.writer = None, None
+        else:
+            self.features, self.writer = model.target_only_features(
+                [TargetChain(sequence="G" * binder_length, use_msa=False)]
+            )
+        self.model_indices = list(
+            model.ensemble_members() if model_indices is None else model_indices
+        )
+
+    def _prediction_inputs(self, sequence: str):
+        if self.model.prediction_features_depend_on_sequence():
+            features, writer = self.model.target_only_features(
+                [TargetChain(sequence=sequence, use_msa=False)]
+            )
+            return None, features, writer
+        return _one_hot(sequence), self.features, self.writer
+
+    def predict(
+        self, sequence: str, *, key, model_indices: list[int] | None = None
+    ) -> list[ModelPrediction]:
+        sequence = clean_sequence(sequence)
+        pssm, features, writer = self._prediction_inputs(sequence)
+        results = []
+        for model_index in model_indices or self.model_indices:
+            key, sub = jax.random.split(key)
+            model_kwargs = self.model.member_kwargs(model_index)
+            if self.sampling_steps is not None:
+                model_kwargs["sampling_steps"] = self.sampling_steps
+            prediction = self.model.predict(
+                PSSM=pssm,
+                features=features,
+                writer=writer,
+                recycling_steps=self.recycling_steps,
+                key=sub,
+                **model_kwargs,
+            )
+            results.append(
+                ModelPrediction(
+                    model_index=model_index,
+                    metrics=monomer_metrics(prediction),
+                    structure=prediction.st,
+                )
+            )
+        return results

--- a/src/mosaic/models/af2.py
+++ b/src/mosaic/models/af2.py
@@ -64,7 +64,11 @@ class AFOutput(eqx.Module):
     recycling_state: state.AlphaFoldState
 
 
-def load_af2(data_dir: str | Path | None = None, multimer=True):
+def load_af2(
+    data_dir: str | Path | None = None,
+    multimer=True,
+    model_numbers: tuple[int, ...] | None = None,
+):
     data_dir = resolve_cache(data_dir, "alphafold2")
 
     if not (data_dir / "params").exists():
@@ -87,13 +91,14 @@ def load_af2(data_dir: str | Path | None = None, multimer=True):
             tar.extractall(path=params_dir)
         tar_path.unlink()
 
+    numbers = tuple(model_numbers or range(1, 6 if multimer else 3))
+    model_names = [
+        f"model_{i}_{'multimer_v3' if multimer else 'ptm'}" for i in numbers
+    ]
     try:
         model_params = [
             data.get_model_haiku_params(model_name=model_name, data_dir=data_dir)
-            for model_name in tqdm(
-                [f"model_{i}_{'multimer_v3' if multimer else 'ptm'}" for i in range(1, 6 if multimer else 3)],
-                desc="Loading AF2 params",
-            )
+            for model_name in tqdm(model_names, desc="Loading AF2 params")
         ]
     except FileNotFoundError as e:
         raise FileNotFoundError(
@@ -101,7 +106,9 @@ def load_af2(data_dir: str | Path | None = None, multimer=True):
         )
     stacked_model_params = tree.map(lambda *v: np.stack(v), *model_params)
 
-    cfg = config.model_config("model_1_multimer_v3" if multimer else "model_1_ptm")
+    # Monomer models 3-5 are trained without templates, so derive the config
+    # from a parameter set that is actually being loaded.
+    cfg = config.model_config(model_names[0])
     cfg.max_msa_clusters = 1
     cfg.max_extra_msa = 1
     cfg.masked_msa_replace_fraction = 0
@@ -379,12 +386,40 @@ class AlphaFold2(StructurePredictionModel):
     af2_forward: callable
     stacked_parameters: PyTree
     multimer: bool
+    model_numbers: tuple[int, ...] = eqx.field(static=True)
 
-    def __init__(self, data_dir: str | Path | None = None, multimer=True):
-        (forward_function, stacked_params) = load_af2(data_dir=data_dir, multimer=multimer)
+    def __init__(
+        self,
+        data_dir: str | Path | None = None,
+        multimer=True,
+        model_numbers: tuple[int, ...] | None = None,
+    ):
+        """Load an explicit compatible subset of one-based AF2 networks."""
+        (forward_function, stacked_params) = load_af2(
+            data_dir=data_dir, multimer=multimer, model_numbers=model_numbers
+        )
         self.af2_forward = forward_function
         self.stacked_parameters = stacked_params
         self.multimer = multimer
+        self.model_numbers = tuple(
+            model_numbers or range(1, 6 if multimer else 3)
+        )
+
+    def ensemble_members(self) -> tuple[int, ...]:
+        """Return global zero-based indices for the loaded parameter sets."""
+        return tuple(number - 1 for number in self.model_numbers)
+
+    def member_kwargs(self, member: int) -> dict:
+        """Translate a global member into its position in the loaded stack."""
+        try:
+            return {"model_idx": self.model_numbers.index(member + 1)}
+        except ValueError:
+            raise ValueError(
+                f"model {member + 1} is not loaded; have {list(self.model_numbers)}"
+            ) from None
+
+    def design_member_kwargs(self, member: int, *, use_dropout: bool) -> dict:
+        return {**self.member_kwargs(member), "use_dropout": use_dropout}
 
     def target_only_features(self, chains: list[TargetChain]):
         for c in chains:

--- a/src/mosaic/models/esmfold2.py
+++ b/src/mosaic/models/esmfold2.py
@@ -268,6 +268,14 @@ class ESMFold2(StructurePredictionModel):
     esmc_token_of_aa: Int[Array, "20"]
     unk_input_id: int = eqx.field(static=True)
 
+    def supports_template_chains(self) -> bool:
+        return False
+
+    def prediction_features_depend_on_sequence(self) -> bool:
+        # Native validation must use real residue identities and atom packing;
+        # a reusable design pack takes the geometry-refresh training path.
+        return True
+
     def _check_msa_compat(self, chains: list[TargetChain]) -> None:
         # The Fast checkpoint has no MSA encoder; an MSA would put its
         # `profile` aggregate off-distribution, so refuse rather than
@@ -703,6 +711,5 @@ def ESMFold2ExperimentalFull2025() -> ESMFold2:
     for target structure prediction with real MSAs.
     """
     return _make("biohub/ESMFold2-Experimental-Cutoff2025", experimental=True)
-
 
 

--- a/src/mosaic/models/protenix.py
+++ b/src/mosaic/models/protenix.py
@@ -4,8 +4,10 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import protenix.backend as protenix_backend
+import protenix.data.ccd as protenix_ccd
 from jaxtyping import Array, Float, PyTree
 
+from protenix.configs.configs_data import data_configs
 from protenix.data.template import ChainInput, featurize
 
 from mosaic.losses.protenix import (
@@ -41,7 +43,21 @@ def install_protenix_msa_auth_fix():
 install_protenix_msa_auth_fix()
 
 def load_model(name="protenix_mini_default_v0.5.0"):
-    protenix_backend._CACHE_DIR = str(cache_dir() / "protenix")
+    cache_root = cache_dir() / "protenix"
+    protenix_backend._CACHE_DIR = str(cache_root)
+    data_configs["ccd_components_file"] = str(
+        cache_root / "components.v20240608.cif"
+    )
+    data_configs["ccd_components_rdkit_mol_file"] = str(
+        cache_root / "components.v20240608.cif.rdkit_mol.pkl"
+    )
+    data_configs["pdb_cluster_file"] = str(
+        cache_root / "clusters-by-entity-40.txt"
+    )
+    protenix_ccd.COMPONENTS_FILE = data_configs["ccd_components_file"]
+    protenix_ccd.RKDIT_MOL_PKL = (
+        cache_root / "components.v20240608.cif.rdkit_mol.pkl"
+    )
     jax_model = protenix_backend.load_model(name)
     # set gamma0, step_scale_eta, and N_steps to match the vanilla ODE sampler settings
     jax_model = eqx.tree_at(lambda m: (m.gamma0, m.step_scale_eta, m.noise_scale_lambda, m.N_steps), jax_model, (0.0, 1.0, 1.0, 20))

--- a/src/mosaic/proteinmpnn/inputs.py
+++ b/src/mosaic/proteinmpnn/inputs.py
@@ -1,0 +1,159 @@
+"""Build ProteinMPNN inputs from a PDB file.
+
+Mirrors ColabDesign's ``mk_mpnn_model().prep_inputs`` so that mosaic can design
+sequences on the same backbones without going through ColabDesign.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import gemmi
+import numpy as np
+
+from mosaic.proteinmpnn.sampling import encode_sequence
+
+__all__ = ["MPNNInputs", "inputs_from_pdb", "parse_fixed_positions"]
+
+_BACKBONE = ("N", "CA", "C", "O")
+
+_THREE_TO_ONE = {
+    "ALA": "A", "ARG": "R", "ASN": "N", "ASP": "D", "CYS": "C",
+    "GLN": "Q", "GLU": "E", "GLY": "G", "HIS": "H", "ILE": "I",
+    "LEU": "L", "LYS": "K", "MET": "M", "PHE": "F", "PRO": "P",
+    "SER": "S", "THR": "T", "TRP": "W", "TYR": "Y", "VAL": "V",
+}
+
+
+@dataclass
+class MPNNInputs:
+    X: np.ndarray  # (L, 4, 3) N, CA, C, O
+    S: np.ndarray  # (L,) indices into MPNN_ALPHABET
+    mask: np.ndarray  # (L,) bool
+    residue_idx: np.ndarray  # (L,) per-chain, offset by chain
+    chain_index: np.ndarray  # (L,) 0-based chain number
+    chains: list[str]
+    lengths: list[int]
+    residue_numbers: np.ndarray  # (L,) author numbering, for fix_pos parsing
+
+    @property
+    def sequence(self) -> str:
+        from mosaic.proteinmpnn.sampling import decode_sequence
+
+        return decode_sequence(self.S)
+
+    def chain_slice(self, chain: str) -> slice:
+        i = self.chains.index(chain)
+        start = int(sum(self.lengths[:i]))
+        return slice(start, start + self.lengths[i])
+
+
+def inputs_from_pdb(
+    pdb_path: str | Path,
+    chains: str | list[str] | None = None,
+) -> MPNNInputs:
+    """Parse ``pdb_path`` into ProteinMPNN inputs.
+
+    ``chains`` selects and orders the chains (``"A,B"`` or ``["A", "B"]``).
+    """
+    structure = gemmi.read_structure(str(pdb_path))
+    structure.setup_entities()
+    structure.remove_alternative_conformations()
+    structure.remove_hydrogens()
+    structure.remove_ligands_and_waters()
+    model = structure[0]
+
+    available = [chain.name for chain in model]
+    if chains is None:
+        selected = available
+    else:
+        if isinstance(chains, str):
+            chains = [c.strip() for c in chains.split(",") if c.strip()]
+        missing = [c for c in chains if c not in available]
+        if missing:
+            raise ValueError(f"{pdb_path}: chains {missing} not found in {available}")
+        selected = list(chains)
+
+    X, S, mask, residue_idx, chain_index, residue_numbers = [], [], [], [], [], []
+    lengths = []
+
+    for chain_number, chain_name in enumerate(selected):
+        chain = model[chain_name]
+        n_residues = 0
+        for position, residue in enumerate(chain):
+            one_letter = _THREE_TO_ONE.get(residue.name, "X")
+            coords = np.full((4, 3), np.nan, dtype=np.float32)
+            found = 0
+            for atom_i, atom_name in enumerate(_BACKBONE):
+                atom = residue.find_atom(atom_name, "*")
+                if atom is not None:
+                    coords[atom_i] = [atom.pos.x, atom.pos.y, atom.pos.z]
+                    found += 1
+            if found == 0:
+                continue
+
+            X.append(np.nan_to_num(coords))
+            S.append(one_letter)
+            mask.append(found == len(_BACKBONE))
+            residue_idx.append(position + 100 * chain_number)
+            chain_index.append(chain_number)
+            residue_numbers.append(residue.seqid.num)
+            n_residues += 1
+        lengths.append(n_residues)
+
+    if not X:
+        raise ValueError(f"{pdb_path}: no residues with backbone atoms found")
+
+    return MPNNInputs(
+        X=np.stack(X).astype(np.float32),
+        S=encode_sequence("".join(S)),
+        mask=np.array(mask, dtype=bool),
+        residue_idx=np.array(residue_idx, dtype=np.int32),
+        chain_index=np.array(chain_index, dtype=np.int32),
+        chains=selected,
+        lengths=lengths,
+        residue_numbers=np.array(residue_numbers, dtype=np.int32),
+    )
+
+
+def parse_fixed_positions(spec: str, inputs: MPNNInputs) -> np.ndarray:
+    """Resolve a ColabDesign-style position spec to flat indices.
+
+    Accepts chain-wide selections (``"A"``), single residues (``"B12"``) and
+    ranges (``"B12-20"``), comma separated.  Residue numbers refer to the
+    author numbering in the source PDB.
+    """
+    fixed: set[int] = set()
+    offsets = {c: int(sum(inputs.lengths[:i])) for i, c in enumerate(inputs.chains)}
+
+    for token in spec.split(","):
+        token = token.strip()
+        if not token:
+            continue
+
+        if token in offsets:
+            start = offsets[token]
+            fixed.update(range(start, start + inputs.lengths[inputs.chains.index(token)]))
+            continue
+
+        chain = token[0]
+        if chain not in offsets:
+            raise ValueError(f"unknown chain in fix_pos token {token!r}")
+        body = token[1:]
+        lo, _, hi = body.partition("-")
+        lo_num = int(lo)
+        hi_num = int(hi) if hi else lo_num
+
+        chain_mask = inputs.chain_index == inputs.chains.index(chain)
+        in_range = (
+            chain_mask
+            & (inputs.residue_numbers >= lo_num)
+            & (inputs.residue_numbers <= hi_num)
+        )
+        found = np.flatnonzero(in_range)
+        if found.size == 0:
+            raise ValueError(f"fix_pos token {token!r} matched no residues")
+        fixed.update(found.tolist())
+
+    return np.array(sorted(fixed), dtype=np.int32)

--- a/src/mosaic/proteinmpnn/sampling.py
+++ b/src/mosaic/proteinmpnn/sampling.py
@@ -1,0 +1,355 @@
+"""Autoregressive sampling for ProteinMPNN.
+
+`mosaic.losses.protein_mpnn.inverse_fold` uses Jacobi iteration, which is fast
+and differentiable but only approximates the true autoregressive distribution
+and offers no way to hold positions fixed.  Binder design pipelines need exact
+sampling with fixed positions (target chain + interface hotspots) and amino
+acid omission, so this module implements the real thing.
+
+The sampler walks the decoding order one designable position at a time,
+re-running :meth:`ProteinMPNN.decode` with the partially decoded sequence.  The
+autoregressive mask guarantees the logits at the position being decoded depend
+only on positions decoded earlier, so this is mathematically identical to the
+cached incremental decoder in the reference implementation -- just expressed
+with the ``decode`` primitive mosaic already has.  Fixed positions are placed
+first in the decoding order, so the scan only runs over designable positions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, Bool, Float, Int
+
+from mosaic.proteinmpnn.mpnn import MPNN_ALPHABET, ProteinMPNN
+
+__all__ = [
+    "MPNN_ALPHABET",
+    "MPNNSample",
+    "encode_sequence",
+    "decode_sequence",
+    "make_bias",
+    "sample",
+    "sample_batch",
+    "score_sequence",
+]
+
+_N_AA = 20
+_N_TOKENS = len(MPNN_ALPHABET)
+_AA_TO_IDX = {aa: i for i, aa in enumerate(MPNN_ALPHABET)}
+
+
+def encode_sequence(seq: str) -> np.ndarray:
+    """Amino acid string -> indices in the ProteinMPNN alphabet."""
+    return np.array([_AA_TO_IDX.get(aa, _AA_TO_IDX["X"]) for aa in seq], dtype=np.int32)
+
+
+def decode_sequence(indices) -> str:
+    """Indices in the ProteinMPNN alphabet -> amino acid string."""
+    return "".join(MPNN_ALPHABET[int(i)] for i in np.asarray(indices))
+
+
+def make_bias(
+    length: int,
+    *,
+    omit_AAs: str | None = None,
+    per_position_bias: dict[int, dict[str, float]] | None = None,
+) -> np.ndarray:
+    """Build an additive logit bias of shape ``(length, len(MPNN_ALPHABET))``.
+
+    ``omit_AAs`` accepts either ``"CM"`` or ``"C,M"``.  ``X`` is always omitted.
+    """
+    bias = np.zeros((length, _N_TOKENS), dtype=np.float32)
+    bias[:, _N_AA:] = -1e6
+
+    if omit_AAs:
+        for aa in omit_AAs.replace(",", "").strip():
+            if aa in _AA_TO_IDX:
+                bias[:, _AA_TO_IDX[aa]] -= 1e6
+
+    if per_position_bias:
+        for pos, entries in per_position_bias.items():
+            for aa, value in entries.items():
+                if aa in _AA_TO_IDX:
+                    bias[pos, _AA_TO_IDX[aa]] += value
+
+    return bias
+
+
+@dataclass
+class MPNNSample:
+    """One sampled sequence plus the statistics the design pipeline reports."""
+
+    sequence: str
+    S: np.ndarray
+    logits: np.ndarray
+    score: float
+    seqid: float
+    decoding_order: np.ndarray
+
+    def chains(self, chain_index) -> list[str]:
+        chain_index = np.asarray(chain_index)
+        return [
+            decode_sequence(self.S[chain_index == c])
+            for c in np.unique(chain_index)
+        ]
+
+
+def _decoding_scores(key, mask, fix_pos_mask):
+    """Random decoding order: fixed first, then valid, then padding."""
+    scores = jax.random.uniform(key, shape=mask.shape)
+    scores = jnp.where(mask, scores, scores + 1.0)
+    return jnp.where(fix_pos_mask, scores - 1.0, scores)
+
+
+def _sample_single(
+    mpnn: ProteinMPNN,
+    *,
+    X: Float[Array, "N 4 3"],
+    S_native: Int[Array, " N"],
+    mask: Bool[Array, " N"],
+    residue_idx: Int[Array, " N"],
+    chain_encoding_all: Int[Array, " N"],
+    bias: Float[Array, "N T"],
+    fix_pos_mask: Bool[Array, " N"],
+    n_fixed: int,
+    temperature: float,
+    key,
+):
+    encode_key, order_key, gumbel_key = jax.random.split(key, 3)
+
+    h_V, h_E, E_idx = mpnn.encode(
+        X=X,
+        mask=mask,
+        residue_idx=residue_idx,
+        chain_encoding_all=chain_encoding_all,
+        key=encode_key,
+    )
+
+    order_scores = _decoding_scores(order_key, mask, fix_pos_mask)
+    perm = jnp.argsort(order_scores)
+
+    native_onehot = jax.nn.one_hot(S_native, _N_TOKENS)
+    S_init = jnp.where(fix_pos_mask[:, None], native_onehot, 0.0)
+
+    n_steps = mask.shape[0] - n_fixed
+    gumbel = jax.random.gumbel(gumbel_key, (n_steps, _N_TOKENS))
+
+    def step(carry, xs):
+        S, logits_acc = carry
+        t, noise = xs
+
+        logits = mpnn.decode(
+            S=S,
+            h_V=h_V,
+            h_E=h_E,
+            E_idx=E_idx,
+            mask=mask,
+            decoding_order=order_scores,
+        )[0]
+        logits_t = logits[t]
+        logits_acc = logits_acc.at[t].set(logits_t)
+
+        biased = (logits_t + bias[t]) / temperature + noise
+        # `X` (and any padding tokens) are never sampled.
+        aa = jnp.argmax(biased[:_N_AA])
+        S = S.at[t].set(jax.nn.one_hot(aa, _N_TOKENS))
+        return (S, logits_acc), None
+
+    logits_init = jnp.zeros((mask.shape[0], _N_TOKENS))
+    (S, logits), _ = jax.lax.scan(
+        step, (S_init, logits_init), (perm[n_fixed:], gumbel)
+    )
+
+    return {"S": S, "logits": logits, "decoding_order": perm}
+
+
+def _score_from_logits(logits, S, S_native, mask, fix_pos_mask):
+    score_mask = jnp.logical_and(mask, jnp.logical_not(fix_pos_mask)).astype(jnp.float32)
+    log_q = jax.nn.log_softmax(logits, axis=-1)[..., :_N_AA]
+    per_pos = -(S[..., :_N_AA] * log_q).sum(-1)
+    recovered = (S[..., :_N_AA].argmax(-1) == S_native).astype(jnp.float32)
+    denom = score_mask.sum() + 1e-8
+    return (
+        (per_pos * score_mask).sum(-1) / denom,
+        (recovered * score_mask).sum(-1) / denom,
+    )
+
+
+def _prepare(
+    *,
+    length: int,
+    fix_pos,
+    omit_AAs,
+    bias,
+    mask,
+):
+    fix_pos_mask = np.zeros(length, dtype=bool)
+    if fix_pos is not None:
+        fix_pos = np.asarray(fix_pos)
+        if fix_pos.dtype == bool:
+            fix_pos_mask = fix_pos.copy()
+        else:
+            fix_pos_mask[fix_pos.astype(int)] = True
+
+    mask = np.ones(length, dtype=bool) if mask is None else np.asarray(mask, dtype=bool)
+    # Padding positions carry no information and must not be sampled.
+    fix_pos_mask = np.logical_or(fix_pos_mask, ~mask)
+
+    total_bias = make_bias(length, omit_AAs=omit_AAs)
+    if bias is not None:
+        bias = np.asarray(bias, dtype=np.float32)
+        if bias.shape[-1] == _N_AA:
+            total_bias[:, :_N_AA] += bias
+        else:
+            total_bias += bias
+
+    return fix_pos_mask, mask, total_bias
+
+
+def sample_batch(
+    mpnn: ProteinMPNN,
+    *,
+    X,
+    S_native,
+    residue_idx,
+    chain_encoding_all,
+    key,
+    num_seqs: int = 1,
+    temperature: float = 0.1,
+    fix_pos=None,
+    omit_AAs: str | None = None,
+    bias=None,
+    mask=None,
+    batch_size: int | None = None,
+) -> list[MPNNSample]:
+    """Sample ``num_seqs`` sequences for one backbone.
+
+    Positions listed in ``fix_pos`` keep their residue from ``S_native`` and are
+    decoded first so every designed position is conditioned on them.
+    """
+    X = jnp.asarray(X, dtype=jnp.float32)
+    S_native_np = np.asarray(S_native, dtype=np.int32)
+    length = X.shape[0]
+
+    fix_pos_mask, mask_np, total_bias = _prepare(
+        length=length, fix_pos=fix_pos, omit_AAs=omit_AAs, bias=bias, mask=mask
+    )
+    n_fixed = int(fix_pos_mask.sum())
+    if n_fixed == length:
+        raise ValueError("every position is fixed - nothing to design")
+
+    S_native_j = jnp.asarray(S_native_np)
+    mask_j = jnp.asarray(mask_np)
+    fix_j = jnp.asarray(fix_pos_mask)
+    bias_j = jnp.asarray(total_bias)
+    residue_idx_j = jnp.asarray(residue_idx, dtype=jnp.int32)
+    chain_j = jnp.asarray(chain_encoding_all, dtype=jnp.int32)
+
+    def run(k):
+        out = _sample_single(
+            mpnn,
+            X=X,
+            S_native=S_native_j,
+            mask=mask_j,
+            residue_idx=residue_idx_j,
+            chain_encoding_all=chain_j,
+            bias=bias_j,
+            fix_pos_mask=fix_j,
+            n_fixed=n_fixed,
+            temperature=temperature,
+            key=k,
+        )
+        score, seqid = _score_from_logits(
+            out["logits"], out["S"], S_native_j, mask_j, fix_j
+        )
+        return {**out, "score": score, "seqid": seqid}
+
+    run_batch = jax.jit(jax.vmap(run))
+
+    batch_size = num_seqs if batch_size is None else min(batch_size, num_seqs)
+    samples: list[MPNNSample] = []
+    remaining = num_seqs
+    while remaining > 0:
+        n = min(batch_size, remaining)
+        key, sub = jax.random.split(key)
+        out = jax.tree.map(np.asarray, run_batch(jax.random.split(sub, n)))
+        for i in range(n):
+            S = out["S"][i].argmax(-1)
+            samples.append(
+                MPNNSample(
+                    sequence=decode_sequence(S),
+                    S=S,
+                    logits=out["logits"][i],
+                    score=float(out["score"][i]),
+                    seqid=float(out["seqid"][i]),
+                    decoding_order=out["decoding_order"][i],
+                )
+            )
+        remaining -= n
+
+    return samples
+
+
+def sample(mpnn: ProteinMPNN, **kwargs) -> MPNNSample:
+    """Sample a single sequence.  See :func:`sample_batch`."""
+    return sample_batch(mpnn, num_seqs=1, **kwargs)[0]
+
+
+def score_sequence(
+    mpnn: ProteinMPNN,
+    *,
+    X,
+    S,
+    residue_idx,
+    chain_encoding_all,
+    key,
+    mask=None,
+    fix_pos=None,
+    num_decoding_orders: int = 1,
+) -> tuple[float, np.ndarray]:
+    """Average negative log-likelihood of ``S`` under ``mpnn``.
+
+    This is the teacher-forced score used to rank designs; it averages over
+    ``num_decoding_orders`` random autoregressive orders.
+    """
+    X = jnp.asarray(X, dtype=jnp.float32)
+    S_np = np.asarray(S, dtype=np.int32)
+    length = X.shape[0]
+
+    fix_pos_mask, mask_np, _ = _prepare(
+        length=length, fix_pos=fix_pos, omit_AAs=None, bias=None, mask=mask
+    )
+    S_j = jnp.asarray(S_np)
+    mask_j = jnp.asarray(mask_np)
+    fix_j = jnp.asarray(fix_pos_mask)
+    onehot = jax.nn.one_hot(S_j, _N_TOKENS)
+
+    @jax.jit
+    def one(k):
+        encode_key, order_key = jax.random.split(k)
+        h_V, h_E, E_idx = mpnn.encode(
+            X=X,
+            mask=mask_j,
+            residue_idx=jnp.asarray(residue_idx, dtype=jnp.int32),
+            chain_encoding_all=jnp.asarray(chain_encoding_all, dtype=jnp.int32),
+            key=encode_key,
+        )
+        order_scores = _decoding_scores(order_key, mask_j, fix_j)
+        return mpnn.decode(
+            S=onehot,
+            h_V=h_V,
+            h_E=h_E,
+            E_idx=E_idx,
+            mask=mask_j,
+            decoding_order=order_scores,
+        )[0]
+
+    logits = jnp.mean(
+        jnp.stack([one(k) for k in jax.random.split(key, num_decoding_orders)]), 0
+    )
+    score, _ = _score_from_logits(logits, onehot, S_j, mask_j, fix_j)
+    return float(score), np.asarray(logits)

--- a/src/mosaic/structure_prediction.py
+++ b/src/mosaic/structure_prediction.py
@@ -37,6 +37,25 @@ class StructurePrediction(eqx.Module):
 
 
 class StructurePredictionModel(eqx.Module):
+    def supports_template_chains(self) -> bool:
+        """Whether :class:`TargetChain.template_chain` may be supplied.
+
+        Most backends can consume a target template. Models that cannot must
+        override this so binder design can still use them for de novo
+        hallucination and sequence-only folding without passing unsupported
+        input.
+        """
+        return True
+
+    def prediction_features_depend_on_sequence(self) -> bool:
+        """Whether finished-sequence scoring must be featurized per sequence.
+
+        AF2, Boltz2 and Protenix can build a reusable placeholder-binder feature
+        pack and splice a PSSM into it. ESMFold2 native validation must instead
+        featurize the real sequence, including its atom packing.
+        """
+        return False
+
     @abstractmethod
     def target_only_features(self, chains: list[TargetChain]) -> tuple[PyTree, any]:
         """
@@ -93,4 +112,21 @@ class StructurePredictionModel(eqx.Module):
     def build_loss(self, *, loss: LossTerm | LinearCombination, features: PyTree,  recycling_steps: int = 1, sampling_steps: int | None = None,) -> LossTerm:
         pass
 
+    def ensemble_members(self) -> tuple[int, ...]:
+        """Identifiers for members that can be scored independently.
+
+        AF2 overrides this for separately trained networks. Diffusion backends
+        can request several members without an override because callers split
+        the RNG key for each member.
+        """
+        return (0,)
+
+    def member_kwargs(self, member: int) -> dict:
+        """Extra :meth:`predict` arguments selecting one ensemble member."""
+        return {}
+
+    def design_member_kwargs(self, member: int, *, use_dropout: bool) -> dict:
+        """Arguments selecting one member during differentiable design."""
+        del use_dropout
+        return self.member_kwargs(member)
 

--- a/tests/test_binder_design.py
+++ b/tests/test_binder_design.py
@@ -254,6 +254,18 @@ def test_sequence_round_trips_through_the_mpnn_alphabet():
 # --- structure output conventions ---------------------------------------
 
 
+def test_pipeline_config_defaults_blank_binder_chain_to_b():
+    from mosaic.binder_design.pipeline import PipelineConfig
+
+    config = PipelineConfig(
+        target_settings={"chains": "A", "binder_chain": ""},
+        advanced_settings={},
+        filters={},
+    )
+
+    assert config.binder_chain == "B"
+
+
 def test_normalize_complex_pdb_puts_target_chains_first(tmp_path):
     from Bio.PDB import PDBParser
 

--- a/tests/test_binder_design.py
+++ b/tests/test_binder_design.py
@@ -1,0 +1,1112 @@
+"""Tests for the native-Mosaic binder design pipeline.
+
+These deliberately avoid loading model weights or PyRosetta so they stay fast;
+the numerical parity with DdCraft/ColabDesign is established separately by the
+comparison runs recorded in the repository README.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from mosaic.binder_design import filters as filter_utils
+from mosaic.binder_design.labels import design_labels, final_labels, trajectory_labels
+from mosaic.binder_design.validation import ComplexPredictor, MonomerPredictor
+from mosaic.models.af2 import AlphaFold2
+from mosaic.structure_prediction import StructurePredictionModel
+
+# --- CSV schema ---------------------------------------------------------
+
+
+def test_design_labels_have_average_and_per_model_columns():
+    labels = design_labels()
+    assert labels[:3] == ["Design", "Protocol", "Length"]
+    for metric in ("pLDDT", "ShapeComplementarity", "Binder_RMSD"):
+        assert f"Average_{metric}" in labels
+        for model in range(1, 6):
+            assert f"{model}_{metric}" in labels
+    assert labels[-1] == "AdvancedSettings"
+
+
+def test_label_counts_match_ddcraft():
+    """DdCraft's generate_dataframe_labels produced exactly these widths."""
+    assert len(trajectory_labels()) == 45
+    assert len(design_labels()) == 237
+    assert len(final_labels()) == 238
+    assert final_labels()[0] == "Rank"
+    assert final_labels()[1:] == design_labels()
+
+
+# --- filters ------------------------------------------------------------
+
+
+def test_filter_without_threshold_is_inactive():
+    filters = {"Average_pLDDT": {"threshold": None, "higher": True}}
+    assert filter_utils.check_filters({"Average_pLDDT": 0.1}, None, filters) is True
+
+
+def test_higher_and_lower_filters():
+    filters = {
+        "Average_pLDDT": {"threshold": 0.8, "higher": True},
+        "Average_pAE": {"threshold": 0.3, "higher": False},
+    }
+    assert filter_utils.check_filters({"Average_pLDDT": 0.9, "Average_pAE": 0.2}, None, filters) is True
+    assert filter_utils.check_filters({"Average_pLDDT": 0.7, "Average_pAE": 0.2}, None, filters) == [
+        "Average_pLDDT"
+    ]
+    assert filter_utils.check_filters({"Average_pLDDT": 0.9, "Average_pAE": 0.4}, None, filters) == [
+        "Average_pAE"
+    ]
+
+
+def test_missing_per_model_value_passes_but_missing_average_fails():
+    """DdCraft's asymmetry: not every model is necessarily predicted, but an
+    averaged metric that was never computed must not silently accept."""
+    filters = {
+        "1_pLDDT": {"threshold": 0.8, "higher": True},
+        "Average_pLDDT": {"threshold": 0.8, "higher": True},
+    }
+    assert filter_utils.unmet_filters({"1_pLDDT": None, "Average_pLDDT": 0.9}, filters) == []
+    assert filter_utils.unmet_filters({"1_pLDDT": 0.9, "Average_pLDDT": None}, filters) == [
+        "Average_pLDDT"
+    ]
+
+
+def test_interface_aa_filters_are_nested_by_amino_acid():
+    filters = {
+        "Average_InterfaceAAs": {
+            "C": {"threshold": 0, "higher": False},
+            "W": {"threshold": 2, "higher": False},
+        }
+    }
+    values = {"Average_InterfaceAAs": {"C": 1, "W": 1}}
+    assert filter_utils.unmet_filters(values, filters) == ["Average_InterfaceAAs_C"]
+    assert filter_utils.unmet_filters({"Average_InterfaceAAs": None}, filters) == []
+
+
+def test_check_filters_accepts_labels_and_values_in_parallel():
+    filters = {"Average_pLDDT": {"threshold": 0.8, "higher": True}}
+    assert filter_utils.check_filters([0.9], ["Average_pLDDT"], filters) is True
+    assert filter_utils.check_filters([0.5], ["Average_pLDDT"], filters) == ["Average_pLDDT"]
+
+
+def test_non_numeric_value_is_treated_as_a_failure():
+    filters = {"Average_pLDDT": {"threshold": 0.8, "higher": True}}
+    assert filter_utils.unmet_filters({"Average_pLDDT": "n/a"}, filters) == ["Average_pLDDT"]
+
+
+# --- the pre-PyRosetta gate --------------------------------------------
+
+
+def _gate_pipeline(tmp_path, filters, model_indices=(3, 4)):
+    from mosaic.binder_design.pipeline import BinderDesignPipeline
+
+    pipeline = object.__new__(BinderDesignPipeline)
+    pipeline.filters = filters
+    pipeline._model_indices = lambda: list(model_indices)
+    return pipeline
+
+
+def test_base_gate_only_uses_the_predicted_models_thresholds(tmp_path):
+    """The gate mirrors predict_binder_complex: per-model thresholds only.
+
+    Validation runs models 4 and 5, so a threshold on model 1 must be ignored
+    even though the value is present and would fail.
+    """
+    pipeline = _gate_pipeline(
+        tmp_path,
+        {
+            "1_pLDDT": {"threshold": 0.75, "higher": True},
+            "4_pLDDT": {"threshold": 0.60, "higher": True},
+        },
+    )
+    unmet = pipeline._base_af2_filters_pass({"1_pLDDT": 0.10, "4_pLDDT": 0.70})
+    assert unmet == []
+
+
+def test_base_gate_ignores_average_thresholds(tmp_path):
+    """Regression: including Average_* rejected 45% of designs before scoring.
+
+    Production filter sets leave 4_*/5_* at null while setting Average_*, which
+    makes DdCraft's gate a deliberate no-op. Honouring the averages here killed
+    designs that native would have scored and accepted.
+    """
+    pipeline = _gate_pipeline(
+        tmp_path,
+        {
+            "Average_pLDDT": {"threshold": 0.75, "higher": True},
+            "Average_i_pTM": {"threshold": 0.45, "higher": True},
+            "4_pLDDT": {"threshold": None, "higher": True},
+            "5_pLDDT": {"threshold": None, "higher": True},
+        },
+    )
+    unmet = pipeline._base_af2_filters_pass(
+        {"Average_pLDDT": 0.40, "Average_i_pTM": 0.20}
+    )
+    assert unmet == []
+
+
+def test_base_gate_still_rejects_on_a_set_per_model_threshold(tmp_path):
+    pipeline = _gate_pipeline(
+        tmp_path, {"5_i_pTM": {"threshold": 0.45, "higher": True}}
+    )
+    assert pipeline._base_af2_filters_pass({"5_i_pTM": 0.10}) == ["5_i_pTM"]
+
+
+def test_base_gate_never_references_metrics_computed_after_it(tmp_path):
+    """Binder_* and PyRosetta metrics only exist once the gate has passed."""
+    from mosaic.binder_design.pipeline import BinderDesignPipeline
+
+    labels = {
+        f"{i}_{metric}"
+        for i in range(1, 6)
+        for metric in BinderDesignPipeline.BASE_METRICS
+    }
+    for late in (
+        "4_Binder_pLDDT",
+        "4_Binder_pTM",
+        "4_Binder_pAE",
+        "4_Binder_RMSD",
+        "4_dG",
+        "4_ShapeComplementarity",
+    ):
+        assert late not in labels, f"{late} is not available at gate time"
+
+
+# --- MPNN input handling ------------------------------------------------
+
+
+def _write_two_chain_pdb(path: Path) -> None:
+    lines = []
+    serial = 1
+    for chain, length, start in (("A", 3, 1), ("B", 4, 1)):
+        for i in range(length):
+            for atom, element in (("N", "N"), ("CA", "C"), ("C", "C"), ("O", "O")):
+                lines.append(
+                    f"ATOM  {serial:5d}  {atom:<3s} ALA {chain}{start + i:4d}    "
+                    f"{serial:8.3f}{0.0:8.3f}{0.0:8.3f}  1.00 90.00          {element:>2s}"
+                )
+                serial += 1
+    lines.append("END")
+    path.write_text("\n".join(lines))
+
+
+def test_inputs_from_pdb_reads_chains_in_the_requested_order(tmp_path):
+    from mosaic.proteinmpnn.inputs import inputs_from_pdb
+
+    pdb = tmp_path / "complex.pdb"
+    _write_two_chain_pdb(pdb)
+
+    inputs = inputs_from_pdb(pdb, "A,B")
+    assert inputs.chains == ["A", "B"]
+    assert inputs.lengths == [3, 4]
+    assert inputs.X.shape == (7, 4, 3)
+    assert inputs.sequence == "AAAAAAA"
+    assert inputs.chain_slice("B") == slice(3, 7)
+
+    # per-chain residue indexing, offset by chain, as ProteinMPNN expects
+    assert list(inputs.residue_idx) == [0, 1, 2, 100, 101, 102, 103]
+
+
+def test_parse_fixed_positions_handles_chains_residues_and_ranges(tmp_path):
+    from mosaic.proteinmpnn.inputs import inputs_from_pdb, parse_fixed_positions
+
+    pdb = tmp_path / "complex.pdb"
+    _write_two_chain_pdb(pdb)
+    inputs = inputs_from_pdb(pdb, "A,B")
+
+    assert list(parse_fixed_positions("A", inputs)) == [0, 1, 2]
+    assert list(parse_fixed_positions("B2", inputs)) == [4]
+    assert list(parse_fixed_positions("B2-4", inputs)) == [4, 5, 6]
+    assert list(parse_fixed_positions("A,B1", inputs)) == [0, 1, 2, 3]
+
+    with pytest.raises(ValueError):
+        parse_fixed_positions("Z1", inputs)
+
+
+def test_make_bias_omits_requested_amino_acids_and_the_unknown_token():
+    from mosaic.proteinmpnn.sampling import MPNN_ALPHABET, make_bias
+
+    bias = make_bias(5, omit_AAs="C,M")
+    for aa in ("C", "M", "X"):
+        assert np.all(bias[:, MPNN_ALPHABET.index(aa)] < -1e5)
+    assert bias[0, MPNN_ALPHABET.index("A")] == 0.0
+
+    # both spellings DdCraft configs use
+    assert np.array_equal(make_bias(3, omit_AAs="CM"), make_bias(3, omit_AAs="C,M"))
+
+
+def test_sequence_round_trips_through_the_mpnn_alphabet():
+    from mosaic.proteinmpnn.sampling import decode_sequence, encode_sequence
+
+    sequence = "ACDEFGHIKLMNPQRSTVWY"
+    assert decode_sequence(encode_sequence(sequence)) == sequence
+    # unknown residues collapse to X rather than raising
+    assert decode_sequence(encode_sequence("AZB")) == "AXX"
+
+
+# --- structure output conventions ---------------------------------------
+
+
+def test_normalize_complex_pdb_puts_target_chains_first(tmp_path):
+    from Bio.PDB import PDBParser
+
+    from mosaic.binder_design.io import normalize_complex_pdb
+
+    # a prediction as Mosaic emits it: binder first, then the target
+    raw = tmp_path / "raw.pdb"
+    lines = []
+    serial = 1
+    for chain, length in (("B", 4), ("A", 3)):
+        for i in range(length):
+            for atom, element in (("N", "N"), ("CA", "C"), ("C", "C"), ("O", "O")):
+                lines.append(
+                    f"ATOM  {serial:5d}  {atom:<3s} ALA {chain}{i + 1:4d}    "
+                    f"{serial:8.3f}{0.0:8.3f}{0.0:8.3f}  1.00 90.00          {element:>2s}"
+                )
+                serial += 1
+    lines.append("END")
+    raw.write_text("\n".join(lines))
+
+    starting = tmp_path / "start.pdb"
+    _write_two_chain_pdb(starting)
+
+    out = normalize_complex_pdb(
+        raw, tmp_path / "out.pdb", starting, ["A"], "B", binder_length=4
+    )
+
+    model = PDBParser(QUIET=True).get_structure("x", str(out))[0]
+    assert [chain.id for chain in model] == ["A", "B"]
+    assert len(list(model["A"])) == 3
+    assert len(list(model["B"])) == 4
+
+
+def test_normalize_binder_pdb_renames_the_single_chain(tmp_path):
+    from Bio.PDB import PDBParser
+
+    from mosaic.binder_design.io import ChainLayoutError, normalize_binder_pdb
+
+    raw = tmp_path / "binder.pdb"
+    lines = []
+    serial = 1
+    for i in range(4):
+        for atom, element in (("N", "N"), ("CA", "C"), ("C", "C"), ("O", "O")):
+            lines.append(
+                f"ATOM  {serial:5d}  {atom:<3s} ALA B{i + 7:4d}    "
+                f"{serial:8.3f}{0.0:8.3f}{0.0:8.3f}  1.00 90.00          {element:>2s}"
+            )
+            serial += 1
+    lines.append("END")
+    raw.write_text("\n".join(lines))
+
+    out = normalize_binder_pdb(raw, tmp_path / "out.pdb", binder_length=4)
+    model = PDBParser(QUIET=True).get_structure("x", str(out))[0]
+    assert [chain.id for chain in model] == ["A"]
+    assert [residue.id[1] for residue in model["A"]] == [1, 2, 3, 4]
+
+    with pytest.raises(ChainLayoutError):
+        normalize_binder_pdb(raw, tmp_path / "bad.pdb", binder_length=99)
+
+
+# --- configuration ------------------------------------------------------
+
+
+def test_model_slots_are_independent_and_accept_all_registered_names():
+    from mosaic.binder_design.components import AVAILABLE_MODELS, model_selection
+
+    assert AVAILABLE_MODELS == ("af2", "boltz2", "protenix-v2", "esmfold2")
+    settings = {
+        "hallucination_model": "boltz-2",
+        "folding_model": {"name": "protenix_v2", "sampling_steps": 12},
+        "folding_model_options": {"num_samples": 3},
+    }
+    hallucination = model_selection(settings, "hallucination")
+    folding = model_selection(settings, "folding")
+
+    assert hallucination.name == "boltz2"
+    assert folding.name == "protenix-v2"
+    assert folding.sampling_steps == 12
+    assert folding.members == (0, 1, 2)
+
+
+def test_model_slot_defaults_to_af2_and_rejects_unknown_names():
+    from mosaic.binder_design.components import model_selection
+
+    assert model_selection({}, "hallucination").name == "af2"
+    assert model_selection({}, "folding").name == "af2"
+    with pytest.raises(ValueError, match="Unknown structure model"):
+        model_selection({"folding_model": "not-a-model"}, "folding")
+
+
+def test_af2_model_numbers_drive_stage_member_indices():
+    from mosaic.binder_design.components import model_selection
+    from mosaic.binder_design.pipeline import BinderDesignPipeline
+
+    pipeline = object.__new__(BinderDesignPipeline)
+    pipeline.advanced_settings = {}
+    pipeline.config = SimpleNamespace(validation_models=lambda: [3, 4])
+    pipeline.hallucination_selection = model_selection(
+        {"hallucination_model_options": {"model_numbers": [1, 3]}},
+        "hallucination",
+    )
+    pipeline.folding_selection = model_selection(
+        {"folding_model_options": {"model_numbers": [2, 5]}}, "folding"
+    )
+
+    assert pipeline.design_models() == [0, 2]
+    assert pipeline._model_indices() == [1, 4]
+
+
+def test_model_members_use_bounded_zero_based_csv_slots():
+    from mosaic.binder_design.components import model_selection
+
+    selection = model_selection(
+        {"folding_model": "esmfold2", "folding_model_options": {"members": [0, 4]}},
+        "folding",
+    )
+    assert selection.members == (0, 4)
+    with pytest.raises(ValueError, match="zero-based"):
+        _ = model_selection(
+            {"folding_model_options": {"members": [5]}}, "folding"
+        ).members
+
+
+def test_active_filter_metrics_select_standalone_filter_groups(tmp_path):
+    from mosaic.binder_design.pipeline import BinderDesignPipeline
+
+    pipeline = object.__new__(BinderDesignPipeline)
+    pipeline.filters = {
+        "Average_pLDDT": {"threshold": 0.8, "higher": True},
+        "4_dG": {"threshold": -10, "higher": False},
+        "Average_Binder_pTM": {"threshold": None, "higher": True},
+        "Average_InterfaceAAs": {
+            "C": {"threshold": 0, "higher": False},
+            "W": {"threshold": None, "higher": False},
+        },
+    }
+
+    assert pipeline._active_metrics() == {"pLDDT", "dG", "InterfaceAAs"}
+
+
+def test_geometry_filter_group_does_not_load_pyrosetta(tmp_path):
+    from mosaic.binder_design.pipeline import BinderDesignPipeline
+
+    pdb = tmp_path / "complex.pdb"
+    _write_two_chain_pdb(pdb)
+    pipeline = _bare_pipeline(tmp_path / "results", design_labels())
+    pipeline.config = SimpleNamespace(
+        binder_chain="B", first_target_chain="A", target_chains="A"
+    )
+    pipeline.advanced_settings = {}
+    pipeline._load_rosetta = lambda: pytest.fail(
+        "unrelaxed geometry must not load PyRosetta"
+    )
+
+    values = BinderDesignPipeline._score_structure(
+        pipeline,
+        str(pdb),
+        "geometry_only",
+        1,
+        str(pdb),
+        requested_metrics={"Unrelaxed_Clashes"},
+    )
+    assert set(values) == {"Unrelaxed_Clashes"}
+
+
+def test_pyrosetta_filter_group_is_loaded_lazily(tmp_path):
+    from mosaic.binder_design.pipeline import BinderDesignPipeline
+
+    pdb = tmp_path / "complex.pdb"
+    _write_two_chain_pdb(pdb)
+    pipeline = _bare_pipeline(tmp_path / "results", design_labels())
+    pipeline.config = SimpleNamespace(
+        binder_chain="B", first_target_chain="A", target_chains="A"
+    )
+    pipeline.advanced_settings = {}
+    calls = []
+
+    class FakeRosetta:
+        @staticmethod
+        def pr_relax(source, destination, binder_chain):
+            calls.append(("relax", binder_chain))
+            Path(destination).write_bytes(Path(source).read_bytes())
+
+        @staticmethod
+        def score_interface(path, binder_chain):
+            calls.append(("score", binder_chain))
+            return {"interface_dG": -12.5}, {}, ""
+
+    pipeline._load_rosetta = lambda: FakeRosetta
+    values = BinderDesignPipeline._score_structure(
+        pipeline,
+        str(pdb),
+        "pyrosetta_only",
+        1,
+        str(pdb),
+        requested_metrics={"dG"},
+    )
+    assert values == {"dG": -12.5}
+    assert calls == [("relax", "B"), ("score", "B")]
+
+
+def test_config_expands_paths_and_fills_defaults(tmp_path):
+    from mosaic.binder_design.pipeline import PipelineConfig
+
+    root = tmp_path / "root"
+    root.mkdir()
+    target = tmp_path / "target.json"
+    advanced = tmp_path / "advanced.json"
+    filters = tmp_path / "filters.json"
+    target.write_text(
+        json.dumps(
+            {
+                "design_path": "${DDCRAFT_DIR}/results/run/",
+                "starting_pdb": "${DDCRAFT_DIR}/example/t.pdb",
+                "chains": "A",
+                "binder_chain": "B",
+            }
+        )
+    )
+    advanced.write_text(
+        json.dumps({"af_params_dir": "", "dssp_path": "", "dalphaball_path": "", "omit_AAs": " C,M "})
+    )
+    filters.write_text("{}")
+
+    config = PipelineConfig.from_files(target, advanced, filters, root=root)
+
+    assert config.target_settings["design_path"] == f"{root}/results/run/"
+    assert config.target_settings["starting_pdb"] == f"{root}/example/t.pdb"
+    assert config.advanced_settings["af_params_dir"] == str(root)
+    assert config.advanced_settings["dssp_path"].endswith("functions/dssp")
+    assert config.advanced_settings["dalphaball_path"].endswith("functions/DAlphaBall.gcc")
+    assert config.advanced_settings["omit_AAs"] == "C,M"
+
+
+def test_validation_models_are_disjoint_from_design_models(tmp_path):
+    """DdCraft never validates with a model that shaped the backbone."""
+    from mosaic.binder_design.pipeline import PipelineConfig
+
+    config = PipelineConfig(
+        target_settings={"chains": "A"},
+        advanced_settings={"use_multimer_design": True},
+        filters={},
+    )
+    assert config.validation_models() == [3, 4]
+
+    config.advanced_settings["use_multimer_design"] = False
+    assert config.validation_models() == [0, 1, 2, 3, 4]
+
+    config.advanced_settings["predict_models"] = [1]
+    assert config.validation_models() == [1]
+
+
+def _bare_pipeline(tmp_path, design_labels_list):
+    """A pipeline shell without PyRosetta or model loading.
+
+    ``file_design`` and ``write_final_csv`` only touch the filesystem, so the
+    expensive constructor is skipped rather than mocked out piece by piece.
+    """
+    from mosaic.binder_design.pipeline import BinderDesignPipeline, generate_directories
+
+    pipeline = object.__new__(BinderDesignPipeline)
+    pipeline.design_paths = generate_directories(tmp_path)
+    pipeline.design_labels = design_labels_list
+    pipeline.final_labels = ["Rank"] + design_labels_list
+    return pipeline
+
+
+def _write_relaxed(pipeline, name, model, bfactor):
+    path = Path(pipeline.design_paths["MPNN/Relaxed"]) / f"{name}_model{model}.pdb"
+    path.write_text(
+        f"ATOM      1  CA  ALA B   1      "
+        f"0.000   0.000   0.000  1.00{bfactor:6.2f}           C\nEND\n"
+    )
+    return path
+
+
+def test_file_design_keeps_the_highest_confidence_model(tmp_path):
+    from mosaic.binder_design.pipeline import DesignRecord
+
+    pipeline = _bare_pipeline(tmp_path, design_labels())
+    _write_relaxed(pipeline, "d1", 1, 50.0)
+    _write_relaxed(pipeline, "d1", 2, 90.0)
+    _write_relaxed(pipeline, "d1", 3, 70.0)
+
+    record = DesignRecord(name="d1", sequence="A")
+    record.accepted = True
+    destination = pipeline.file_design(record)
+
+    assert destination == Path(pipeline.design_paths["Accepted"]) / "d1.pdb"
+    assert "90.00" in destination.read_text()
+
+
+def test_rejected_designs_go_to_the_rejected_folder(tmp_path):
+    from mosaic.binder_design.pipeline import DesignRecord
+
+    pipeline = _bare_pipeline(tmp_path, design_labels())
+    _write_relaxed(pipeline, "d2", 1, 42.0)
+
+    record = DesignRecord(name="d2", sequence="A")
+    record.accepted = False
+    destination = pipeline.file_design(record)
+
+    assert destination.parent.name == "Rejected"
+    assert not (Path(pipeline.design_paths["Accepted"]) / "d2.pdb").exists()
+
+
+def test_file_design_skips_an_unreadable_fold_without_crashing(tmp_path):
+    from mosaic.binder_design.pipeline import DesignRecord
+
+    pipeline = _bare_pipeline(tmp_path, design_labels())
+    malformed = Path(pipeline.design_paths["MPNN"]) / "bad_model1.pdb"
+    malformed.write_text(
+        "ATOM      1  CA  ALA B   1    -1017.150  -4.005-2090.420  1.00 0.00 C\n"
+    )
+    record = DesignRecord(name="bad", sequence="A")
+
+    assert pipeline.file_design(record) is None
+
+
+def test_final_csv_ranks_accepted_designs_by_i_ptm(tmp_path):
+    import csv
+
+    labels = design_labels()
+    pipeline = _bare_pipeline(tmp_path, labels)
+    accepted = Path(pipeline.design_paths["Accepted"])
+    for name in ("low", "high"):
+        (accepted / f"{name}.pdb").write_text("END\n")
+
+    mpnn_csv = tmp_path / "mpnn_design_stats.csv"
+    with mpnn_csv.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=labels)
+        writer.writeheader()
+        for name, iptm in (("low", 0.4), ("high", 0.9), ("unfiled", 0.99)):
+            writer.writerow({"Design": name, "Average_i_pTM": iptm})
+
+    final_csv = tmp_path / "final_design_stats.csv"
+    assert pipeline.write_final_csv(mpnn_csv, final_csv) == 2
+
+    rows = list(csv.DictReader(final_csv.open()))
+    assert [row["Design"] for row in rows] == ["high", "low"]
+    assert [row["Rank"] for row in rows] == ["1", "2"]
+    ranked = Path(pipeline.design_paths["Accepted/Ranked"])
+    assert {p.name for p in ranked.glob("*.pdb")} == {"1_high.pdb", "2_low.pdb"}
+
+
+def test_final_csv_renumbers_when_rerun(tmp_path):
+    import csv
+
+    labels = design_labels()
+    pipeline = _bare_pipeline(tmp_path, labels)
+    accepted = Path(pipeline.design_paths["Accepted"])
+    (accepted / "a.pdb").write_text("END\n")
+
+    mpnn_csv = tmp_path / "mpnn.csv"
+    final_csv = tmp_path / "final.csv"
+    with mpnn_csv.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=labels)
+        writer.writeheader()
+        writer.writerow({"Design": "a", "Average_i_pTM": 0.5})
+    pipeline.write_final_csv(mpnn_csv, final_csv)
+
+    # A better design lands later; it must take rank 1 and displace "a".
+    (accepted / "b.pdb").write_text("END\n")
+    with mpnn_csv.open("a", newline="") as handle:
+        csv.DictWriter(handle, fieldnames=labels).writerow(
+            {"Design": "b", "Average_i_pTM": 0.8}
+        )
+    assert pipeline.write_final_csv(mpnn_csv, final_csv) == 2
+
+    ranked = Path(pipeline.design_paths["Accepted/Ranked"])
+    assert {p.name for p in ranked.glob("*.pdb")} == {"1_b.pdb", "2_a.pdb"}
+
+
+def _designed(sequence, score):
+    from mosaic.binder_design.mpnn import DesignedSequence
+
+    return DesignedSequence(
+        sequence=sequence, score=score, seqid=0.0, full_sequence=sequence
+    )
+
+
+def test_ranking_keeps_every_candidate_not_just_max_mpnn_sequences(tmp_path):
+    """``max_mpnn_sequences`` caps *accepted* designs, not candidates.
+
+    Truncating the candidate list here meant only two of twenty sequences were
+    ever validated, so a trajectory whose best sequences failed the filters was
+    abandoned instead of falling through to the next candidate.
+    """
+    pipeline = _bare_pipeline(tmp_path, design_labels())
+    pipeline.advanced_settings = {"max_mpnn_sequences": 2}
+    pipeline._seen_sequences = set()
+
+    candidates = [_designed(f"AAA{i}", score=1.0 - i * 0.01) for i in range(20)]
+    ranked = pipeline._rank_sequences(candidates)
+
+    assert len(ranked) == 20
+    assert [s.score for s in ranked] == sorted(s.score for s in candidates)
+
+
+def test_ranking_deduplicates_and_skips_sequences_already_evaluated(tmp_path):
+    pipeline = _bare_pipeline(tmp_path, design_labels())
+    pipeline.advanced_settings = {}
+    pipeline._seen_sequences = {"SEEN"}
+
+    ranked = pipeline._rank_sequences(
+        [
+            _designed("SEEN", 0.1),
+            _designed("DUP", 0.9),
+            _designed("DUP", 0.5),
+            _designed("NEW", 0.7),
+        ]
+    )
+
+    assert [s.sequence for s in ranked] == ["DUP", "NEW"]
+    assert ranked[0].score == 0.5
+
+
+def test_force_reject_aa_drops_sequences_containing_omitted_residues(tmp_path):
+    pipeline = _bare_pipeline(tmp_path, design_labels())
+    pipeline.advanced_settings = {"force_reject_AA": True, "omit_AAs": "C,M"}
+    pipeline._seen_sequences = set()
+
+    ranked = pipeline._rank_sequences(
+        [_designed("AAC", 0.1), _designed("AAM", 0.2), _designed("AAK", 0.3)]
+    )
+
+    assert [s.sequence for s in ranked] == ["AAK"]
+
+
+def test_load_seen_sequences_reads_the_existing_csv(tmp_path):
+    import csv
+
+    labels = design_labels()
+    pipeline = _bare_pipeline(tmp_path, labels)
+    pipeline.advanced_settings = {}
+    pipeline._seen_sequences = set()
+
+    mpnn_csv = tmp_path / "mpnn.csv"
+    with mpnn_csv.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=labels)
+        writer.writeheader()
+        writer.writerow({"Design": "d1", "Sequence": "ABC"})
+        writer.writerow({"Design": "d2", "Sequence": ""})
+
+    assert pipeline.load_seen_sequences(mpnn_csv) == 1
+    assert pipeline._rank_sequences([_designed("ABC", 0.1)]) == []
+
+
+def test_a_failing_design_does_not_abandon_the_remaining_candidates(
+    tmp_path, monkeypatch
+):
+    """One bad structure costs one design, not the rest of the run.
+
+    PyRosetta occasionally fails to read a structure it has just written. That
+    killed a nine-backbone run on its third design, so evaluation is wrapped
+    per candidate exactly as DdCraft wraps it.
+    """
+    import jax
+
+    from mosaic.binder_design import pipeline as pipeline_module
+    from mosaic.binder_design.pipeline import BinderDesignPipeline, DesignRecord
+
+    trajectory = tmp_path / "traj.pdb"
+    _write_two_chain_pdb(trajectory)
+
+    pipeline = _bare_pipeline(tmp_path, design_labels())
+    pipeline.advanced_settings = {"max_mpnn_sequences": 99}
+    pipeline.target_settings = {"starting_pdb": str(trajectory)}
+    pipeline._seen_sequences = set()
+    pipeline.config = SimpleNamespace(binder_chain="B", target_chains="A")
+    pipeline._structure_model = object()
+    pipeline._monomer_model = object()
+    pipeline._recycling_steps = lambda: 1
+    pipeline._ipsae_cutoff = lambda: None
+
+    monkeypatch.setattr(pipeline_module, "ComplexPredictor", lambda *a, **k: None)
+    monkeypatch.setattr(pipeline_module, "MonomerPredictor", lambda *a, **k: None)
+
+    candidates = [_designed(f"SEQ{i}", score=0.1 * i) for i in range(4)]
+    evaluated = []
+
+    def fake_evaluate(design, *, design_name, **kwargs):
+        evaluated.append(design_name)
+        if design.sequence == "SEQ1":
+            raise RuntimeError("Cannot open file")
+        return DesignRecord(name=design_name, sequence=design.sequence)
+
+    pipeline.evaluate_design = fake_evaluate
+    pipeline.design_sequences = lambda pdb, key: (candidates, "")
+
+    records = BinderDesignPipeline.run_trajectory(
+        pipeline, trajectory, key=jax.random.key(0)
+    )
+
+    assert len(evaluated) == 4, "every candidate should still be attempted"
+    assert [r.name for r in records] == ["traj_mpnn1", "traj_mpnn3", "traj_mpnn4"]
+
+
+def test_af2_member_kwargs_map_global_model_numbers_to_stack_positions():
+    """A model holding only a subset still reports global model numbers.
+
+    Monomer models 3-5 are trained without templates and cannot be stacked with
+    1-2, so the binder-alone predictor loads just 4 and 5. Callers keep speaking
+    in global indices so the CSV labels stay 4_* and 5_*.
+    """
+    model = object.__new__(AlphaFold2)
+    object.__setattr__(model, "model_numbers", (4, 5))
+
+    assert model.ensemble_members() == (3, 4)
+    assert model.member_kwargs(3) == {"model_idx": 0}
+    assert model.member_kwargs(4) == {"model_idx": 1}
+
+
+def test_af2_member_kwargs_reject_a_model_that_was_not_loaded():
+    model = object.__new__(AlphaFold2)
+    object.__setattr__(model, "model_numbers", (4, 5))
+
+    with pytest.raises(ValueError, match="model 1 is not loaded"):
+        model.member_kwargs(0)
+
+
+def test_a_model_without_an_ensemble_has_one_member():
+    """Models whose members differ only by RNG key need no override."""
+
+    class SingleNetwork(StructurePredictionModel):
+        def target_only_features(self, chains):
+            raise NotImplementedError
+
+        def binder_features(self, binder_length, chains):
+            raise NotImplementedError
+
+        def predict(self, **kwargs):
+            raise NotImplementedError
+
+        def model_output(self, **kwargs):
+            raise NotImplementedError
+
+        def build_loss(self, **kwargs):
+            raise NotImplementedError
+
+    model = object.__new__(SingleNetwork)
+    assert model.ensemble_members() == (0,)
+    assert model.member_kwargs(0) == {}
+
+
+def test_complex_predictor_takes_its_members_from_the_model():
+    """The default member list is the model's, not an AF2-shaped assumption."""
+    predictor = object.__new__(ComplexPredictor)
+    model = SimpleNamespace(ensemble_members=lambda: (0, 1, 2))
+    predictor.model_indices = list(model.ensemble_members())
+
+    assert predictor.model_indices == [0, 1, 2]
+
+
+def test_sequence_dependent_backend_is_refeaturized_for_each_complex(tmp_path):
+    pdb = tmp_path / "complex.pdb"
+    _write_two_chain_pdb(pdb)
+
+    class SequenceDependentModel:
+        def __init__(self):
+            self.calls = []
+
+        def supports_template_chains(self):
+            return False
+
+        def prediction_features_depend_on_sequence(self):
+            return True
+
+        def ensemble_members(self):
+            return (0,)
+
+        def target_only_features(self, chains):
+            self.calls.append(chains)
+            return tuple(chain.sequence for chain in chains), "writer"
+
+        def binder_features(self, **kwargs):
+            raise AssertionError("native finished-sequence scoring must not use a design pack")
+
+    model = SequenceDependentModel()
+    predictor = ComplexPredictor(
+        model,
+        target_pdb=pdb,
+        target_chains="A",
+        binder_length=4,
+    )
+    pssm, features, writer = predictor._prediction_inputs("CCCC")
+
+    assert pssm is None
+    assert features == ("CCCC", "AAA")
+    assert writer == "writer"
+    assert model.calls[0][0].template_chain is None
+    assert model.calls[0][1].template_chain is None
+
+
+def test_monomer_predictor_defaults_to_backend_members():
+    class ReusableModel:
+        def prediction_features_depend_on_sequence(self):
+            return False
+
+        def ensemble_members(self):
+            return (0, 2)
+
+        def target_only_features(self, chains):
+            return "features", "writer"
+
+    predictor = MonomerPredictor(ReusableModel(), binder_length=4)
+    assert predictor.model_indices == [0, 2]
+
+
+def test_evaluate_pdb_bypasses_hallucination_mpnn_and_pyrosetta(
+    tmp_path, monkeypatch
+):
+    import jax
+
+    from mosaic.binder_design import pipeline as pipeline_module
+    from mosaic.binder_design.pipeline import DesignRecord
+
+    pdb = tmp_path / "input.pdb"
+    _write_two_chain_pdb(pdb)
+    pipeline = _bare_pipeline(tmp_path / "results", design_labels())
+    pipeline.config = SimpleNamespace(binder_chain="B", target_chains="A")
+    pipeline.target_settings = {"starting_pdb": str(pdb)}
+    pipeline.advanced_settings = {}
+    pipeline.filters = {}
+    pipeline.folding_selection = SimpleNamespace(name="boltz2", sampling_steps=5)
+    pipeline._structure_model = object()
+    pipeline._model_indices = lambda: [0]
+    pipeline._recycling_steps = lambda: 1
+    pipeline._ipsae_cutoff = lambda: None
+    pipeline.generate_trajectory = lambda **kwargs: pytest.fail(
+        "evaluation must not hallucinate"
+    )
+    pipeline.design_sequences = lambda *args, **kwargs: pytest.fail(
+        "evaluation must not run ProteinMPNN"
+    )
+    pipeline._load_rosetta = lambda: pytest.fail(
+        "confidence-only evaluation must not load PyRosetta"
+    )
+
+    captured = {}
+
+    class FakeComplexPredictor:
+        def __init__(self, model, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(pipeline_module, "ComplexPredictor", FakeComplexPredictor)
+
+    def fake_evaluate(design, **kwargs):
+        captured["sequence"] = design.sequence
+        captured.update(kwargs)
+        return DesignRecord(name=kwargs["design_name"], sequence=design.sequence)
+
+    pipeline.evaluate_design = fake_evaluate
+    record = pipeline.evaluate_pdb(pdb, key=jax.random.key(0))
+
+    assert captured["sequence"] == "AAAA"
+    assert captured["configured_only"] is True
+    assert captured["reference_pdb"] == str(pdb)
+    assert captured["sampling_steps"] == 5
+    assert captured["monomer_predictor"] is None
+    assert record.values["Protocol"] == "evaluation:boltz2"
+
+
+def test_cli_exposes_evaluation_inputs_and_chain_overrides():
+    from mosaic.binder_design.__main__ import build_parser
+
+    args = build_parser().parse_args(
+        [
+            "--settings",
+            "target.json",
+            "--advanced",
+            "advanced.json",
+            "--filters",
+            "filters.json",
+            "--mode",
+            "evaluate",
+            "--input-pdb",
+            "one.pdb",
+            "--input-pdb",
+            "two.pdb",
+            "--binder-chain",
+            "H",
+            "--target-chains",
+            "A,L",
+            "--output-dir",
+            "separate-results",
+            "--evaluation-metric-group",
+            "pyrosetta",
+        ]
+    )
+    assert args.mode == "evaluate"
+    assert args.input_pdb == [Path("one.pdb"), Path("two.pdb")]
+    assert args.binder_chain == "H"
+    assert args.target_chains == "A,L"
+    assert args.output_dir == Path("separate-results")
+    assert args.evaluation_metric_group == ["pyrosetta"]
+
+
+def test_evaluation_metric_groups_request_work_without_becoming_filters(tmp_path):
+    from mosaic.binder_design.pipeline import BinderDesignPipeline
+
+    pipeline = object.__new__(BinderDesignPipeline)
+    pipeline.advanced_settings = {
+        "evaluation_metric_groups": ["monomer", "pyrosetta"]
+    }
+    pipeline.filters = {
+        "Average_pLDDT": {"threshold": None, "higher": True}
+    }
+
+    active = pipeline._active_metrics()
+
+    assert {"Binder_pLDDT", "Binder_pTM", "Binder_pAE"} <= active
+    assert BinderDesignPipeline.PYROSETTA_METRICS <= active
+    assert "Binder_RMSD" in active
+    assert filter_utils.unmet_filters({}, pipeline.filters) == []
+
+
+def test_unknown_evaluation_metric_group_is_rejected():
+    from mosaic.binder_design.pipeline import BinderDesignPipeline
+
+    pipeline = object.__new__(BinderDesignPipeline)
+    pipeline.advanced_settings = {"evaluation_metric_groups": ["mystery"]}
+    pipeline.filters = {}
+
+    with pytest.raises(ValueError, match="Unknown evaluation metric group"):
+        pipeline._active_metrics()
+
+
+def test_evaluation_matrix_isolates_backends_and_forwards_optional_metrics(
+    tmp_path, monkeypatch
+):
+    from mosaic.binder_design import matrix
+
+    settings = tmp_path / "settings.json"
+    filters = tmp_path / "filters.json"
+    input_pdb = tmp_path / "complex.pdb"
+    advanced_dir = tmp_path / "advanced"
+    output_root = tmp_path / "matrix"
+    settings.write_text("{}\n")
+    filters.write_text("{}\n")
+    input_pdb.write_text("MODEL\nEND\n")
+    advanced_dir.mkdir()
+    for filename in matrix.BACKEND_PRESETS.values():
+        (advanced_dir / filename).write_text("{}\n")
+
+    calls = []
+
+    def fake_runner(command, **kwargs):
+        calls.append((command, kwargs["env"]))
+        output = Path(command[command.index("--output-dir") + 1])
+        backend = output.name
+        with (output / "evaluation_stats.csv").open("w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=["Design", "Average_pLDDT"])
+            writer.writeheader()
+            writer.writerow({"Design": f"{backend}_design", "Average_pLDDT": "0.9"})
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(matrix.sys, "executable", "/runtime/python")
+    result = matrix.main(
+        [
+            "--settings",
+            str(settings),
+            "--filters",
+            str(filters),
+            "--advanced-dir",
+            str(advanced_dir),
+            "--output-root",
+            str(output_root),
+            "--backend",
+            "boltz2",
+            "--backend",
+            "protenix-v2",
+            "--input-pdb",
+            str(input_pdb),
+            "--metric-group",
+            "pyrosetta",
+            "--device",
+            "boltz2=0",
+            "--device",
+            "protenix-v2=2",
+        ],
+        runner=fake_runner,
+    )
+
+    assert result == 0
+    assert len(calls) == 2
+    assert calls[0][0][:3] == [
+        "/runtime/python",
+        "-m",
+        "mosaic.binder_design",
+    ]
+    assert calls[0][1]["CUDA_VISIBLE_DEVICES"] == "0"
+    assert calls[1][1]["CUDA_VISIBLE_DEVICES"] == "2"
+    assert all("--evaluation-metric-group" in command for command, _ in calls)
+    with (output_root / "evaluation_matrix.csv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert [row["Backend"] for row in rows] == ["boltz2", "protenix-v2"]
+    manifest = json.loads((output_root / "manifest.json").read_text())
+    assert manifest["metric_groups"] == ["pyrosetta"]
+    assert manifest["backends"]["boltz2"]["status"] == "completed"
+
+
+def test_shipped_evaluation_presets_cover_every_backend_without_extra_filters():
+    from mosaic.binder_design.components import model_selection
+    from mosaic.binder_design.pipeline import BinderDesignPipeline, PipelineConfig
+
+    repository = Path(__file__).parents[2]
+    config_root = repository / "ddcraft" / "configs"
+    if not config_root.is_dir():
+        pytest.skip("evaluation presets live in kite-binder-design")
+    target = config_root / "settings_target" / "mosaic_evaluation_example.json"
+    filters = config_root / "settings_filters" / "confidence_only.json"
+    presets = {
+        "af2.json": ("af2", (3,), None),
+        "boltz2.json": ("boltz2", (0,), 5),
+        "protenix_v2.json": ("protenix-v2", (0,), 5),
+        "esmfold2_fast.json": ("esmfold2", (0,), 5),
+    }
+
+    filter_settings = json.loads(filters.read_text())
+    assert set(filter_settings) == {
+        f"Average_{metric}" for metric in BinderDesignPipeline.BASE_METRICS
+    }
+    assert all(
+        conditions["threshold"] is None
+        for conditions in filter_settings.values()
+    )
+
+    for filename, expected in presets.items():
+        config = PipelineConfig.from_files(
+            target,
+            config_root / "settings_advanced" / "mosaic_evaluation" / filename,
+            filters,
+            root=repository / "ddcraft",
+        )
+        selection = model_selection(config.advanced_settings, "folding")
+        assert (selection.name, selection.members, selection.sampling_steps) == expected
+        assert config.advanced_settings["num_recycles_validation"] == 0
+        assert config.target_settings["design_path"].startswith(
+            str(repository / "ddcraft")
+        )
+
+
+def test_accepted_design_count_reads_the_accepted_directory(tmp_path):
+    """Generation stops on accepted designs on disk, so a resume stops at the same total."""
+    pipeline = _bare_pipeline(tmp_path, design_labels())
+    accepted = Path(pipeline.design_paths["Accepted"])
+    accepted.mkdir(parents=True, exist_ok=True)
+
+    assert pipeline.accepted_design_count() == 0
+
+    (accepted / "a_model4.pdb").write_text("")
+    (accepted / "b_model5.pdb").write_text("")
+    (accepted / "notes.txt").write_text("ignored")
+
+    assert pipeline.accepted_design_count() == 2


### PR DESCRIPTION
## Summary

- port the native four-stage binder-design pipeline into Mosaic
- make AF2, Boltz-2, Protenix-v2, and ESMFold2 independently selectable for hallucination and folding
- add evaluation-only mode for existing binder-target complexes; it never runs hallucination or ProteinMPNN
- keep PyRosetta lazy and optional, with independent confidence, monomer, geometry, DSSP, and PyRosetta metric groups
- add a multi-backend matrix runner with isolated outputs and a combined CSV
- add standalone example configs and documentation
- normalize an empty launcher binder-chain value to chain B before PDB output

## Validation

- full targeted engine suite: 52 passed, 1 skipped
- latest binder-design suite after binder-chain normalization: 50 passed, 1 skipped
- targeted Ruff checks passed for the CLI, pipeline, matrix runner, and tests
- git diff --check passed
- live MLStack executor runs produced accepted AF2, Boltz-2, Protenix-v2, and ESMFold2 structures
- GPU 1 was not used

## Notes

- existing AF2-calibrated thresholds should not be assumed to transfer to the other model families
- PyRosetta is only imported when requested by a metric group or active filter and still requires a separately licensed installation
- evaluation mode does not run hallucination or ProteinMPNN
- no model weights or proprietary structures are included
