### PR TITLE
Fast cached autoregressive sampling for ProteinMPNN 

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,10 +301,13 @@ mpnn = load_mpnn_sol(0.05)
 ids = inverse_fold(
     mpnn=mpnn, binder_length=len(SEQUENCE),
     output=pred.model_output, temp=0.001,
-    key=jax.random.key(0), jacobi_iterations=10,
+    key=jax.random.key(0),
 )
 print("".join(TOKENS[int(i)] for i in ids))
 ```
+
+Set `method="jacobi"` to use approximate parallel decoding; `jacobi_iterations`
+controls its number of refinement steps.
 
 > Every structure prediction model also supports a lower-level feature + losses interfaces if you'd like to do something fancy (e.g. design a protein binder against a small molecule with Boltz or Protenix).
 

--- a/src/mosaic/losses/protein_mpnn.py
+++ b/src/mosaic/losses/protein_mpnn.py
@@ -248,8 +248,10 @@ def _autoregressive_inverse_fold(
     total_length = output.full_sequence.shape[0]
     mask = jnp.ones(total_length, dtype=jnp.int32)
     residue_idx = _per_chain_residue_idx(output.asym_id, output.residue_idx)
+    # separate structure noise, decoding order, and residue sampling
     encode_key, order_key, sample_key = jax.random.split(key, 3)
 
+    # encode the backbone once
     h_V, h_E, E_idx = mpnn.encode(
         X=output.backbone_coordinates,
         mask=mask,
@@ -263,20 +265,23 @@ def _autoregressive_inverse_fold(
     decoding_order = decoding_order.at[:binder_length].add(2.0)
     binder_order = jnp.argsort(decoding_order[:binder_length])
 
+    # mark neighbors decoded before each residue
     rank = jnp.argsort(jnp.argsort(decoding_order))
     order_mask = rank[None, :] < rank[:, None]
     mask_bw = jnp.take_along_axis(order_mask[None], E_idx, axis=2)[..., None]
     mask_bw *= mask[None, :, None, None]
 
+    # seed sequence embeddings with the fixed target
     token_matrix = jnp.asarray(boltz_to_mpnn_matrix())
     sequence_mpnn = output.full_sequence.at[:binder_length].set(0) @ token_matrix
     h_S = (sequence_mpnn @ mpnn.W_s.weight)[None]
     h_EX_encoder = cat_neighbors_nodes(jnp.zeros_like(h_S), h_E, E_idx)
     h_EXV_encoder = cat_neighbors_nodes(h_V, h_EX_encoder, E_idx)
+    # use encoder features for residues not yet decoded
     h_EXV_encoder_fw = (1.0 - mask_bw) * h_EXV_encoder
 
-    # initialize the fixed-target states in parallel \
-    # binder states are overwritten in decoding order and cannot affect earlier positions.
+    # cache fixed-target states across decoder layers
+    # provisional binder states are overwritten before use
     h_ES = cat_neighbors_nodes(h_S, h_E, E_idx)
     h_V_stack = [h_V]
     for layer in mpnn.decoder_layers:
@@ -285,6 +290,7 @@ def _autoregressive_inverse_fold(
         h_V_stack.append(h_V)
     h_V_stack = jnp.stack(h_V_stack)
 
+    # draw once for each binder position
     gumbel = jax.random.gumbel(sample_key, (binder_length, len(TOKENS)))
     bias = jnp.zeros_like(gumbel) if bias is None else bias
     sequence = jnp.zeros(binder_length, dtype=jnp.int32)
@@ -298,27 +304,32 @@ def _autoregressive_inverse_fold(
 
     def sample_position(carry, position):
         h_S, h_V_stack, sequence = carry
+        # gather this residue and its graph neighborhood
         E_idx_t = gather_position(E_idx, position)
         h_ES_t = cat_position(h_S, gather_position(h_E, position), E_idx_t)
         mask_bw_t = gather_position(mask_bw, position)
         h_EXV_t = gather_position(h_EXV_encoder_fw, position)
         mask_t = mask[position][None, None]
 
+        # update only this residue through each decoder layer
         for layer_idx, layer in enumerate(mpnn.decoder_layers):
             h_V_t = gather_position(h_V_stack[layer_idx], position)
             h_ESV_t = cat_position(h_V_stack[layer_idx], h_ES_t, E_idx_t)
             h_V_t = layer(h_V_t, mask_bw_t * h_ESV_t + h_EXV_t, mask_t)
             h_V_stack = h_V_stack.at[layer_idx + 1, :, position].set(h_V_t[:, 0])
 
+        # sample in mosaic's 20-residue alphabet
         logits = mpnn.W_out(h_V_stack[-1, 0, position]) @ token_matrix.T
         residue = (logits + bias[position] + temp * gumbel[position]).argmax()
         sequence = sequence.at[position].set(residue)
         embedding = (
             jax.nn.one_hot(residue, len(TOKENS)) @ token_matrix
         ) @ mpnn.W_s.weight
+        # expose the sampled residue to later positions
         h_S = h_S.at[0, position].set(embedding)
         return (h_S, h_V_stack, sequence), None
 
+    # follow the sampled binder order
     (_, _, sequence), _ = jax.lax.scan(
         sample_position,
         (h_S, h_V_stack, sequence),

--- a/src/mosaic/losses/protein_mpnn.py
+++ b/src/mosaic/losses/protein_mpnn.py
@@ -2,6 +2,8 @@
 # 1. BoltzProteinMPNNLoss: Average log-likelihood of soft binder sequence given Boltz-predicted complex structure
 # 2. FixedChainInverseFoldingLL: Average log-likelihood of fixed monomer sequence given fixed monomer structure
 
+from typing import Literal
+
 import gemmi
 import jax
 import numpy as np
@@ -9,7 +11,12 @@ from jax import numpy as jnp
 from jaxtyping import Array, Float, Int
 
 from ..common import TOKENS, LossTerm
-from ..proteinmpnn.mpnn import MPNN_ALPHABET, ProteinMPNN
+from ..proteinmpnn.mpnn import (
+    MPNN_ALPHABET,
+    ProteinMPNN,
+    cat_neighbors_nodes,
+    gather_nodes_t,
+)
 from .structure_prediction import StructureModelOutput
 
 
@@ -228,9 +235,99 @@ class ProteinMPNNLoss(LossTerm):
 
         return -binder_ll, {"protein_mpnn_ll": binder_ll}
 
-# TODO: implement autoregressive sampling
-# for now though the jacobi method converges quickly enough
-def inverse_fold(
+
+def _autoregressive_inverse_fold(
+    mpnn: ProteinMPNN,
+    binder_length: int,
+    output: StructureModelOutput,
+    temp: float,
+    key,
+    bias: Float[Array, "N 20"] | None = None,
+):
+    """Sample the binder autoregressively while keeping the target fixed."""
+    total_length = output.full_sequence.shape[0]
+    mask = jnp.ones(total_length, dtype=jnp.int32)
+    residue_idx = _per_chain_residue_idx(output.asym_id, output.residue_idx)
+    encode_key, order_key, sample_key = jax.random.split(key, 3)
+
+    h_V, h_E, E_idx = mpnn.encode(
+        X=output.backbone_coordinates,
+        mask=mask,
+        residue_idx=residue_idx,
+        chain_encoding_all=output.asym_id,
+        key=encode_key,
+    )
+
+    decoding_order = jax.random.uniform(order_key, (total_length,))
+    # targets come first
+    decoding_order = decoding_order.at[:binder_length].add(2.0)
+    binder_order = jnp.argsort(decoding_order[:binder_length])
+
+    rank = jnp.argsort(jnp.argsort(decoding_order))
+    order_mask = rank[None, :] < rank[:, None]
+    mask_bw = jnp.take_along_axis(order_mask[None], E_idx, axis=2)[..., None]
+    mask_bw *= mask[None, :, None, None]
+
+    token_matrix = jnp.asarray(boltz_to_mpnn_matrix())
+    sequence_mpnn = output.full_sequence.at[:binder_length].set(0) @ token_matrix
+    h_S = (sequence_mpnn @ mpnn.W_s.weight)[None]
+    h_EX_encoder = cat_neighbors_nodes(jnp.zeros_like(h_S), h_E, E_idx)
+    h_EXV_encoder = cat_neighbors_nodes(h_V, h_EX_encoder, E_idx)
+    h_EXV_encoder_fw = (1.0 - mask_bw) * h_EXV_encoder
+
+    # initialize the fixed-target states in parallel \
+    # binder states are overwritten in decoding order and cannot affect earlier positions.
+    h_ES = cat_neighbors_nodes(h_S, h_E, E_idx)
+    h_V_stack = [h_V]
+    for layer in mpnn.decoder_layers:
+        h_ESV = mask_bw * cat_neighbors_nodes(h_V, h_ES, E_idx)
+        h_V = layer(h_V, h_ESV + h_EXV_encoder_fw, mask)
+        h_V_stack.append(h_V)
+    h_V_stack = jnp.stack(h_V_stack)
+
+    gumbel = jax.random.gumbel(sample_key, (binder_length, len(TOKENS)))
+    bias = jnp.zeros_like(gumbel) if bias is None else bias
+    sequence = jnp.zeros(binder_length, dtype=jnp.int32)
+
+    def gather_position(array, position):
+        return jax.lax.dynamic_index_in_dim(array, position, axis=1, keepdims=True)
+
+    def cat_position(nodes, edges, neighbor_idx):
+        neighbors = gather_nodes_t(nodes, neighbor_idx[:, 0])[:, None]
+        return jnp.concatenate((edges, neighbors), axis=-1)
+
+    def sample_position(carry, position):
+        h_S, h_V_stack, sequence = carry
+        E_idx_t = gather_position(E_idx, position)
+        h_ES_t = cat_position(h_S, gather_position(h_E, position), E_idx_t)
+        mask_bw_t = gather_position(mask_bw, position)
+        h_EXV_t = gather_position(h_EXV_encoder_fw, position)
+        mask_t = mask[position][None, None]
+
+        for layer_idx, layer in enumerate(mpnn.decoder_layers):
+            h_V_t = gather_position(h_V_stack[layer_idx], position)
+            h_ESV_t = cat_position(h_V_stack[layer_idx], h_ES_t, E_idx_t)
+            h_V_t = layer(h_V_t, mask_bw_t * h_ESV_t + h_EXV_t, mask_t)
+            h_V_stack = h_V_stack.at[layer_idx + 1, :, position].set(h_V_t[:, 0])
+
+        logits = mpnn.W_out(h_V_stack[-1, 0, position]) @ token_matrix.T
+        residue = (logits + bias[position] + temp * gumbel[position]).argmax()
+        sequence = sequence.at[position].set(residue)
+        embedding = (
+            jax.nn.one_hot(residue, len(TOKENS)) @ token_matrix
+        ) @ mpnn.W_s.weight
+        h_S = h_S.at[0, position].set(embedding)
+        return (h_S, h_V_stack, sequence), None
+
+    (_, _, sequence), _ = jax.lax.scan(
+        sample_position,
+        (h_S, h_V_stack, sequence),
+        binder_order,
+    )
+    return sequence
+
+
+def _jacobi_inverse_fold(
     mpnn: ProteinMPNN,
     binder_length: int,
     output: StructureModelOutput,
@@ -292,6 +389,42 @@ def inverse_fold(
     return sequence
 
 
+def inverse_fold(
+    mpnn: ProteinMPNN,
+    binder_length: int,
+    output: StructureModelOutput,
+    temp: float,
+    key,
+    *,
+    method: Literal["autoregressive", "jacobi"] = "autoregressive",
+    jacobi_iterations: int = 10,
+    bias: Float[Array, "N 20"] | None = None,
+):
+    """Sample a binder sequence with ProteinMPNN."""
+    if method == "autoregressive":
+        return _autoregressive_inverse_fold(
+            mpnn,
+            binder_length,
+            output,
+            temp,
+            key,
+            bias,
+        )
+    if method == "jacobi":
+        return _jacobi_inverse_fold(
+            mpnn,
+            binder_length,
+            output,
+            temp,
+            key,
+            jacobi_iterations,
+            bias,
+        )
+    raise ValueError(
+        f"Unknown inverse-folding method {method!r}; expected 'autoregressive' or 'jacobi'"
+    )
+
+
 class InverseFoldingSequenceRecovery(LossTerm):
     """
         Inner product of binder sequence and average sequence from ProteinMPNN
@@ -308,8 +441,9 @@ class InverseFoldingSequenceRecovery(LossTerm):
     mpnn: ProteinMPNN
     temp: Float
     num_samples: int = 16
+    method: Literal["autoregressive", "jacobi"] = "autoregressive"
     jacobi_iterations: int = 10
-    bias: Float[Array, "N 20"]  = None
+    bias: Float[Array, "N 20"] | None = None
 
     def __call__(
         self,
@@ -325,8 +459,9 @@ class InverseFoldingSequenceRecovery(LossTerm):
                     output=output,
                     temp=self.temp,
                     key=k,
+                    method=self.method,
                     jacobi_iterations=self.jacobi_iterations,
-                    bias = self.bias,
+                    bias=self.bias,
                 ),
                 20,
             )

--- a/tests/test_model_smoke.py
+++ b/tests/test_model_smoke.py
@@ -420,7 +420,6 @@ def test_promera_backbone_design_and_refold_flow(structure_model):
         binder_length,
         backbone,
         temp=0.1,
-        jacobi_iterations=1,
         key=jax.random.key(14),
     )
     refold_features, writer = structure_model.binder_features(binder_length, [target])

--- a/tests/test_protein_mpnn.py
+++ b/tests/test_protein_mpnn.py
@@ -1,0 +1,133 @@
+from types import SimpleNamespace
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from mosaic.losses.protein_mpnn import (
+    _autoregressive_inverse_fold,
+    _per_chain_residue_idx,
+    boltz_to_mpnn_matrix,
+    inverse_fold,
+)
+from mosaic.proteinmpnn.mpnn import ProteinMPNN
+
+
+def _problem(target=(3, 7)):
+    hidden_dim = 2
+
+    def encode(*, X, **kwargs):
+        length = X.shape[0]
+        neighbors = jnp.broadcast_to(jnp.arange(length), (length, length))[None]
+        return (
+            jnp.zeros((1, length, hidden_dim)),
+            jnp.zeros((1, length, length, hidden_dim)),
+            neighbors,
+        )
+
+    def decoder_layer(h_V, h_E, mask_V=None):
+        sequence = h_E[..., hidden_dim : 2 * hidden_dim]
+        neighbors = h_E[..., 2 * hidden_dim :]
+        messages = (sequence + 0.5 * neighbors).sum(-2)
+        return (h_V + messages) * mask_V[..., None]
+
+    mpnn = SimpleNamespace(
+        W_s=SimpleNamespace(weight=jnp.arange(42).reshape(21, hidden_dim) / 20),
+        W_out=lambda x: x @ jnp.sin(jnp.arange(42).reshape(21, hidden_dim)).T,
+        decoder_layers=(decoder_layer,),
+        encode=encode,
+    )
+    mpnn.decode = lambda **kwargs: ProteinMPNN.decode(mpnn, **kwargs)
+    output = SimpleNamespace(
+        backbone_coordinates=jnp.zeros((6, 4, 3)),
+        full_sequence=jnp.vstack(
+            (jnp.zeros((4, 20)), jax.nn.one_hot(jnp.array(target), 20))
+        ),
+        asym_id=jnp.array([0, 0, 0, 0, 1, 1]),
+        residue_idx=jnp.array([0, 1, 2, 3, 0, 1]),
+    )
+    return mpnn, output
+
+
+def _full_decoder_sample(mpnn, binder_length, output, temp, key, bias):
+    total_length = output.full_sequence.shape[0]
+    mask = jnp.ones(total_length, dtype=jnp.int32)
+    encode_key, order_key, sample_key = jax.random.split(key, 3)
+    h_V, h_E, E_idx = mpnn.encode(
+        X=output.backbone_coordinates,
+        mask=mask,
+        residue_idx=_per_chain_residue_idx(output.asym_id, output.residue_idx),
+        chain_encoding_all=output.asym_id,
+        key=encode_key,
+    )
+    decoding_order = jax.random.uniform(order_key, (total_length,))
+    decoding_order = decoding_order.at[:binder_length].add(2.0)
+    binder_order = np.asarray(jnp.argsort(decoding_order[:binder_length]))
+    gumbel = jax.random.gumbel(sample_key, (binder_length, 20))
+    token_matrix = jnp.asarray(boltz_to_mpnn_matrix())
+    sequence = output.full_sequence
+
+    for position in binder_order:
+        logits = (
+            mpnn.decode(
+                S=sequence @ token_matrix,
+                h_V=h_V,
+                h_E=h_E,
+                E_idx=E_idx,
+                mask=mask,
+                decoding_order=decoding_order,
+            )[0, position]
+            @ token_matrix.T
+        )
+        residue = (logits + bias[position] + temp * gumbel[position]).argmax()
+        sequence = sequence.at[position].set(jax.nn.one_hot(residue, 20))
+
+    return sequence[:binder_length].argmax(-1)
+
+
+@pytest.mark.parametrize(
+    ("temperature", "seed", "target", "expected"),
+    [
+        (0.0, 11, (3, 7), [12, 12, 12, 12]),
+        (0.2, 12, (3, 7), [5, 12, 12, 5]),
+        (0.8, 13, (2, 9), [12, 18, 5, 12]),
+    ],
+)
+def test_autoregressive_sampler_matches_full_decoder(
+    temperature, seed, target, expected
+) -> None:
+    mpnn, output = _problem(target)
+    key = jax.random.key(seed)
+    bias = jnp.broadcast_to(jnp.linspace(-0.2, 0.2, 20), (4, 20))
+
+    reference = _full_decoder_sample(mpnn, 4, output, temperature, key, bias)
+    np.testing.assert_array_equal(reference, expected)
+    actual = _autoregressive_inverse_fold(
+        mpnn, 4, output, temperature, key, bias
+    )
+
+    np.testing.assert_array_equal(actual, reference)
+
+
+def test_autoregressive_sampler_matches_full_decoder_under_jit() -> None:
+    mpnn, output = _problem()
+    keys = jax.random.split(jax.random.key(7), 3)
+    bias = jnp.broadcast_to(jnp.linspace(-0.2, 0.2, 20), (4, 20))
+
+    expected = np.stack(
+        [_full_decoder_sample(mpnn, 4, output, 0.0, key, bias) for key in keys]
+    )
+    np.testing.assert_array_equal(expected, np.full((3, 4), 12))
+
+    sample = eqx.filter_jit(
+        jax.vmap(
+            lambda key: inverse_fold(
+                mpnn, 4, output, jnp.array(0.0), key, bias=bias
+            )
+        )
+    )
+    actual = sample(keys)
+
+    np.testing.assert_array_equal(actual, expected)


### PR DESCRIPTION
The canonical method of sampling from ProteinMPNN (as proposed in their paper) is autoregressive. An ordering of backbone residues is sampled and then the full decoder is sequentially run forward to predict the next residue in the ordered sequence, then it is appended and the decoder is run again. In the mosiac binder design context, this means that for a binder of length `N` we need to run `N` decoder forwards, which is obviously not efficient. ProteinMPNN predictions form part of the `InverseFoldingSequenceRecovery` loss in mosiac, which involves generating a batch (default size 16) of ProteinMPNN predicted inverse folds. We run this every iteration of optimisation.

Currently mosiac implements Jacobi sampling for ProteinMPNN prediction which is more efficient than AR sampling, but is only approximate. Jacobi sampling starts with a random initialisation of binder residues, then runs the decoder forward to get a prediction for all the positions at once (Note: in the AR case, we do get these predictions as well, but chuck away everything but the next residue). The new predictions for the binder residues are then substituted for the random initialisations and then prediction is run again. This process is repeated for a fixed number of iterations, by which point the predicted residues have hopefully converged to a fixed set. The number of decoder predictions required by the Jacobi method is fixed with `N`. 

There is a much more efficient way of running AR prediction that leverages the fact than in the ProteinMPNN decoder many of the embeddings/computed quantities don't change as we sequentially add residues because the "casual" mask means than new residues can't influence the old ones (in the randomly sampled order). This means that we can cache these embeddings over the `N` iterations and only compute a small update at each step of sampling. This is what is implemented in the original PyTorch ProteinMPNN code [here](https://github.com/dauparas/ProteinMPNN/blob/8907e6671bfbfc92303b5f79c4b5e6ce47cdef57/protein_mpnn_utils.py#L1104).

This PR implements cached AR sampling in mosiac. We also add some additional optimisations relative to the o.g. implementation that leverage the fact the target residues are fixed when we're designing binders, and always come first. You can run the decoder in parallel to get the states for the target positions and then run the `N`sequential steps. The implementation is obviously quite involved, but I have tried to comment the code to make what's happening at least somewhat clear. 

The upshot is that the cached AR implementation is slower for single samples `B=1`, as expected, but for the `B=16` size batches used in `InverseFoldingSequenceRecovery` it is much faster. This means that we get a nice speed up, and get exact sampling instead of an approximation! Benchmark results below.

| Method                 | B=1 batch latency | B=16 batch latency |
| ---------------------- | ----------------: | -----------------: |
| Jacobi (10 iterations) |    2.84 ± 0.01 ms |    46.36 ± 0.17 ms |
| Cached AR (this PR)    |    6.85 ± 0.01 ms |    15.02 ± 0.07 ms |

*Mean ± standard error over 100 runs not including jax compile on an L40S with an 80-residue binder and 100-residue fixed target.*

I've also benchmarked against the o.g. implementation in PyTorch, and an alternative jax implementation of MPNN (and LigandMPNN) called [Aminx](https://github.com/maraxen/aminx). This is much (3x-50x) faster than both. I ran the Boltz PD-L1 minibinder notebook to check the full pipeline still works, but I only ran a couple of designs so can't claim better/worse performance on actual binder design. The runtimes are essentially the same because the structure terms of the loss dominate. I can try run a more extensive study if you think that would be useful. As well as the benchmarks and notebook I did a sanity check on IL-7R and compared with actual binder (chain D), and got mean 57% sequence recovery over 16 samples, which is consistent with the numbers in the paper. 

I have made the AR sampling the default, since that's probably what people generally will want, but ofc happy to change that so it's opt in. 


