### PR TITLE
Add AF2 cyclic (head-to-tail) binder design support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ wheels/
 
 .envrc
 uv.lock
+
+# Local-only Claude Code instructions, not shared with the team
+CLAUDE.local.md

--- a/README.md
+++ b/README.md
@@ -311,6 +311,40 @@ print("".join(TOKENS[int(i)] for i in ids))
 > **WARNING**: AF3-style models (all structure models except for AF2) have at least three input channels related to the binder sequence: the token channel, the MSA, and the reference atomic positions channel. That last one is quite difficult to deal with in a differentiable and JIT-friendly manner during design because each amino acid has a different number of atoms. To get around this we distinguish between two types of features: target-only features and binder features. For binder features (those related to the binder that will be used during design) we use either UNK or G for the reference atomic position channel. This means that predictions using design features _do not have sidechains_. This doesn't seem to affect performance for most models. If you like sidechains you can repredict your designs with target-only features for both the binder and target.
 
 
+#### Cyclic binder design
+---
+
+`AlphaFold2.binder_features` accepts a `cyclic` flag for designing head-to-tail cyclic
+(macrocyclic) binders. Setting `cyclic=True` biases the structure module's residue-index
+offsets (`mosaic.geometry.cyclic_offset_matrix`) so the trunk treats the binder as a closed
+loop rather than a linear chain:
+
+```python
+af_features, af_writer = af2.binder_features(
+    binder_length=binder_length,
+    chains=[TargetChain(sequence=target_sequence, use_msa=False)],
+    cyclic=True,
+)
+```
+
+This offset bias alone isn't reliably strong enough to force closure once combined with other
+contact losses during full sequence optimization, so pair it with `sp.CyclicClosureLoss()` — an
+explicit contact loss between the binder's first and last residues — and pass `cyclic=True` to
+`sp.WithinBinderContact` so its sequence-separation mask wraps around the cycle:
+
+```python
+loss = af2.build_loss(
+    loss=sp.BinderTargetContact()
+    + sp.WithinBinderContact(cyclic=True)
+    + sp.CyclicClosureLoss(),
+    features=af_features,
+    recycling_steps=2,
+)
+```
+
+See [examples/af2_cyclic_binder.py](examples/af2_cyclic_binder.py) for a full walkthrough.
+
+
 #### Protenix
 ---
 

--- a/examples/af2_cyclic_binder.py
+++ b/examples/af2_cyclic_binder.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.16.3"
+__generated_with = "0.23.16"
 app = marimo.App(width="full")
 
 with app.setup:
@@ -17,8 +17,7 @@ with app.setup:
 
 @app.cell(hide_code=True)
 def _():
-    mo.md(
-        """
+    mo.md("""
     ---
     **Warning**
 
@@ -37,8 +36,7 @@ def _():
        residues. The offset bias alone isn't consistently strong enough to force closure once
        it's combined with other contact losses during full sequence design, so we add this term
        directly to the loss.
-    """
-    )
+    """)
     return
 
 
@@ -72,11 +70,11 @@ def _(af2, binder_length, target_sequence):
 
 @app.cell(hide_code=True)
 def _():
-    mo.md(
-        """We combine the usual binder-design losses with `CyclicClosureLoss` to enforce
+    mo.md("""
+    We combine the usual binder-design losses with `CyclicClosureLoss` to enforce
     head-to-tail closure, and pass `cyclic=True` to `WithinBinderContact` so its
-    sequence-separation mask wraps around the cyclic binder instead of treating it as linear."""
-    )
+    sequence-separation mask wraps around the cyclic binder instead of treating it as linear.
+    """)
     return
 
 
@@ -94,11 +92,20 @@ def _(af2, af_features):
 
 @app.cell
 def _(af2, af_features, af_writer):
+    def binder_closure_distance(st):
+        """CA-CA distance between the binder's first and last residues (chain 0)."""
+        binder_chain = st[0][0]
+        first_ca = binder_chain[0].get_ca().pos
+        last_ca = binder_chain[len(binder_chain) - 1].get_ca().pos
+        return first_ca.dist(last_ca)
+
     def predict(sequence):
         pred = af2.predict(
             PSSM=sequence, features=af_features, writer=af_writer, key=jax.random.key(0)
         )
-        return pred, pdb_viewer(pred.st)
+        closure_distance = binder_closure_distance(pred.st)
+        return pred, pdb_viewer(pred.st), closure_distance
+
     return (predict,)
 
 
@@ -122,14 +129,17 @@ def _(binder_length, loss):
 
 @app.cell
 def _(PSSM, predict):
-    output, viewer = predict(PSSM)
+    output, viewer, closure_distance = predict(PSSM)
+    print(f"binder first-to-last CA distance: {closure_distance:.2f} A")
     viewer
-    return (output,)
+    return
 
 
 @app.cell(hide_code=True)
 def _():
-    mo.md("""Let's sharpen the PSSM to a single sequence and repredict.""")
+    mo.md("""
+    Let's sharpen the PSSM to a single sequence and repredict.
+    """)
     return
 
 
@@ -147,9 +157,10 @@ def _(PSSM, loss):
 
 @app.cell
 def _(predict, pssm_sharper):
-    sharp_output, sharp_viewer = predict(pssm_sharper)
+    sharp_output, sharp_viewer, sharp_closure_distance = predict(pssm_sharper)
+    print(f"binder first-to-last CA distance: {sharp_closure_distance:.2f} A")
     sharp_viewer
-    return (sharp_output,)
+    return
 
 
 if __name__ == "__main__":

--- a/examples/af2_cyclic_binder.py
+++ b/examples/af2_cyclic_binder.py
@@ -1,0 +1,156 @@
+import marimo
+
+__generated_with = "0.16.3"
+app = marimo.App(width="full")
+
+with app.setup:
+    import jax
+    import marimo as mo
+    import numpy as np
+
+    import mosaic.losses.structure_prediction as sp
+    from mosaic.models.af2 import AlphaFold2
+    from mosaic.notebook_utils import pdb_viewer
+    from mosaic.optimizers import simplex_APGM
+    from mosaic.structure_prediction import TargetChain
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(
+        """
+    ---
+    **Warning**
+
+    1. You'll almost certainly need a GPU or TPU
+    2. Because JAX uses JIT compilation the first execution of a cell may take quite a while
+    3. You might have to run these optimization methods multiple times before you get a reasonable binder
+    ---
+
+    This example designs a head-to-tail **cyclic** binder against a target using AF2. Two
+    things make a binder "cyclic" here:
+
+    1. `AlphaFold2.binder_features(..., cyclic=True)`, which biases the structure module's
+       residue-index offsets (`mosaic.geometry.cyclic_offset_matrix`) so the trunk treats the
+       binder as a closed loop rather than a linear chain.
+    2. `sp.CyclicClosureLoss()`, an explicit contact loss between the binder's first and last
+       residues. The offset bias alone isn't consistently strong enough to force closure once
+       it's combined with other contact losses during full sequence design, so we add this term
+       directly to the loss.
+    """
+    )
+    return
+
+
+@app.cell
+def _():
+    target_sequence = "SFPASVQLHTAVEMHHWCIPFSVDGQPAPSLRWLFNGSVLNETSFIFTEFLEPAANETVRHGCLRLNQPTHVNNGNYTLLAANPFGQASASIMAAF"
+    return (target_sequence,)
+
+
+@app.cell
+def _():
+    binder_length = 20
+    return (binder_length,)
+
+
+@app.cell
+def _():
+    af2 = AlphaFold2()
+    return (af2,)
+
+
+@app.cell
+def _(af2, binder_length, target_sequence):
+    af_features, af_writer = af2.binder_features(
+        binder_length=binder_length,
+        chains=[TargetChain(sequence=target_sequence, use_msa=False)],
+        cyclic=True,
+    )
+    return af_features, af_writer
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(
+        """We combine the usual binder-design losses with `CyclicClosureLoss` to enforce
+    head-to-tail closure, and pass `cyclic=True` to `WithinBinderContact` so its
+    sequence-separation mask wraps around the cyclic binder instead of treating it as linear."""
+    )
+    return
+
+
+@app.cell
+def _(af2, af_features):
+    loss = af2.build_loss(
+        loss=sp.BinderTargetContact()
+        + sp.WithinBinderContact(cyclic=True)
+        + sp.CyclicClosureLoss(),
+        features=af_features,
+        recycling_steps=2,
+    )
+    return (loss,)
+
+
+@app.cell
+def _(af2, af_features, af_writer):
+    def predict(sequence):
+        pred = af2.predict(
+            PSSM=sequence, features=af_features, writer=af_writer, key=jax.random.key(0)
+        )
+        return pred, pdb_viewer(pred.st)
+    return (predict,)
+
+
+@app.cell
+def _(binder_length, loss):
+    _, PSSM = simplex_APGM(
+        loss_function=loss,
+        x=jax.nn.softmax(
+            0.5
+            * jax.random.gumbel(
+                key=jax.random.key(np.random.randint(100000)),
+                shape=(binder_length, 20),
+            )
+        ),
+        n_steps=100,
+        stepsize=0.1,
+        momentum=0.9,
+    )
+    return (PSSM,)
+
+
+@app.cell
+def _(PSSM, predict):
+    output, viewer = predict(PSSM)
+    viewer
+    return (output,)
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md("""Let's sharpen the PSSM to a single sequence and repredict.""")
+    return
+
+
+@app.cell
+def _(PSSM, loss):
+    pssm_sharper, _ = simplex_APGM(
+        loss_function=loss,
+        n_steps=25,
+        x=PSSM,
+        stepsize=0.2,
+        scale=1.5,
+    )
+    return (pssm_sharper,)
+
+
+@app.cell
+def _(predict, pssm_sharper):
+    sharp_output, sharp_viewer = predict(pssm_sharper)
+    sharp_viewer
+    return (sharp_output,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/mosaic/NOTICE
+++ b/src/mosaic/NOTICE
@@ -1,0 +1,32 @@
+ColabDesign
+-----------
+optimizers.py (colabdesign_stage, _colabdesign_transform, _colabdesign_pullback,
+_seq_grad_norm) ports the AfDesign logit-optimization recipe (soft/temp/hard
+ramping, normalised sequence gradient) from ColabDesign
+(https://github.com/sokrypton/ColabDesign), used under the MIT License:
+
+    MIT License
+
+    Copyright (c) 2021 Sergey Ovchinnikov
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+geometry.py (cyclic_offset_matrix) ports ColabDesign's cyclic_offset
+(af_cyc_design.ipynb), as productionized in grasp's utils/cyclic_offset.py, under
+the same ColabDesign MIT License above.

--- a/src/mosaic/alphafold/model/modules.py
+++ b/src/mosaic/alphafold/model/modules.py
@@ -1684,6 +1684,8 @@ class EmbeddingsAndEvoformer(hk.Module):
       # Add one-hot-encoded clipped residue distances to the pair activations.
       pos = batch['residue_index']
       offset = pos[:, None] - pos[None, :]
+      if 'offset' in batch:
+        offset = batch['offset']
       rel_pos = jax.nn.one_hot(
           jnp.clip(
               offset + c.max_relative_feature,

--- a/src/mosaic/alphafold/model/modules_multimer.py
+++ b/src/mosaic/alphafold/model/modules_multimer.py
@@ -249,7 +249,10 @@ class EmbeddingsAndEvoformer(hk.Module):
         pos = batch["residue_index"]
         asym_id = batch["asym_id"]
         asym_id_same = jnp.equal(asym_id[:, None], asym_id[None, :])
-        offset = pos[:, None] - pos[None, :]
+        if "offset" in batch:
+            offset = batch["offset"]
+        else:
+            offset = pos[:, None] - pos[None, :]
         dtype = jnp.bfloat16 if gc.bfloat16 else jnp.float32
 
         clipped_offset = jnp.clip(

--- a/src/mosaic/geometry.py
+++ b/src/mosaic/geometry.py
@@ -15,9 +15,11 @@ def cyclic_offset_matrix(
     shortest signed separation around the ring instead of the linear ``i - j``.
 
     offset_type:
-      1: unsigned cyclic distance (min(|i-j|, length-|i-j|)).
-      2: cyclic distance, re-signed to match the linear offset's sign, but only
-         overriding the linear distance where the cyclic path is shorter.
+      1: cyclic distance (min(|i-j|, length-|i-j|)), signed to match the linear
+         offset's sign (i.e. the sign of ``i - j``).
+      2: like 1, but wherever the cyclic path is shorter than the linear one,
+         the sign is flipped relative to the linear offset — reflecting that the
+         shortest path now wraps around in the opposite direction.
       3: like 2, but pairs with cyclic distance > 2 are saturated to
          ``saturation_value`` (biases losses away from long-range pairs).
 

--- a/src/mosaic/geometry.py
+++ b/src/mosaic/geometry.py
@@ -5,7 +5,9 @@
 import numpy as np
 
 
-def cyclic_offset_matrix(length: int, offset_type: int = 2) -> np.ndarray:
+def cyclic_offset_matrix(
+    length: int, offset_type: int = 2, saturation_value: int = 32
+) -> np.ndarray:
     """Wraparound sequence-separation matrix for a head-to-tail cyclic chain.
 
     Port of ColabDesign's ``cyclic_offset`` (af_cyc_design.ipynb), as productionized
@@ -16,8 +18,15 @@ def cyclic_offset_matrix(length: int, offset_type: int = 2) -> np.ndarray:
       1: unsigned cyclic distance (min(|i-j|, length-|i-j|)).
       2: cyclic distance, re-signed to match the linear offset's sign, but only
          overriding the linear distance where the cyclic path is shorter.
-      3: like 2, but pairs with cyclic distance > 2 are saturated to a large
-         constant (biases losses away from long-range pairs).
+      3: like 2, but pairs with cyclic distance > 2 are saturated to
+         ``saturation_value`` (biases losses away from long-range pairs).
+
+    saturation_value: magnitude used by offset_type=3 for long-range pairs. Defaults
+      to 32 to match AF2-multimer's own relpos clipping (``max_relative_idx``), which
+      is what ``offset`` ultimately feeds into via
+      ``EmbeddingsAndEvoformer._relative_encoding``'s ``batch["offset"]`` override —
+      keep this in sync with ``max_relative_idx`` if that's ever configured
+      differently. Unused for offset_type 1/2.
     """
     if offset_type not in (1, 2, 3):
         raise ValueError(f"Invalid offset_type: {offset_type}. Must be 1, 2, or 3.")
@@ -32,6 +41,6 @@ def cyclic_offset_matrix(length: int, offset_type: int = 2) -> np.ndarray:
         c_offset[a] = -c_offset[a]
     if offset_type == 3:
         idx = np.abs(c_offset) > 2
-        c_offset[idx] = (32 * c_offset[idx]) / np.abs(c_offset[idx])
+        c_offset[idx] = (saturation_value * c_offset[idx]) / np.abs(c_offset[idx])
 
     return c_offset * np.sign(offset)

--- a/src/mosaic/geometry.py
+++ b/src/mosaic/geometry.py
@@ -41,6 +41,6 @@ def cyclic_offset_matrix(
         c_offset[a] = -c_offset[a]
     if offset_type == 3:
         idx = np.abs(c_offset) > 2
-        c_offset[idx] = (saturation_value * c_offset[idx]) / np.abs(c_offset[idx])
+        c_offset[idx] = saturation_value * np.sign(c_offset[idx])
 
     return c_offset * np.sign(offset)

--- a/src/mosaic/geometry.py
+++ b/src/mosaic/geometry.py
@@ -1,3 +1,7 @@
+# cyclic_offset_matrix below is adapted from ColabDesign
+# (https://github.com/sokrypton/ColabDesign), Copyright (c) 2021 Sergey
+# Ovchinnikov, MIT License. See ./NOTICE.
+
 import numpy as np
 
 

--- a/src/mosaic/geometry.py
+++ b/src/mosaic/geometry.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def cyclic_offset_matrix(length: int, offset_type: int = 2) -> np.ndarray:
+    """Wraparound sequence-separation matrix for a head-to-tail cyclic chain.
+
+    Port of ColabDesign's ``cyclic_offset`` (af_cyc_design.ipynb), as productionized
+    in grasp's ``utils/cyclic_offset.py``. For each residue pair (i, j), computes the
+    shortest signed separation around the ring instead of the linear ``i - j``.
+
+    offset_type:
+      1: unsigned cyclic distance (min(|i-j|, length-|i-j|)).
+      2: cyclic distance, re-signed to match the linear offset's sign, but only
+         overriding the linear distance where the cyclic path is shorter.
+      3: like 2, but pairs with cyclic distance > 2 are saturated to a large
+         constant (biases losses away from long-range pairs).
+    """
+    if offset_type not in (1, 2, 3):
+        raise ValueError(f"Invalid offset_type: {offset_type}. Must be 1, 2, or 3.")
+
+    i = np.arange(length)
+    ij = np.stack([i, i + length], -1)
+    offset = i[:, None] - i[None, :]
+    c_offset = np.abs(ij[:, None, :, None] - ij[None, :, None, :]).min((2, 3))
+
+    if offset_type >= 2:
+        a = c_offset < np.abs(offset)
+        c_offset[a] = -c_offset[a]
+    if offset_type == 3:
+        idx = np.abs(c_offset) > 2
+        c_offset[idx] = (32 * c_offset[idx]) / np.abs(c_offset[idx])
+
+    return c_offset * np.sign(offset)

--- a/src/mosaic/losses/structure_prediction.py
+++ b/src/mosaic/losses/structure_prediction.py
@@ -10,6 +10,7 @@ import numpy as np
 import gemmi
 
 from ..common import LossTerm
+from ..geometry import cyclic_offset_matrix
 
 # 64 bins, 0.0–32.0 Å, shared across all model backends
 PAE_BINS = np.arange(start=0.25, stop=32.0, step=0.5)
@@ -241,6 +242,7 @@ class WithinBinderContact(LossTerm):
     max_contact_distance: float = 14.0
     min_sequence_separation: int = 8
     num_contacts_per_residue: int = 25
+    cyclic: bool = False
 
     def __call__(
         self,
@@ -255,10 +257,13 @@ class WithinBinderContact(LossTerm):
             bins=output.distogram_bins,
         )
         # only count binder-binder contacts with sequence sep > min_sequence_separation
-        within_binder_mask = (
-            jnp.abs(jnp.arange(binder_len)[:, None] - jnp.arange(binder_len)[None, :])
-            > self.min_sequence_separation
-        )
+        if self.cyclic:
+            seqsep = jnp.abs(jnp.array(cyclic_offset_matrix(binder_len, offset_type=1)))
+        else:
+            seqsep = jnp.abs(
+                jnp.arange(binder_len)[:, None] - jnp.arange(binder_len)[None, :]
+            )
+        within_binder_mask = seqsep > self.min_sequence_separation
         # for each position in binder find positions most likely to make contact
 
         # JAX/XLO has a bizarre issue with top_k when used inside vmap _only_ when used on multiple GPUs.
@@ -343,6 +348,7 @@ class BinderTargetContact(LossTerm):
 class HelixLoss(LossTerm):
     max_distance: float = 6.0
     target_value: float = -2.0
+    cyclic: bool = False
 
     def __call__(
         self,
@@ -356,7 +362,15 @@ class HelixLoss(LossTerm):
             self.max_distance,
             bins=output.distogram_bins,
         )
-        value = jnp.diagonal(log_contact, 3).mean()
+        if self.cyclic:
+            # i, i+3 pairs, but wrapped around the N/C junction instead of a
+            # fixed linear diagonal (which would miss/misrepresent pairs near
+            # the termini for a head-to-tail cyclic binder).
+            offset = jnp.abs(jnp.array(cyclic_offset_matrix(binder_len, offset_type=1)))
+            mask = offset == 3
+            value = (jnp.where(mask, log_contact, 0.0).sum()) / (mask.sum() + 1e-8)
+        else:
+            value = jnp.diagonal(log_contact, 3).mean()
 
         loss = jax.nn.elu(self.target_value - value)
 

--- a/src/mosaic/losses/structure_prediction.py
+++ b/src/mosaic/losses/structure_prediction.py
@@ -283,6 +283,37 @@ class WithinBinderContact(LossTerm):
         return -average_log_prob, {"intra_contact": average_log_prob}
 
 
+class CyclicClosureLoss(LossTerm):
+    """Explicit N/C-terminal contact loss for head-to-tail cyclic binders.
+
+    The cyclic offset (``mosaic.geometry.cyclic_offset_matrix``, threaded
+    through ``batch["offset"]``) only biases the structure module's prior
+    toward a closed conformation — it doesn't directly reward closure, and
+    that bias alone isn't reliably strong enough once combined with other
+    contact losses (``BinderTargetContact``, ``WithinBinderContact``) during
+    full sequence optimization against a real target. This term closes that
+    gap directly: a contact loss between the binder's first and last
+    residues only.
+    """
+
+    closure_distance: float = 4.0
+
+    def __call__(
+        self,
+        sequence: Float[Array, "N 20"],
+        output: StructureModelOutput,
+        key,
+    ):
+        binder_len = sequence.shape[0]
+        log_contact = contact_cross_entropy(
+            output.distogram_logits[:binder_len, :binder_len],
+            self.closure_distance,
+            bins=output.distogram_bins,
+        )
+        log_prob = log_contact[0, -1]
+        return -log_prob, {"cyclic_closure": log_prob}
+
+
 class ESMFoldInterContact(LossTerm):
     """Subtly variation on `BinderTargetContact` used in ESMFold2 hallucination:
     for each _target_ residue use the most confident binder residue. Defaults to22"""

--- a/src/mosaic/models/af2.py
+++ b/src/mosaic/models/af2.py
@@ -1,4 +1,5 @@
 from mosaic.cache import resolve_cache
+from mosaic.geometry import cyclic_offset_matrix
 from mosaic.structure_prediction import (
     StructurePredictionModel,
     TargetChain,
@@ -306,7 +307,9 @@ def af2_atom_positions(chain: gemmi.Chain) -> tuple[np.ndarray, np.ndarray]:
     return all_positions[None], all_positions_mask[None]
 
 
-def make_af_features(chains: list[TargetChain]) -> dict[str, jax.Array]:
+def make_af_features(
+    chains: list[TargetChain], cyclic_binder_length: int | None = None
+) -> dict[str, jax.Array]:
     assert all(not c.use_msa for c in chains), "AF2 interface does not support MSAs"
 
     # check for missing residues in template chains
@@ -345,6 +348,12 @@ def make_af_features(chains: list[TargetChain]) -> dict[str, jax.Array]:
         "sym_id": chain_index,
         "entity_id": chain_index,
     }
+
+    if cyclic_binder_length is not None:
+        offset = index_within_chain[:, None] - index_within_chain[None, :]
+        binder_offset = cyclic_offset_matrix(cyclic_binder_length)
+        offset[:cyclic_binder_length, :cyclic_binder_length] = binder_offset
+        raw_features["offset"] = offset
 
     template_features = [
         af2_atom_positions(tc.template_chain)
@@ -386,16 +395,17 @@ class AlphaFold2(StructurePredictionModel):
         self.stacked_parameters = stacked_params
         self.multimer = multimer
 
-    def target_only_features(self, chains: list[TargetChain]):
+    def target_only_features(self, chains: list[TargetChain], cyclic_binder_length: int | None = None):
         for c in chains:
             assert c.polymer_type == "PROTEIN", "AF2 only supports protein chains"
             assert not c.use_msa, "AF2 interface does not support MSA yet"
 
-        return make_af_features(chains=chains), None
+        return make_af_features(chains=chains, cyclic_binder_length=cyclic_binder_length), None
 
-    def binder_features(self, binder_length, chains: list[TargetChain]):
+    def binder_features(self, binder_length, chains: list[TargetChain], cyclic: bool = False):
         features, _ = self.target_only_features(
-            [TargetChain(sequence="G" * binder_length, use_msa=False)] + chains
+            [TargetChain(sequence="G" * binder_length, use_msa=False)] + chains,
+            cyclic_binder_length=binder_length if cyclic else None,
         )
         return features, None
 

--- a/src/mosaic/models/af2.py
+++ b/src/mosaic/models/af2.py
@@ -413,7 +413,9 @@ class AlphaFold2(StructurePredictionModel):
         self.stacked_parameters = stacked_params
         self.multimer = multimer
 
-    def target_only_features(self, chains: list[TargetChain], cyclic_binder_length: int | None = None):
+    def target_only_features(
+        self, chains: list[TargetChain], cyclic_binder_length: int | None = None
+    ):
         for c in chains:
             assert c.polymer_type == "PROTEIN", "AF2 only supports protein chains"
             assert not c.use_msa, "AF2 interface does not support MSA yet"

--- a/src/mosaic/models/af2.py
+++ b/src/mosaic/models/af2.py
@@ -43,6 +43,13 @@ def from_string(s: str) -> gemmi.Structure:
     return st
 
 
+# AF2-monomer chain-break convention: gap residue_index by this much between
+# chains of a multi-chain complex so relpos features don't read a chain
+# boundary as an ordinary short-range contact. Used by both
+# `multimer_to_monomer_features` and `make_af_features` below.
+CHAIN_BREAK_GAP = 50
+
+
 class Distogram(eqx.Module):
     bin_edges: Float[Array, "63"]
     logits: Float[Array, "N N 63"]
@@ -195,7 +202,7 @@ def multimer_to_monomer_features(features: dict):
         jax.nn.one_hot(features['aatype'], 21)
         ], axis=-1)
     monomer_features['target_feat'] = target_feat
-    monomer_features['residue_index'] = jnp.cumsum(has_break)*50 + jnp.arange(features['asym_id'].size)
+    monomer_features['residue_index'] = jnp.cumsum(has_break)*CHAIN_BREAK_GAP + jnp.arange(features['asym_id'].size)
     monomer_features['template_all_atom_masks'] = features['template_all_atom_mask']
     monomer_features['template_mask'] = np.ones(1)
 
@@ -321,8 +328,19 @@ def make_af_features(
 
     # TODO: handle homo-multimers better?
     L = sum(len(c.sequence) for c in chains)
+    # Apply the same chain-break gap as multimer_to_monomer_features (see
+    # CHAIN_BREAK_GAP), so the model doesn't read a multi-chain complex as
+    # one contiguous chain. Without this, cross-chain relpos features look
+    # like ordinary short-range contacts, which destabilizes the whole
+    # predicted structure (including the binder's own cyclic closure) even
+    # though the binder-binder sub-block of `offset` is fully overridden
+    # below.
+    chain_starts = np.cumsum([0] + [len(c.sequence) + CHAIN_BREAK_GAP for c in chains[:-1]])
     index_within_chain = np.concatenate(
-        [np.arange(len(c.sequence), dtype=int) for c in chains]
+        [
+            np.arange(len(c.sequence), dtype=int) + start
+            for c, start in zip(chains, chain_starts)
+        ]
     )
     chain_index = np.concatenate(
         [

--- a/src/mosaic/optimizers.py
+++ b/src/mosaic/optimizers.py
@@ -1,3 +1,7 @@
+# colabdesign_stage and its helpers below are adapted from ColabDesign
+# (https://github.com/sokrypton/ColabDesign), Copyright (c) 2021 Sergey
+# Ovchinnikov, MIT License. See ./NOTICE.
+
 import time
 from typing import Callable
 
@@ -699,7 +703,7 @@ def biohub_optimizer(
 
 
 def _colabdesign_transform(z, soft, temp, hard):
-    """Map ColabDesign logits to the sequence passed to the user's loss."""
+    """Map ColabDesign logits to the sequence passed to the user's loss. See ./NOTICE."""
     soft_seq = jax.nn.softmax(z / temp)
     hard_seq = jax.nn.one_hot(soft_seq.argmax(-1), z.shape[-1])
     # straight thru estimator

--- a/tests/test_cyclic_loss.py
+++ b/tests/test_cyclic_loss.py
@@ -1,0 +1,106 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from mosaic.geometry import cyclic_offset_matrix
+from mosaic.losses.structure_prediction import (
+    HelixLoss,
+    WithinBinderContact,
+    StructureModelOutput,
+)
+
+
+def _random_output(binder_len: int, key) -> StructureModelOutput:
+    n = binder_len
+    bins = jnp.linspace(2.0, 20.0, 8)
+    distogram_logits = jax.random.normal(key, (n, n, len(bins)))
+    return StructureModelOutput(
+        distogram_logits=distogram_logits,
+        distogram_bins=bins,
+        plddt=jnp.ones(n),
+        pae=jnp.zeros((n, n)),
+        pae_logits=jnp.zeros((n, n, 1)),
+        pae_bins=jnp.zeros(1),
+        structure_coordinates=jnp.zeros((n, 37, 3)),
+        backbone_coordinates=jnp.zeros((n, 4, 3)),
+        full_sequence=jax.nn.one_hot(jnp.zeros(n, dtype=jnp.int32), 20),
+        asym_id=jnp.zeros(n, dtype=jnp.int32),
+        residue_idx=jnp.arange(n),
+        atom37_coords=jnp.zeros((n, 37, 3)),
+        atom37_mask=jnp.zeros((n, 37)),
+    )
+
+
+def test_within_binder_contact_cyclic_false_is_regression_safe():
+    binder_len = 10
+    key = jax.random.PRNGKey(0)
+    output = _random_output(binder_len, key)
+    sequence = jnp.zeros((binder_len, 20))
+
+    loss_default = WithinBinderContact(min_sequence_separation=5)
+    loss_explicit_linear = WithinBinderContact(min_sequence_separation=5, cyclic=False)
+
+    value_default, aux_default = loss_default(sequence, output, key=None)
+    value_explicit, aux_explicit = loss_explicit_linear(sequence, output, key=None)
+
+    assert value_default == value_explicit
+    assert aux_default == aux_explicit
+
+
+def test_within_binder_contact_cyclic_true_differs_from_linear():
+    binder_len = 10
+    key = jax.random.PRNGKey(1)
+    output = _random_output(binder_len, key)
+    sequence = jnp.zeros((binder_len, 20))
+
+    linear_loss = WithinBinderContact(min_sequence_separation=5, cyclic=False)
+    cyclic_loss = WithinBinderContact(min_sequence_separation=5, cyclic=True)
+
+    linear_value, _ = linear_loss(sequence, output, key=None)
+    cyclic_value, _ = cyclic_loss(sequence, output, key=None)
+
+    # with min_sequence_separation=5 and binder_len=10, the wraparound pair
+    # (0, 9) has cyclic distance 1 (excluded) but linear distance 9 (included),
+    # so the two masks genuinely differ and should produce different losses.
+    assert linear_value != cyclic_value
+
+
+def test_helix_loss_cyclic_false_is_regression_safe():
+    binder_len = 12
+    key = jax.random.PRNGKey(2)
+    output = _random_output(binder_len, key)
+    sequence = jnp.zeros((binder_len, 20))
+
+    loss_default = HelixLoss()
+    loss_explicit_linear = HelixLoss(cyclic=False)
+
+    value_default, aux_default = loss_default(sequence, output, key=None)
+    value_explicit, aux_explicit = loss_explicit_linear(sequence, output, key=None)
+
+    assert value_default == value_explicit
+    assert aux_default == aux_explicit
+
+
+def test_helix_loss_cyclic_true_includes_wraparound_i_plus_3_pairs():
+    binder_len = 12
+    key = jax.random.PRNGKey(3)
+    output = _random_output(binder_len, key)
+    sequence = jnp.zeros((binder_len, 20))
+
+    linear_loss = HelixLoss(cyclic=False)
+    cyclic_loss = HelixLoss(cyclic=True)
+
+    linear_value, _ = linear_loss(sequence, output, key=None)
+    cyclic_value, _ = cyclic_loss(sequence, output, key=None)
+
+    # jnp.diagonal(log_contact, 3) only ever sees binder_len - 3 pairs and never
+    # the wraparound i,i+3 pairs near the C-terminus, so cyclic mode (which
+    # includes those wraparound pairs) should generally produce a different
+    # value for a random (non-degenerate) contact map.
+    assert linear_value != cyclic_value
+
+    # sanity: the cyclic mask should select exactly 2*binder_len pairs (each
+    # residue has both a forward and backward "distance-3" neighbor around
+    # the ring, i.e. (i, i+3) and (i, i-3)).
+    offset = np.abs(cyclic_offset_matrix(binder_len, offset_type=1))
+    assert (offset == 3).sum() == 2 * binder_len

--- a/tests/test_cyclic_loss.py
+++ b/tests/test_cyclic_loss.py
@@ -1,8 +1,6 @@
 import jax
 import jax.numpy as jnp
-import numpy as np
 
-from mosaic.geometry import cyclic_offset_matrix
 from mosaic.losses.structure_prediction import (
     CyclicClosureLoss,
     HelixLoss,
@@ -99,12 +97,6 @@ def test_helix_loss_cyclic_true_includes_wraparound_i_plus_3_pairs():
     # includes those wraparound pairs) should generally produce a different
     # value for a random (non-degenerate) contact map.
     assert linear_value != cyclic_value
-
-    # sanity: the cyclic mask should select exactly 2*binder_len pairs (each
-    # residue has both a forward and backward "distance-3" neighbor around
-    # the ring, i.e. (i, i+3) and (i, i-3)).
-    offset = np.abs(cyclic_offset_matrix(binder_len, offset_type=1))
-    assert (offset == 3).sum() == 2 * binder_len
 
 
 def test_cyclic_closure_loss_only_scores_first_last_pair():

--- a/tests/test_cyclic_loss.py
+++ b/tests/test_cyclic_loss.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from mosaic.geometry import cyclic_offset_matrix
 from mosaic.losses.structure_prediction import (
+    CyclicClosureLoss,
     HelixLoss,
     WithinBinderContact,
     StructureModelOutput,
@@ -104,3 +105,64 @@ def test_helix_loss_cyclic_true_includes_wraparound_i_plus_3_pairs():
     # the ring, i.e. (i, i+3) and (i, i-3)).
     offset = np.abs(cyclic_offset_matrix(binder_len, offset_type=1))
     assert (offset == 3).sum() == 2 * binder_len
+
+
+def test_cyclic_closure_loss_only_scores_first_last_pair():
+    binder_len = 10
+    key = jax.random.PRNGKey(4)
+    output = _random_output(binder_len, key)
+    sequence = jnp.zeros((binder_len, 20))
+
+    loss = CyclicClosureLoss()
+    value, aux = loss(sequence, output, key=None)
+
+    from mosaic.losses.structure_prediction import contact_cross_entropy
+
+    expected_log_contact = contact_cross_entropy(
+        output.distogram_logits, loss.closure_distance, bins=output.distogram_bins
+    )
+    expected_value = -expected_log_contact[0, -1]
+
+    assert value == expected_value
+    assert aux == {"cyclic_closure": expected_log_contact[0, -1]}
+
+
+def test_cyclic_closure_loss_rewards_short_terminal_distance():
+    binder_len = 6
+    bins = jnp.linspace(2.0, 20.0, 8)
+    sequence = jnp.zeros((binder_len, 20))
+    loss = CyclicClosureLoss(closure_distance=4.0)
+
+    def _output_with_terminal_logits(terminal_logits):
+        distogram_logits = jnp.zeros((binder_len, binder_len, len(bins)))
+        distogram_logits = distogram_logits.at[0, -1].set(terminal_logits)
+        return StructureModelOutput(
+            distogram_logits=distogram_logits,
+            distogram_bins=bins,
+            plddt=jnp.ones(binder_len),
+            pae=jnp.zeros((binder_len, binder_len)),
+            pae_logits=jnp.zeros((binder_len, binder_len, 1)),
+            pae_bins=jnp.zeros(1),
+            structure_coordinates=jnp.zeros((binder_len, 37, 3)),
+            backbone_coordinates=jnp.zeros((binder_len, 4, 3)),
+            full_sequence=jax.nn.one_hot(jnp.zeros(binder_len, dtype=jnp.int32), 20),
+            asym_id=jnp.zeros(binder_len, dtype=jnp.int32),
+            residue_idx=jnp.arange(binder_len),
+            atom37_coords=jnp.zeros((binder_len, 37, 3)),
+            atom37_mask=jnp.zeros((binder_len, 37)),
+        )
+
+    # all mass on the shortest bin (< closure_distance) vs. all mass on the
+    # longest bin (> closure_distance): closure loss should be far lower
+    # (more rewarding) in the "close" case.
+    close_output = _output_with_terminal_logits(
+        jnp.array([10.0] + [0.0] * (len(bins) - 1))
+    )
+    far_output = _output_with_terminal_logits(
+        jnp.array([0.0] * (len(bins) - 1) + [10.0])
+    )
+
+    close_value, _ = loss(sequence, close_output, key=None)
+    far_value, _ = loss(sequence, far_output, key=None)
+
+    assert close_value < far_value

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -52,3 +52,22 @@ def test_offset_type_1_reduces_to_linear_for_small_length_boundary():
     # for length=4, the maximum possible unsigned cyclic distance is 2 (L/2).
     m = cyclic_offset_matrix(4, offset_type=1)
     assert m.max() == 2
+
+
+def test_offset_type_3_saturation_value_defaults_to_af2_max_relative_idx():
+    # AF2-multimer's relpos clipping (_relative_encoding) uses max_relative_idx=32
+    # by default; offset_type=3's saturation constant must match that, not an
+    # unrelated hardcoded value.
+    length = 8
+    m = cyclic_offset_matrix(length, offset_type=3)
+    far_pairs_mask = np.abs(cyclic_offset_matrix(length, offset_type=1)) > 2
+    assert np.all(np.abs(m[far_pairs_mask]) == 32)
+
+
+def test_offset_type_3_saturation_value_is_configurable():
+    # a caller using AF2 with a non-default max_relative_idx must be able to
+    # keep offset_type=3's saturation consistent with it.
+    length = 8
+    m = cyclic_offset_matrix(length, offset_type=3, saturation_value=64)
+    far_pairs_mask = np.abs(cyclic_offset_matrix(length, offset_type=1)) > 2
+    assert np.all(np.abs(m[far_pairs_mask]) == 64)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+
+from mosaic.geometry import cyclic_offset_matrix
+
+
+def test_invalid_offset_type_raises():
+    with pytest.raises(ValueError):
+        cyclic_offset_matrix(4, offset_type=0)
+
+
+def test_offset_type_1_wraparound_distance_is_antisymmetric_in_magnitude():
+    m = cyclic_offset_matrix(4, offset_type=1)
+    # signed like the linear offset, but magnitude is the wraparound distance:
+    # |m| is symmetric (a proper distance), even though m itself is antisymmetric.
+    assert np.array_equal(np.abs(m), np.abs(m).T)
+    # residue 0 and residue 3 are adjacent on the ring (distance 1), not 3.
+    assert abs(m[0, 3]) == 1
+    assert abs(m[0, 2]) == 2
+    # interior pairs match the ordinary linear distance.
+    assert abs(m[1, 2]) == 1
+
+
+def test_offset_type_2_matches_linear_offset_away_from_wraparound():
+    length = 6
+    m = cyclic_offset_matrix(length, offset_type=2)
+    i = np.arange(length)
+    linear_offset = i[:, None] - i[None, :]
+    # for interior pairs the cyclic path isn't shorter, so type 2 == linear offset.
+    assert m[1, 2] == linear_offset[1, 2]
+    assert m[2, 3] == linear_offset[2, 3]
+
+
+def test_offset_type_2_wraparound_pair_is_close():
+    length = 6
+    m = cyclic_offset_matrix(length, offset_type=2)
+    # residue 0 and residue length-1 are wraparound-adjacent: cyclic distance 1,
+    # far shorter than the linear distance (length-1), so it should be re-signed
+    # to a small magnitude rather than the large linear offset.
+    assert abs(m[0, length - 1]) == 1
+
+
+def test_offset_type_3_saturates_long_range_pairs():
+    length = 8
+    m = cyclic_offset_matrix(length, offset_type=3)
+    # a pair whose cyclic distance exceeds 2 should be saturated to +/-32.
+    far_pairs_mask = np.abs(cyclic_offset_matrix(length, offset_type=1)) > 2
+    assert np.all(np.abs(m[far_pairs_mask]) == 32)
+
+
+def test_offset_type_1_reduces_to_linear_for_small_length_boundary():
+    # for length=4, the maximum possible unsigned cyclic distance is 2 (L/2).
+    m = cyclic_offset_matrix(4, offset_type=1)
+    assert m.max() == 2

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -19,6 +19,8 @@ def test_offset_type_1_wraparound_distance_is_antisymmetric_in_magnitude():
     assert abs(m[0, 2]) == 2
     # interior pairs match the ordinary linear distance.
     assert abs(m[1, 2]) == 1
+    # for length=4, the maximum possible unsigned cyclic distance is 2 (L/2).
+    assert m.max() == 2
 
 
 def test_offset_type_2_matches_linear_offset_away_from_wraparound():
@@ -44,22 +46,6 @@ def test_offset_type_3_saturates_long_range_pairs():
     length = 8
     m = cyclic_offset_matrix(length, offset_type=3)
     # a pair whose cyclic distance exceeds 2 should be saturated to +/-32.
-    far_pairs_mask = np.abs(cyclic_offset_matrix(length, offset_type=1)) > 2
-    assert np.all(np.abs(m[far_pairs_mask]) == 32)
-
-
-def test_offset_type_1_reduces_to_linear_for_small_length_boundary():
-    # for length=4, the maximum possible unsigned cyclic distance is 2 (L/2).
-    m = cyclic_offset_matrix(4, offset_type=1)
-    assert m.max() == 2
-
-
-def test_offset_type_3_saturation_value_defaults_to_af2_max_relative_idx():
-    # AF2-multimer's relpos clipping (_relative_encoding) uses max_relative_idx=32
-    # by default; offset_type=3's saturation constant must match that, not an
-    # unrelated hardcoded value.
-    length = 8
-    m = cyclic_offset_matrix(length, offset_type=3)
     far_pairs_mask = np.abs(cyclic_offset_matrix(length, offset_type=1)) > 2
     assert np.all(np.abs(m[far_pairs_mask]) == 32)
 

--- a/tests/test_model_smoke.py
+++ b/tests/test_model_smoke.py
@@ -500,11 +500,11 @@ def test_model_output_structure_matches_prediction(multichain_prediction):
     assert np.sqrt(np.mean(np.square(converted_coords - predicted_coords))) < 0.1
 
 
-def _binder_terminal_ca_distance(prediction) -> float:
-    binder_chain = _protein_chains(prediction.st)[0]
-    atoms = _atom_coordinates([binder_chain])
-    n_terminal_ca = atoms[(0, 0, "CA")]
-    c_terminal_ca = atoms[(0, len(binder_chain) - 1, "CA")]
+def _binder_terminal_ca_distance(model_output, binder_length: int) -> float:
+    ca_index = 1  # atom37 order: N, CA, C, O, ...
+    coordinates = np.asarray(model_output.atom37_coords[:binder_length])
+    n_terminal_ca = coordinates[0, ca_index]
+    c_terminal_ca = coordinates[-1, ca_index]
     return float(np.linalg.norm(n_terminal_ca - c_terminal_ca))
 
 
@@ -553,23 +553,36 @@ def test_af2_cyclic_binder_closes_termini_more_than_linear(structure_model):
     if type(structure_model).__name__ != "AlphaFold2":
         pytest.skip("AF2-specific cyclic-binder test")
 
-    target = TargetChain(sequence="ACDEFGHIKLMNPQRSTVWY", use_msa=False)
-    binder_length = 12
+    # Smaller than test_af2_cyclic_binder_forward_pass_runs: compute is
+    # roughly cubic in sequence length, and this test pays for it once per
+    # (model_idx, cyclic) combination below.
+    target = TargetChain(sequence="ACDEFGHIKL", use_msa=False)
+    binder_length = 8
     pssm = jax.nn.one_hot(jnp.zeros(binder_length, dtype=int), 20)
 
-    distances = {}
-    for cyclic in (False, True):
-        features, writer = structure_model.binder_features(
-            binder_length, [target], cyclic=cyclic
-        )
-        prediction = structure_model.predict(
-            PSSM=pssm,
-            features=features,
-            writer=writer,
-            recycling_steps=1,
-            sampling_steps=None,
-            key=jax.random.key(2),
-        )
-        distances[cyclic] = _binder_terminal_ca_distance(prediction)
+    num_sub_models = 5 if structure_model.multimer else 2
+    margins = []
+    for model_idx in range(num_sub_models):
+        key = jax.random.key(model_idx)
+        distances = {}
+        for cyclic in (False, True):
+            features, _writer = structure_model.binder_features(
+                binder_length, [target], cyclic=cyclic
+            )
+            output = structure_model.model_output(
+                PSSM=pssm,
+                features=features,
+                recycling_steps=1,
+                sampling_steps=None,
+                model_idx=model_idx,
+                key=key,
+            )
+            distances[cyclic] = _binder_terminal_ca_distance(output, binder_length)
+        margins.append(distances[False] - distances[True])
 
-    assert distances[True] < distances[False]
+    # Every independently-trained multimer sub-model should agree, by a real
+    # margin (not a coin-flip tie), that cyclization pulls the termini
+    # closer together than the linear default. Observed margins across all
+    # 5 multimer sub-models are ~9.5-15 A; 3.0 A leaves a wide safety
+    # buffer while still ruling out a near-tie passing by chance.
+    assert all(margin > 3.0 for margin in margins), margins

--- a/tests/test_model_smoke.py
+++ b/tests/test_model_smoke.py
@@ -500,20 +500,6 @@ def test_model_output_structure_matches_prediction(multichain_prediction):
     assert np.sqrt(np.mean(np.square(converted_coords - predicted_coords))) < 0.1
 
 
-@pytest.fixture(scope="module")
-def af2_model():
-    from mosaic.models.af2 import AlphaFold2
-
-    cpu = jax.devices("cpu")[0]
-    with jax.default_device(cpu):
-        model = AlphaFold2()
-        yield model
-
-        del model
-    jax.clear_caches()
-    gc.collect()
-
-
 def _binder_terminal_ca_distance(prediction) -> float:
     binder_chain = _protein_chains(prediction.st)[0]
     atoms = _atom_coordinates([binder_chain])
@@ -524,10 +510,13 @@ def _binder_terminal_ca_distance(prediction) -> float:
 
 @pytest.mark.slow
 @pytest.mark.model_forward
-def test_af2_cyclic_binder_forward_pass_runs(af2_model):
+def test_af2_cyclic_binder_forward_pass_runs(structure_model):
+    if type(structure_model).__name__ != "AlphaFold2":
+        pytest.skip("AF2-specific cyclic-binder test")
+
     target = TargetChain(sequence="ACDEFGHIKLMNPQRSTVWY", use_msa=False)
     binder_length = 12
-    features, writer = af2_model.binder_features(
+    features, writer = structure_model.binder_features(
         binder_length, [target], cyclic=True
     )
 
@@ -536,7 +525,7 @@ def test_af2_cyclic_binder_forward_pass_runs(af2_model):
     assert features["offset"].shape == (total_length, total_length)
 
     pssm = jax.nn.one_hot(jnp.zeros(binder_length, dtype=int), 20)
-    loss = af2_model.build_loss(
+    loss = structure_model.build_loss(
         loss=MeanConfidenceLoss(), features=features, recycling_steps=1
     )
     value_and_grad = eqx.filter_jit(eqx.filter_value_and_grad(loss, has_aux=True))
@@ -547,7 +536,7 @@ def test_af2_cyclic_binder_forward_pass_runs(af2_model):
     assert gradient.shape == pssm.shape
     assert np.isfinite(np.asarray(gradient)).all()
 
-    prediction = af2_model.predict(
+    prediction = structure_model.predict(
         PSSM=pssm,
         features=features,
         writer=writer,
@@ -560,17 +549,20 @@ def test_af2_cyclic_binder_forward_pass_runs(af2_model):
 
 @pytest.mark.slow
 @pytest.mark.model_forward
-def test_af2_cyclic_binder_closes_termini_more_than_linear(af2_model):
+def test_af2_cyclic_binder_closes_termini_more_than_linear(structure_model):
+    if type(structure_model).__name__ != "AlphaFold2":
+        pytest.skip("AF2-specific cyclic-binder test")
+
     target = TargetChain(sequence="ACDEFGHIKLMNPQRSTVWY", use_msa=False)
     binder_length = 12
     pssm = jax.nn.one_hot(jnp.zeros(binder_length, dtype=int), 20)
 
     distances = {}
     for cyclic in (False, True):
-        features, writer = af2_model.binder_features(
+        features, writer = structure_model.binder_features(
             binder_length, [target], cyclic=cyclic
         )
-        prediction = af2_model.predict(
+        prediction = structure_model.predict(
             PSSM=pssm,
             features=features,
             writer=writer,

--- a/tests/test_model_smoke.py
+++ b/tests/test_model_smoke.py
@@ -631,3 +631,54 @@ def test_af2_cyclic_binder_closes_termini_more_than_linear_monomer():
     gc.collect()
 
     assert all(margin > 3.0 for margin in margins), margins
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_af2_cyclic_binder_closes_absolutely_with_target_chain_gap():
+    # A relative margin (cyclic closer than linear, as in the test above) can
+    # pass even when neither prediction is anywhere near actually closed.
+    # This checks the practical claim: with a target chain present, cyclic
+    # binder termini end up close in absolute terms, not just closer than
+    # the linear control. Regression target for the missing target/binder
+    # `residue_index` chain-break gap in `make_af_features` (mosaic's own
+    # `multimer_to_monomer_features` already uses this +50 convention;
+    # `make_af_features` didn't, so cross-chain relpos features looked like
+    # ordinary short-range contacts and destabilized the predicted
+    # structure enough that the binder's own cyclic-offset sub-block
+    # couldn't pull its termini together).
+    from mosaic.models.af2 import AlphaFold2
+
+    cpu = jax.devices("cpu")[0]
+    with jax.default_device(cpu):
+        model = AlphaFold2(multimer=False)
+
+        target = TargetChain(sequence="ACDEFGHIKL", use_msa=False)
+        binder_length = 8
+        pssm = jax.nn.one_hot(jnp.zeros(binder_length, dtype=int), 20)
+
+        distances = []
+        for model_idx in range(2):
+            key = jax.random.key(model_idx)
+            features, _writer = model.binder_features(
+                binder_length, [target], cyclic=True
+            )
+            output = model.model_output(
+                PSSM=pssm,
+                features=features,
+                recycling_steps=1,
+                sampling_steps=None,
+                model_idx=model_idx,
+                key=key,
+            )
+            distances.append(_binder_terminal_ca_distance(output, binder_length))
+
+        del model
+    jax.clear_caches()
+    gc.collect()
+
+    # Real head-to-tail closure puts N/C-terminal CA atoms within a few A of
+    # each other; 10 A leaves headroom for prediction noise while still
+    # ruling out the ~15-25 A "not actually closed" failure mode observed
+    # before the chain-break gap fix.
+    assert all(distance < 10.0 for distance in distances), distances

--- a/tests/test_model_smoke.py
+++ b/tests/test_model_smoke.py
@@ -590,13 +590,25 @@ def test_af2_cyclic_binder_closes_termini_more_than_linear(structure_model):
 
 @pytest.mark.slow
 @pytest.mark.model_forward
-def test_af2_cyclic_binder_closes_termini_more_than_linear_monomer():
+def test_af2_cyclic_binder_closes_absolutely_with_target_chain_gap():
     # The multimer/monomer AF2 code paths (modules_multimer.py vs. modules.py)
     # each need their own `batch["offset"]` override; the module-scoped
     # `structure_model` fixture above only exercises the multimer=True
     # default, so it could not catch a monomer-path regression. Callers that
     # run AF2 with multimer=False (e.g. grasp's mosaic design stage) go
     # through modules.py's relpos exclusively.
+    #
+    # A relative margin (cyclic closer than linear) can pass even when
+    # neither prediction is anywhere near actually closed. This also checks
+    # the practical claim: with a target chain present, cyclic binder
+    # termini end up close in absolute terms, not just closer than the
+    # linear control. Regression target for the missing target/binder
+    # `residue_index` chain-break gap in `make_af_features` (mosaic's own
+    # `multimer_to_monomer_features` already uses this +50 convention;
+    # `make_af_features` didn't, so cross-chain relpos features looked like
+    # ordinary short-range contacts and destabilized the predicted
+    # structure enough that the binder's own cyclic-offset sub-block
+    # couldn't pull its termini together).
     from mosaic.models.af2 import AlphaFold2
 
     cpu = jax.devices("cpu")[0]
@@ -608,6 +620,7 @@ def test_af2_cyclic_binder_closes_termini_more_than_linear_monomer():
         pssm = jax.nn.one_hot(jnp.zeros(binder_length, dtype=int), 20)
 
         margins = []
+        cyclic_distances = []
         for model_idx in range(2):
             key = jax.random.key(model_idx)
             distances = {}
@@ -625,60 +638,15 @@ def test_af2_cyclic_binder_closes_termini_more_than_linear_monomer():
                 )
                 distances[cyclic] = _binder_terminal_ca_distance(output, binder_length)
             margins.append(distances[False] - distances[True])
+            cyclic_distances.append(distances[True])
 
         del model
     jax.clear_caches()
     gc.collect()
 
     assert all(margin > 3.0 for margin in margins), margins
-
-
-@pytest.mark.slow
-@pytest.mark.model_forward
-def test_af2_cyclic_binder_closes_absolutely_with_target_chain_gap():
-    # A relative margin (cyclic closer than linear, as in the test above) can
-    # pass even when neither prediction is anywhere near actually closed.
-    # This checks the practical claim: with a target chain present, cyclic
-    # binder termini end up close in absolute terms, not just closer than
-    # the linear control. Regression target for the missing target/binder
-    # `residue_index` chain-break gap in `make_af_features` (mosaic's own
-    # `multimer_to_monomer_features` already uses this +50 convention;
-    # `make_af_features` didn't, so cross-chain relpos features looked like
-    # ordinary short-range contacts and destabilized the predicted
-    # structure enough that the binder's own cyclic-offset sub-block
-    # couldn't pull its termini together).
-    from mosaic.models.af2 import AlphaFold2
-
-    cpu = jax.devices("cpu")[0]
-    with jax.default_device(cpu):
-        model = AlphaFold2(multimer=False)
-
-        target = TargetChain(sequence="ACDEFGHIKL", use_msa=False)
-        binder_length = 8
-        pssm = jax.nn.one_hot(jnp.zeros(binder_length, dtype=int), 20)
-
-        distances = []
-        for model_idx in range(2):
-            key = jax.random.key(model_idx)
-            features, _writer = model.binder_features(
-                binder_length, [target], cyclic=True
-            )
-            output = model.model_output(
-                PSSM=pssm,
-                features=features,
-                recycling_steps=1,
-                sampling_steps=None,
-                model_idx=model_idx,
-                key=key,
-            )
-            distances.append(_binder_terminal_ca_distance(output, binder_length))
-
-        del model
-    jax.clear_caches()
-    gc.collect()
-
     # Real head-to-tail closure puts N/C-terminal CA atoms within a few A of
     # each other; 10 A leaves headroom for prediction noise while still
     # ruling out the ~15-25 A "not actually closed" failure mode observed
     # before the chain-break gap fix.
-    assert all(distance < 10.0 for distance in distances), distances
+    assert all(distance < 10.0 for distance in cyclic_distances), cyclic_distances

--- a/tests/test_model_smoke.py
+++ b/tests/test_model_smoke.py
@@ -586,3 +586,48 @@ def test_af2_cyclic_binder_closes_termini_more_than_linear(structure_model):
     # 5 multimer sub-models are ~9.5-15 A; 3.0 A leaves a wide safety
     # buffer while still ruling out a near-tie passing by chance.
     assert all(margin > 3.0 for margin in margins), margins
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_af2_cyclic_binder_closes_termini_more_than_linear_monomer():
+    # The multimer/monomer AF2 code paths (modules_multimer.py vs. modules.py)
+    # each need their own `batch["offset"]` override; the module-scoped
+    # `structure_model` fixture above only exercises the multimer=True
+    # default, so it could not catch a monomer-path regression. Callers that
+    # run AF2 with multimer=False (e.g. grasp's mosaic design stage) go
+    # through modules.py's relpos exclusively.
+    from mosaic.models.af2 import AlphaFold2
+
+    cpu = jax.devices("cpu")[0]
+    with jax.default_device(cpu):
+        model = AlphaFold2(multimer=False)
+
+        target = TargetChain(sequence="ACDEFGHIKL", use_msa=False)
+        binder_length = 8
+        pssm = jax.nn.one_hot(jnp.zeros(binder_length, dtype=int), 20)
+
+        margins = []
+        for model_idx in range(2):
+            key = jax.random.key(model_idx)
+            distances = {}
+            for cyclic in (False, True):
+                features, _writer = model.binder_features(
+                    binder_length, [target], cyclic=cyclic
+                )
+                output = model.model_output(
+                    PSSM=pssm,
+                    features=features,
+                    recycling_steps=1,
+                    sampling_steps=None,
+                    model_idx=model_idx,
+                    key=key,
+                )
+                distances[cyclic] = _binder_terminal_ca_distance(output, binder_length)
+            margins.append(distances[False] - distances[True])
+
+        del model
+    jax.clear_caches()
+    gc.collect()
+
+    assert all(margin > 3.0 for margin in margins), margins

--- a/tests/test_model_smoke.py
+++ b/tests/test_model_smoke.py
@@ -498,3 +498,86 @@ def test_model_output_structure_matches_prediction(multichain_prediction):
     converted_coords = np.asarray([converted_atoms[key] for key in comparable_atoms])
     predicted_coords = np.asarray([predicted_atoms[key] for key in comparable_atoms])
     assert np.sqrt(np.mean(np.square(converted_coords - predicted_coords))) < 0.1
+
+
+@pytest.fixture(scope="module")
+def af2_model():
+    from mosaic.models.af2 import AlphaFold2
+
+    cpu = jax.devices("cpu")[0]
+    with jax.default_device(cpu):
+        model = AlphaFold2()
+        yield model
+
+        del model
+    jax.clear_caches()
+    gc.collect()
+
+
+def _binder_terminal_ca_distance(prediction) -> float:
+    binder_chain = _protein_chains(prediction.st)[0]
+    atoms = _atom_coordinates([binder_chain])
+    n_terminal_ca = atoms[(0, 0, "CA")]
+    c_terminal_ca = atoms[(0, len(binder_chain) - 1, "CA")]
+    return float(np.linalg.norm(n_terminal_ca - c_terminal_ca))
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_af2_cyclic_binder_forward_pass_runs(af2_model):
+    target = TargetChain(sequence="ACDEFGHIKLMNPQRSTVWY", use_msa=False)
+    binder_length = 12
+    features, writer = af2_model.binder_features(
+        binder_length, [target], cyclic=True
+    )
+
+    assert "offset" in features
+    total_length = binder_length + len(target.sequence)
+    assert features["offset"].shape == (total_length, total_length)
+
+    pssm = jax.nn.one_hot(jnp.zeros(binder_length, dtype=int), 20)
+    loss = af2_model.build_loss(
+        loss=MeanConfidenceLoss(), features=features, recycling_steps=1
+    )
+    value_and_grad = eqx.filter_jit(eqx.filter_value_and_grad(loss, has_aux=True))
+    (value, auxiliary), gradient = value_and_grad(pssm, key=jax.random.key(0))
+
+    assert np.isfinite(np.asarray(value)).all()
+    assert auxiliary is not None
+    assert gradient.shape == pssm.shape
+    assert np.isfinite(np.asarray(gradient)).all()
+
+    prediction = af2_model.predict(
+        PSSM=pssm,
+        features=features,
+        writer=writer,
+        recycling_steps=1,
+        sampling_steps=None,
+        key=jax.random.key(1),
+    )
+    assert np.isfinite(np.asarray(prediction.plddt)).all()
+
+
+@pytest.mark.slow
+@pytest.mark.model_forward
+def test_af2_cyclic_binder_closes_termini_more_than_linear(af2_model):
+    target = TargetChain(sequence="ACDEFGHIKLMNPQRSTVWY", use_msa=False)
+    binder_length = 12
+    pssm = jax.nn.one_hot(jnp.zeros(binder_length, dtype=int), 20)
+
+    distances = {}
+    for cyclic in (False, True):
+        features, writer = af2_model.binder_features(
+            binder_length, [target], cyclic=cyclic
+        )
+        prediction = af2_model.predict(
+            PSSM=pssm,
+            features=features,
+            writer=writer,
+            recycling_steps=1,
+            sampling_steps=None,
+            key=jax.random.key(2),
+        )
+        distances[cyclic] = _binder_terminal_ca_distance(prediction)
+
+    assert distances[True] < distances[False]


### PR DESCRIPTION
Recreates #81 (auto-closed when the fork was deleted; GitHub can't relink a PR to a recreated fork). Same branch/content as #81.